### PR TITLE
ci: publish coldstep-linux-amd64 on release tags; demos use v0.1.4

### DIFF
--- a/.github/workflows/coldstep-demo-detect.yml
+++ b/.github/workflows/coldstep-demo-detect.yml
@@ -1,7 +1,10 @@
 # Simplified detect-mode demo (observe-only) with previous-run JSONL diff (`COLDSTEP_DIFF_PREV_RUN`).
 # One real probe per detect capability (same probes as `coldstep-demo.yml` detect-mode). For the full integration
 # workflow including enforce, see `.github/workflows/coldstep-demo.yml`.
-# Consumer pin (elsewhere): `uses: coldstep-io/coldstep@v0.1.3`
+# Consumer pin (elsewhere): `uses: coldstep-io/coldstep@v0.1.4`
+#
+# Agent binary: download `coldstep-linux-amd64` from the repo GitHub Release for `COLDSTEP_AGENT_VERSION`
+# (published by `supply-chain-attest.yml` on version tags). The action uses `release-path` and does not compile.
 
 name: coldstep-demo-detect
 
@@ -10,6 +13,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  COLDSTEP_AGENT_VERSION: v0.1.4
 
 jobs:
   demo:
@@ -26,9 +30,18 @@ jobs:
       - name: Assert tracked text is UTF-8 (before uses ./)
         run: python3 scripts/assert_utf8_text.py
 
-      - uses: actions/setup-go@v6
-        with:
-          go-version: '1.24.x'
+      - name: Download coldstep agent (GitHub Release)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p bin
+          gh release download "${COLDSTEP_AGENT_VERSION}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern 'coldstep-linux-amd64' \
+            --dir bin
+          mv bin/coldstep-linux-amd64 bin/coldstep
+          chmod +x bin/coldstep
 
       - name: coldstep-io/coldstep (detect)
         uses: ./
@@ -40,6 +53,7 @@ jobs:
           smoke-test-egress: 'false'
           allowed-hosts: theclouddj.com, *.ubuntu.com
           feature-gates: proc_tree=1,tls_sni=1,fs_events=1
+          release-path: bin/coldstep
 
       - name: Install nmap (apt)
         run: |

--- a/.github/workflows/coldstep-demo-enforce.yml
+++ b/.github/workflows/coldstep-demo-enforce.yml
@@ -1,6 +1,8 @@
 # Simplified enforce-mode demo (cgroup egress allowlist). Previous-run JSONL diff uses the same opt-in env as detect
 # (`COLDSTEP_DIFF_PREV_RUN`). Control matrix matches `coldstep-demo.yml` prevent-mode (nmap/nc allow, curl/nc deny).
-# Consumer pin (elsewhere): `uses: coldstep-io/coldstep@v0.1.3`
+# Consumer pin (elsewhere): `uses: coldstep-io/coldstep@v0.1.4`
+#
+# Agent binary: same GitHub Release download + `release-path` as `coldstep-demo-detect.yml`.
 
 name: coldstep-demo-enforce
 
@@ -9,6 +11,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  COLDSTEP_AGENT_VERSION: v0.1.4
 
 jobs:
   demo:
@@ -25,9 +28,18 @@ jobs:
       - name: Assert tracked text is UTF-8 (before uses ./)
         run: python3 scripts/assert_utf8_text.py
 
-      - uses: actions/setup-go@v6
-        with:
-          go-version: '1.24.x'
+      - name: Download coldstep agent (GitHub Release)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p bin
+          gh release download "${COLDSTEP_AGENT_VERSION}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern 'coldstep-linux-amd64' \
+            --dir bin
+          mv bin/coldstep-linux-amd64 bin/coldstep
+          chmod +x bin/coldstep
 
       # apt and stub-resolver DNS must run before enforce: cgroup deny breaks 127.0.0.53:53 and unrelated UDP.
       - name: Ensure curl and nmap (before enforce)
@@ -53,6 +65,7 @@ jobs:
           allowed-hosts: theclouddj.com, *.ubuntu.com
           allowed-domains: theclouddj.com archive.ubuntu.com azure.archive.ubuntu.com
           allowed-ips: 1.1.1.1
+          release-path: bin/coldstep
 
       - name: Allowed target — nmap port 80 (theclouddj.com)
         run: |

--- a/.github/workflows/supply-chain-attest.yml
+++ b/.github/workflows/supply-chain-attest.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
   attestations: write
   artifact-metadata: write
@@ -94,6 +94,25 @@ jobs:
         with:
           subject-path: '${{ github.workspace }}/coldstep-action-bundle.tar.gz'
           sbom-path: '${{ github.workspace }}/sbom-js.cdx.json'
+
+      # One published binary per tag; demo workflows download this instead of compiling on every run.
+      - name: Upload Linux agent to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          cp bin/coldstep coldstep-linux-amd64
+          chmod +x coldstep-linux-amd64
+          tag="${GITHUB_REF_NAME}"
+          if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            gh release upload "${tag}" coldstep-linux-amd64 --repo "${GITHUB_REPOSITORY}" --clobber
+          else
+            gh release create "${tag}" coldstep-linux-amd64 \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "${tag}" \
+              --notes "Linux amd64 eBPF agent (ubuntu-latest). Composite action and SBOMs: see repository and workflow artifacts."
+          fi
 
       - name: Upload attestable artifacts
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
- supply-chain-attest: upload coldstep-linux-amd64 to GitHub Release on v* tags
- coldstep-demo-detect/enforce: download agent from release; COLDSTEP_AGENT_VERSION v0.1.4