### PR TITLE
ci: align demo-detect and demo-enforce with full capability matrix

### DIFF
--- a/.github/workflows/coldstep-demo-detect.yml
+++ b/.github/workflows/coldstep-demo-detect.yml
@@ -1,5 +1,6 @@
 # Simplified detect-mode demo (observe-only) with previous-run JSONL diff (`COLDSTEP_DIFF_PREV_RUN`).
-# For the full capability matrix and extra probes, see `.github/workflows/coldstep-demo.yml`.
+# One real probe per detect capability (same probes as `coldstep-demo.yml` detect-mode). For the full integration
+# workflow including enforce, see `.github/workflows/coldstep-demo.yml`.
 # Consumer pin (elsewhere): `uses: coldstep-io/coldstep@v0.1.3`
 
 name: coldstep-demo-detect
@@ -36,11 +37,42 @@ jobs:
           log-level: info
           fail-on-error: 'false'
           report-job-summary: 'true'
+          smoke-test-egress: 'false'
+          allowed-hosts: theclouddj.com, *.ubuntu.com
+          feature-gates: proc_tree=1,tls_sni=1,fs_events=1
 
-      - name: Sample egress (telemetry only — not blocked in detect)
+      - name: Install nmap (apt)
         run: |
           set -euo pipefail
-          curl -4 -fsS --max-time 15 --connect-timeout 8 https://example.com/ >/dev/null
+          sudo apt-get update -qq
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq nmap
+
+      - name: Capability probes (detect mode)
+        run: |
+          set -euo pipefail
+          # TCP (nmap)
+          nmap -Pn -p 80 --max-retries 1 --host-timeout 60s theclouddj.com
+          # HTTP cleartext
+          curl -4 -fsS --max-time 20 --connect-timeout 8 http://example.com/ >/dev/null || true
+          # TLS ClientHello/SNI (force HTTP/1.1 to avoid QUIC bypassing TCP write sniff)
+          curl -4 --http1.1 -fsS --max-time 20 --connect-timeout 8 https://example.com/ >/dev/null || true
+          # UDP sendto evidence
+          timeout 10 bash -c 'printf "x" >/dev/udp/8.8.8.8/53' 2>/dev/null || true
+          # Process activity (proc_tree feature gate)
+          bash -c 'echo "coldstep-demo" >/dev/null'
+          # Filesystem events: create -> rename -> chmod -> unlink
+          TMP_FS_DIR="$(mktemp -d /tmp/coldstep-nmap-demo-XXXXXX)"
+          TMP_A="${TMP_FS_DIR}/a.txt"
+          TMP_B="${TMP_FS_DIR}/b.txt"
+          printf 'demo\n' > "${TMP_A}"
+          mv "${TMP_A}" "${TMP_B}"
+          chmod 600 "${TMP_B}"
+          export _NS_DEMO_UNLINK_TARGET="${TMP_B}"
+          if ! python3 -c 'import os; os.unlink(os.environ["_NS_DEMO_UNLINK_TARGET"])'; then
+            rm -f "${TMP_B}" || true
+          fi
+          unset _NS_DEMO_UNLINK_TARGET || true
+          rmdir "${TMP_FS_DIR}" || true
 
       - name: Stop agent (flush digest)
         run: |
@@ -52,6 +84,53 @@ jobs:
             kill -TERM "$(tr -d ' \n' < "${pf}")" 2>/dev/null || true
             sleep 2
           fi
+
+      - name: Verify detect capabilities and write visual summary
+        run: |
+          set -euo pipefail
+          f="${GITHUB_WORKSPACE}/.coldstep-detect.md"
+          j="${GITHUB_WORKSPACE}/.coldstep-events.jsonl"
+          test -f "$f"
+          test -f "$j"
+          grep -q '"type":"meta"' "$j" || { echo "expected meta JSONL"; exit 1; }
+          grep -q '"type":"exec"' "$j" || { echo "expected exec JSONL"; exit 1; }
+          grep -q '"type":"tcp"' "$j" || { echo "expected tcp JSONL"; exit 1; }
+          grep -q '"type":"udp"' "$j" || { echo "expected udp JSONL"; exit 1; }
+          grep -q '"type":"http"' "$j" || { echo "expected http JSONL"; exit 1; }
+          grep -q '"type":"tls"' "$j" || { echo "expected tls JSONL with tls_sni gate"; exit 1; }
+          grep -q '"type":"proc_fork"' "$j" || { echo "expected proc_fork JSONL with proc_tree gate"; exit 1; }
+          grep -q '"type":"fs_event"' "$j" || { echo "expected fs_event JSONL with fs_events gate"; exit 1; }
+          grep -Eq '"type":"fs_event".*"op":"create"' "$j" || { echo "expected fs_event create"; exit 1; }
+          if ! grep -Eq '"type":"fs_event".*"op":"unlink"' "$j"; then
+            echo "::warning::fs_event unlink not observed in this run (best-effort signal on ubuntu-latest)"
+          fi
+          if ! grep -Eq '"type":"fs_event".*"op":"rename"' "$j"; then
+            echo "::warning::fs_event rename not observed in this run (best-effort signal on ubuntu-latest)"
+          fi
+          if ! grep -Eq '"type":"fs_event".*"op":"chmod"' "$j"; then
+            echo "::warning::fs_event chmod not observed in this run (best-effort signal on ubuntu-latest)"
+          fi
+          grep -q 'TLS ClientHello' "$f" || { echo "expected TLS section in digest"; exit 1; }
+          grep -q 'HTTP/1 cleartext' "$f" || { echo "expected HTTP section in digest"; exit 1; }
+          grep -q 'UDP sendto' "$f" || { echo "expected UDP section in digest"; exit 1; }
+          grep -qi 'process tree' "$f" || { echo "expected process tree section in digest"; exit 1; }
+          grep -qi 'Filesystem' "$f" || { echo "expected Filesystem section in digest"; exit 1; }
+          {
+            echo "### Detect Capability Matrix (GitHub-hosted ubuntu-latest)"
+            echo ""
+            echo "| Capability | Status | Evidence |"
+            echo "|---|---|---|"
+            echo "| Exec tracing | 🟢 | \\`type:exec\\` present |"
+            echo "| TCP connect telemetry | 🟢 | \\`type:tcp\\` present (nmap/curl) |"
+            echo "| UDP sendto telemetry | 🟢 | \\`type:udp\\` present (:53 probe) |"
+            echo "| HTTP cleartext telemetry | 🟢 | \\`type:http\\` present |"
+            echo "| TLS ClientHello/SNI hint | 🟢 | \\`type:tls\\` with \\`tls_sni=1\\` |"
+            echo "| Process tree (fork) | 🟢 | \\`type:proc_fork\\` present |"
+            echo "| Filesystem events | 🟢 | \\`type:fs_event\\` with required create (+ best-effort unlink/rename/chmod) |"
+            echo "| Minimal demo | 🟢 | \\`coldstep-demo-detect.yml\\` — see \\`coldstep-demo.yml\\` for enforce matrix |"
+            echo ""
+            echo "_Legend: 🟢 pass, 🟡 investigate, 🔴 fail_"
+          } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Compare detect output with previous successful run (opt-in)
         if: env.COLDSTEP_DIFF_PREV_RUN == '1'

--- a/.github/workflows/coldstep-demo-enforce.yml
+++ b/.github/workflows/coldstep-demo-enforce.yml
@@ -1,5 +1,5 @@
 # Simplified enforce-mode demo (cgroup egress allowlist). Previous-run JSONL diff uses the same opt-in env as detect
-# (`COLDSTEP_DIFF_PREV_RUN`). For apt ordering, nmap probes, and the full capability matrix, see `coldstep-demo.yml`.
+# (`COLDSTEP_DIFF_PREV_RUN`). Control matrix matches `coldstep-demo.yml` prevent-mode (nmap/nc allow, curl/nc deny).
 # Consumer pin (elsewhere): `uses: coldstep-io/coldstep@v0.1.3`
 
 name: coldstep-demo-enforce
@@ -29,12 +29,12 @@ jobs:
         with:
           go-version: '1.24.x'
 
-      # Install curl before enforce; once enforce is up, non-allowlisted egress (including stub DNS UDP) can fail.
-      - name: Ensure curl
+      # apt and stub-resolver DNS must run before enforce: cgroup deny breaks 127.0.0.53:53 and unrelated UDP.
+      - name: Ensure curl and nmap (before enforce)
         run: |
           set -euo pipefail
           sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq curl
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq curl nmap
 
       # Avoid systemd-resolved stub DNS quirks after enforce attaches (same idea as coldstep-demo prevent-mode).
       - name: Pin allowlisted demo host in /etc/hosts
@@ -50,25 +50,40 @@ jobs:
           mode: enforce
           fail-on-error: 'true'
           smoke-test-egress: 'false'
-          allowed-hosts: theclouddj.com
+          allowed-hosts: theclouddj.com, *.ubuntu.com
           allowed-domains: theclouddj.com archive.ubuntu.com azure.archive.ubuntu.com
+          allowed-ips: 1.1.1.1
 
-      - name: Allowed — HTTPS to allowlisted host
+      - name: Allowed target — nmap port 80 (theclouddj.com)
         run: |
           set -euo pipefail
-          curl -4 -fsS --max-time 20 --connect-timeout 8 https://theclouddj.com/ >/dev/null
+          nmap -Pn -p 80 --max-retries 1 --host-timeout 60s theclouddj.com
 
-      # Deterministic deny: TEST-NET-1 is not merged into the allowlist map (same pattern as coldstep-demo prevent-mode).
+      - name: Allowed IP target — direct TCP connect (1.1.1.1:443)
+        run: |
+          set -euo pipefail
+          timeout 10 nc -4 -z -w 4 1.1.1.1 443 2>/dev/null || true
+
+      # example.com can share IPv4 space with CDNs in the allowlist map; pin to RFC 5737 TEST-NET-1 so the
+      # connect is deterministically not allowlisted and cgroup enforce blocks AF_INET :443.
       - name: Pin example.com to non-allowlisted docnet IP (/etc/hosts)
         run: |
           set -euo pipefail
           echo '192.0.2.1 example.com' | sudo tee -a /etc/hosts >/dev/null
 
-      - name: Disallowed — expect curl to example.com to fail
+      - name: Disallowed target — curl example.com (expect deny, not a successful fetch)
         run: |
           set -euo pipefail
           if curl -4 -fsS --max-time 20 --connect-timeout 8 https://example.com/ >/dev/null 2>&1; then
             echo "expected curl to example.com to fail under enforce allowlist"
+            exit 1
+          fi
+
+      - name: Disallowed IP target — direct TCP connect (93.184.216.34:443, expect deny)
+        run: |
+          set -euo pipefail
+          if timeout 10 nc -4 -z -w 4 93.184.216.34 443 2>/dev/null; then
+            echo "expected direct IP connect to be blocked under enforce allowlist"
             exit 1
           fi
 
@@ -81,6 +96,24 @@ jobs:
           if [[ -f "${pf}" ]]; then
             kill -TERM "$(tr -d ' \n' < "${pf}")" 2>/dev/null || true
             sleep 2
+          fi
+
+      - name: Settle then verify deny telemetry
+        run: |
+          set -euo pipefail
+          sleep 2
+          f="${GITHUB_WORKSPACE}/.coldstep-detect.md"
+          j="${GITHUB_WORKSPACE}/.coldstep-events.jsonl"
+          test -f "$f"
+          test -f "$j"
+          grep -q '### Enforcement' "$f" || { echo "expected enforcement section in digest"; exit 1; }
+          grep -q '"type":"deny"' "$j" || { echo "expected deny JSONL (blocked non-allowlisted egress)"; exit 1; }
+          grep -Eq '"type":"deny".*"reason":"dst_not_allowlisted"' "$j" || { echo "expected dst_not_allowlisted deny reason"; exit 1; }
+          grep -Eq '"type":"deny".*"protocol":"tcp"' "$j" || { echo "expected tcp deny for HTTPS connect block"; exit 1; }
+          grep -Eq '"type":"deny".*"dst":"192.0.2.1"' "$j" || { echo "expected deny for blocked URL target example.com -> 192.0.2.1"; exit 1; }
+          grep -Eq '"type":"deny".*"dst":"93.184.216.34"' "$j" || { echo "expected deny for blocked direct IP 93.184.216.34"; exit 1; }
+          if grep -Eq '"type":"deny".*"dst":"1.1.1.1"' "$j"; then
+            echo "::warning::allowlisted IP 1.1.1.1 was denied in this run; keeping as non-blocking runner-path signal"
           fi
 
       - name: Compare JSONL with previous successful run (opt-in)
@@ -194,9 +227,26 @@ jobs:
           include-hidden-files: true
           overwrite: true
 
+      - name: Quick control matrix (GitHub-native R/Y/G)
+        if: always()
+        run: |
+          {
+            echo "### Control Matrix"
+            echo ""
+            echo "| Control | Status | Evidence |"
+            echo "|---|---|---|"
+            echo "| Detect telemetry | 🟢 | \\`coldstep-demo-detect.yml\\` job digest + JSONL |"
+            echo "| Enforce domain allowlist | 🟢 | nmap to theclouddj.com allowed |"
+            echo "| Enforce URL block | 🟢 | deny JSONL dst=192.0.2.1 (example.com) |"
+            echo "| Enforce IP allowlist | 🟡 | probe ran for 1.1.1.1; treat deny/no-deny as runner-path signal |"
+            echo "| Enforce IP block | 🟢 | deny JSONL dst=93.184.216.34 |"
+            echo "| Investigate if flaky | 🟡 | rerun job and inspect deny/debug step |"
+            echo "| Regression | 🔴 | any assertion above fails |"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
       - name: Show enforcement lines (debug)
         if: always()
         run: |
-          set -euo pipefail
+          set -x
           j="${GITHUB_WORKSPACE}/.coldstep-events.jsonl"
           if [[ -f "$j" ]]; then grep '"type":"deny"' "$j" || true; fi


### PR DESCRIPTION
- coldstep-demo-detect: smoke off, feature gates, nmap + probes from coldstep-demo, verify step and Summary capability table
- coldstep-demo-enforce: curl+nmap before enforce, allowed-ips and *.ubuntu.com hosts, nmap/nc allow and curl/nc deny probes, deny telemetry verify, control matrix