### PR TITLE
chore(security): close 11 of 14 CodeQL alerts (XSS, perms, ReDoS-test, dist suppression)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,16 @@
+name: Coldstep CodeQL config
+
+# Why this file exists:
+# CodeQL was scanning `dist/**` (the esbuild-bundled output of `src/main.ts` and
+# `src/post.ts`) and flagging vendored Node ecosystem code we do not author:
+#   - SHA-1 in `undici` for the WebSocket Sec-WebSocket-Accept handshake
+#     (mandated by RFC 6455 §4.2.2 — protocol-defined, not a vulnerability).
+#   - ReDoS-style regex in a BigInt-aware JSON parser (vendored library).
+# Bundles are generated artifacts (per `AGENTS.md` line 10: regenerate with
+# `npm run build` whenever `src/main.ts` / `src/post.ts` change). Scanning them
+# duplicates lint surface and produces noise CodeQL has no source-line fix for.
+# Source under `src/` IS still scanned.
+
+paths-ignore:
+  - dist/**
+  - node_modules/**

--- a/.github/workflows/coldstep-ci-runner.yml
+++ b/.github/workflows/coldstep-ci-runner.yml
@@ -14,6 +14,13 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+# Default to least-privilege for every job in this reusable workflow.
+# Jobs that legitimately need more (e.g. `actions: read` to download a
+# previous-run baseline artifact for JSONL diff) override this block at the
+# job level — see `coldstep-demo-detect.yml` for the same pattern.
+permissions:
+  contents: read
+
 jobs:
   action_manifest:
     runs-on: ubuntu-latest

--- a/.github/workflows/coldstep-demo-marketplace.yml
+++ b/.github/workflows/coldstep-demo-marketplace.yml
@@ -12,6 +12,11 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+# Minimal consumer workflow — no artifact download, no API writes, just
+# checkout + run the published composite + print the result.
+permissions:
+  contents: read
+
 jobs:
   detect:
     runs-on: ubuntu-latest

--- a/.github/workflows/coldstep-demo.yml
+++ b/.github/workflows/coldstep-demo.yml
@@ -25,6 +25,12 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   COLDSTEP_AGENT_VERSION: v0.1.4
 
+# Default to least-privilege; the detect-mode job overrides with
+# `permissions: { actions: read, contents: read }` when previous-run baseline
+# diff is enabled (mirrors `coldstep-demo-detect.yml`).
+permissions:
+  contents: read
+
 jobs:
   detect-mode:
     runs-on: ubuntu-latest

--- a/scripts/coldstep_detect_report/templates/report.html
+++ b/scripts/coldstep_detect_report/templates/report.html
@@ -60,21 +60,44 @@
     const $ = (sel) => document.querySelector(sel);
 
     // 1. Capability matrix as a small table.
-    /* WARNING: these template literals write to innerHTML. Every field below
-       currently comes from constants in build_report_model.REQUIRED_CAPABILITIES
-       or controlled JSON keys produced by build_report_model.py. Before adding
-       any user-derived field (CLI label, observed traffic string, error text),
-       switch to textContent or an escapeHtml() helper. */
+    // Built via createElement + textContent so adding any future user-derived
+    // field (CLI label, observed traffic string, error text) cannot smuggle
+    // HTML or script tags. The status string is constrained via classList.add
+    // (whitespace would throw). Closes CodeQL js/xss-through-dom on this mount.
     {
-      const rows = model.capability_matrix
-        .map(r => `<tr>
-            <td>${r.label}</td>
-            <td class="status ${r.status}">${r.status}</td>
-            <td>${r.evidence_count}</td>
-          </tr>`)
-        .join("");
-      $('[data-mount="capabilities"]').innerHTML =
-        `<table class="cap"><thead><tr><th>Capability</th><th>Status</th><th>Evidence</th></tr></thead><tbody>${rows}</tbody></table>`;
+      const mount = $('[data-mount="capabilities"]');
+      mount.replaceChildren();
+      const table = document.createElement("table");
+      table.className = "cap";
+      const thead = document.createElement("thead");
+      const headerRow = document.createElement("tr");
+      for (const h of ["Capability", "Status", "Evidence"]) {
+        const th = document.createElement("th");
+        th.textContent = h;
+        headerRow.appendChild(th);
+      }
+      thead.appendChild(headerRow);
+      table.appendChild(thead);
+      const tbody = document.createElement("tbody");
+      for (const r of model.capability_matrix) {
+        const tr = document.createElement("tr");
+        const tdLabel = document.createElement("td");
+        tdLabel.textContent = r.label;
+        const tdStatus = document.createElement("td");
+        tdStatus.classList.add("status");
+        if (typeof r.status === "string" && /^[a-z0-9_-]+$/i.test(r.status)) {
+          tdStatus.classList.add(r.status);
+        }
+        tdStatus.textContent = r.status;
+        const tdCount = document.createElement("td");
+        tdCount.textContent = String(r.evidence_count);
+        tr.appendChild(tdLabel);
+        tr.appendChild(tdStatus);
+        tr.appendChild(tdCount);
+        tbody.appendChild(tr);
+      }
+      table.appendChild(tbody);
+      mount.appendChild(table);
     }
 
     // 2. Events bar chart (Observable Plot).
@@ -113,21 +136,57 @@
     }
 
     // 4. Diff: small tables, one per bucket.
+    // r.fingerprint is the canonical "traffic » <type> » <dst> » <dport> » <fqdn> » ..."
+    // string built from observed network egress — IS user-derived. Every insert
+    // below routes through textContent (or an attribute set via property) so
+    // embedded HTML/script bytes are neutralised. Closes CodeQL js/xss-through-dom.
     {
+      const mount = $('[data-mount="diff"]');
+      mount.replaceChildren();
       const sec = (label, rows) => {
-        if (!rows || !rows.length) return `<p class="empty">${label}: <em>none</em></p>`;
-        const body = rows.map(r =>
-          r.fingerprint
-            ? `<tr><td>${r.count ?? r.current ?? ""}</td><td><code>${r.fingerprint}</code></td></tr>`
-            : ""
-        ).join("");
-        return `<h3>${label}</h3><table class="diff"><tbody>${body}</tbody></table>`;
+        if (!rows || !rows.length) {
+          const p = document.createElement("p");
+          p.className = "empty";
+          p.append(`${label}: `);
+          const em = document.createElement("em");
+          em.textContent = "none";
+          p.appendChild(em);
+          return [p];
+        }
+        const heading = document.createElement("h3");
+        heading.textContent = label;
+        const table = document.createElement("table");
+        table.className = "diff";
+        const tbody = document.createElement("tbody");
+        for (const r of rows) {
+          if (!r.fingerprint) continue;
+          const tr = document.createElement("tr");
+          const tdCount = document.createElement("td");
+          tdCount.textContent = String(r.count ?? r.current ?? "");
+          const tdFp = document.createElement("td");
+          const code = document.createElement("code");
+          code.textContent = r.fingerprint;
+          tdFp.appendChild(code);
+          tr.appendChild(tdCount);
+          tr.appendChild(tdFp);
+          tbody.appendChild(tr);
+        }
+        table.appendChild(tbody);
+        return [heading, table];
       };
       const d = model.diff;
-      $('[data-mount="diff"]').innerHTML =
-        d.status === "ok"
-          ? sec("New traffic", d.traffic_new) + sec("Missing traffic", d.traffic_gone) + sec("Changed multiplicity", d.traffic_changed)
-          : `<p class="empty">Diff unavailable: ${d.reason || "unknown"}</p>`;
+      if (d.status === "ok") {
+        for (const node of [
+          ...sec("New traffic", d.traffic_new),
+          ...sec("Missing traffic", d.traffic_gone),
+          ...sec("Changed multiplicity", d.traffic_changed),
+        ]) mount.appendChild(node);
+      } else {
+        const p = document.createElement("p");
+        p.className = "empty";
+        p.textContent = `Diff unavailable: ${d.reason || "unknown"}`;
+        mount.appendChild(p);
+      }
     }
   </script>
 </body>

--- a/scripts/test_coldstep_detect_report_build.py
+++ b/scripts/test_coldstep_detect_report_build.py
@@ -40,8 +40,14 @@ class BuildReportModelTests(unittest.TestCase):
     def test_diff_lists_missing_traffic_fingerprint_for_removed_host(self):
         model = MOD.build(current_jsonl=str(CURR), baseline_jsonl=str(BASE))
         gone = [row["fingerprint"] for row in model["diff"]["traffic_gone"]]
-        self.assertTrue(any("theclouddj.com" in fp for fp in gone),
-                        f"expected theclouddj.com in traffic_gone, got {gone}")
+        # Fingerprint shape from ci_coldstep_jsonl_traffic_diff.traffic_fingerprint
+        # is "traffic » <type> » <dst> » <dport> » <fqdn> » ..." — split on the
+        # separator and check the FQDN component as a structured field rather
+        # than substring-matching the full fingerprint (avoids false positives
+        # like "not-theclouddj.com" and CodeQL py/incomplete-url-substring-sanitization).
+        gone_fqdns = {part.strip() for fp in gone for part in fp.split("\u00bb")}
+        self.assertIn("theclouddj.com", gone_fqdns,
+                      f"expected theclouddj.com in traffic_gone fqdns, got {gone}")
 
     def test_egress_sankey_aggregates_by_host_and_policy(self):
         model = MOD.build(current_jsonl=str(CURR), baseline_jsonl=str(BASE))


### PR DESCRIPTION
## Summary

Closes / dismisses **all 14 open CodeQL alerts** on `main` in one focused security-remediation pass. No functional behaviour change; tests still green.

| # | Severity | Rule | Where | Disposition |
|---|---|---|---|---|
| 1-6 | medium | `actions/missing-workflow-permissions` | `coldstep-ci-runner.yml` (6 jobs) | **Fixed** — top-level `permissions: contents: read` |
| 7 | medium | same | `coldstep-demo.yml` | **Fixed** — top-level `permissions: contents: read` |
| 8 | medium | same | `coldstep-demo-marketplace.yml` | **Fixed** — top-level `permissions: contents: read` |
| 9 | high | `py/incomplete-url-substring-sanitization` | `scripts/test_coldstep_detect_report_build.py:43` | **Fixed** — split fingerprint on `»`, list-membership lookup |
| 10 | high | `js/xss-through-dom` | `templates/report.html:77` (capabilities) | **Fixed** — safe DOM construction (`createElement` + `textContent`) |
| 11 | high | `js/xss-through-dom` | `templates/report.html:128` (diff) | **Fixed** — same pattern; `r.fingerprint` is genuinely user-derived from observed egress |
| 12 | high | `js/weak-cryptographic-algorithm` | `dist/main/index.js:16909` | **Dismissed** — vendored `undici`; SHA-1 is mandated by RFC 6455 §4.2.2 |
| 13 | high | `js/weak-cryptographic-algorithm` | `dist/post/index.js:16909` | **Dismissed** — same library, same reason |
| 14 | high | `js/redos` | `dist/post/index.js:20549` | **Dismissed** — vendored BigInt-aware JSON parser regex |

## Per-finding detail

### Workflow permissions (alerts 1-8, 8 closed)

Every job in the 3 flagged workflows was inheriting the default `GITHUB_TOKEN` (broad write) because no `permissions:` block existed at workflow scope. Added `permissions: contents: read` at the top level — fixes all 8 alerts at once and preserves the existing job-level `permissions: { actions: read, contents: read }` overrides used by `coldstep-demo-detect.yml`'s baseline-diff job (the established pattern in this repo).

### XSS-through-DOM (alerts 10-11, 2 closed)

The capabilities and diff mounts were both writing to `.innerHTML` with template-literal interpolation. The capabilities mount took values from `build_report_model.REQUIRED_CAPABILITIES` constants (a comment above the code explicitly warned future contributors not to add user-derived fields without escaping). The **diff mount took `r.fingerprint`**, which is built by `ci_coldstep_jsonl_traffic_diff.traffic_fingerprint` from observed network egress — i.e. an attacker that can cause a DNS lookup or HTTP request from the runner can plant arbitrary bytes (e.g. `evil.com<script>alert(1)</script>`) into the JSONL, into the report model, into the rendered HTML.

Both sites are now built via `document.createElement` + `.textContent`. Status pill class names are gated through `classList.add` with a `[a-z0-9_-]` allowlist (so even a malformed `r.status` cannot inject extra classes or attribute breakouts).

### Incomplete URL substring sanitization (alert 9, 1 closed)

```diff
- self.assertTrue(any("theclouddj.com" in fp for fp in gone), ...)
+ gone_fqdns = {part.strip() for fp in gone for part in fp.split("\u00bb")}
+ self.assertIn("theclouddj.com", gone_fqdns, ...)
```

The fingerprint shape from `traffic_fingerprint()` is `traffic » <type> » <dst> » <dport> » <fqdn> » <direction> » <policy>` — splitting on `»` and using set membership is precise (rejects `not-theclouddj.com`) and clears the CodeQL rule (which fires on string-`in`, not list-`in`).

### dist/** vendored library findings (alerts 12-14, 3 dismissed + future-proofed)

The 3 high-severity findings in `dist/main/index.js` and `dist/post/index.js` are inside vendored Node ecosystem code:

* **SHA-1 in `undici`'s WebSocket handshake** — `crypto.createHash("sha1").update(keyValue + uid).digest("base64")` implements `Sec-WebSocket-Accept` exactly as defined in RFC 6455 §4.2.2 (`base64(sha1(client-key + 258EAFA5-E914-47DA-95CA-C5AB0DC85B11))`). This is correct-by-spec; the SHA-1 use is not a security primitive, it is a protocol fingerprint.
* **ReDoS-shaped regex in a BigInt-aware JSON parser** — vendored library code; the affected entry point is not exposed to attacker-controlled JSON in our use of it.

Per `AGENTS.md` line 10, `dist/main/` and `dist/post/` are esbuild bundles regenerated from `src/main.ts` / `src/post.ts` — they are build artifacts, not source we author. This PR adds **`.github/codeql/codeql-config.yml`** with `paths-ignore: ['dist/**', 'node_modules/**']` so CodeQL stops re-flagging vendored code on every push (still scans `src/`, `scripts/`, workflows). The 3 currently-open alerts are dismissed via `gh code-scanning alert dismiss --reason won't-fix` with a link back to this PR.

## Verification

* `python -m unittest discover -s scripts -p 'test_*.py'` — **35 / 35 OK** including the rewritten fingerprint test.
* No `src/*.ts` change, so `dist/` is untouched (no rebuild needed).
* Signed commit (RSA `514CE5E0FEABBA8E1F4D8C581AF728AB416D279A`).

## Test plan

- [ ] CI green on `chore/codeql-security-remediation` (action_manifest, unit, unit-arm, integration, action_bundle, detect-mode, prevent-mode all pass).
- [ ] CodeQL re-scan after merge shows 11 alerts auto-closed by the fixes; alerts #12–14 stay dismissed.
- [ ] Spot-check `coldstep-demo` dispatch run on the merged `main` to confirm the workflow still completes end-to-end (least-privilege default did not regress any artifact / API access path).
- [ ] After merge, rebase `feat/otx-enrichment` on the new `main` so PR #30 picks up the safe-DOM rewrite + permissions baseline (the OTX work touches `report.html` in different sections, no conflict expected with the 2 sections fixed here).
