### PR TITLE
Security: sanitize COLDSTEP_REPORT_MODEL_IN in rdns enricher (CWE-23)

### DIFF
--- a/scripts/coldstep_dns/enrich_rdns.py
+++ b/scripts/coldstep_dns/enrich_rdns.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from pathlib import Path
 from typing import Iterable, Optional
@@ -66,14 +67,41 @@ def run(
     return 0
 
 
+_SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9_./\\:-]+\.json$")
+
+
+def _safe_model_path(raw: str) -> str:
+    # Mirrors scripts/coldstep_otx/enrich.py: COLDSTEP_REPORT_MODEL_IN is
+    # untrusted from Snyk Code's point of view (python/PT, CWE-23). Defence
+    # is two-stage so a poisoned env var cannot reach the read/write sinks
+    # in run(): a regex allowlist for the literal characters, then
+    # realpath()+commonpath() containment under GITHUB_WORKSPACE (or cwd
+    # outside CI). Anything else is refused at the boundary.
+    if not _SAFE_PATH_RE.match(raw):
+        raise ValueError("disallowed characters in model path")
+    root = os.path.realpath(os.environ.get("GITHUB_WORKSPACE") or os.getcwd())
+    resolved = os.path.realpath(raw)
+    if os.path.commonpath([resolved, root]) != root:
+        raise ValueError(f"{resolved!r} is not under {root!r}")
+    return resolved
+
+
 def main() -> int:
     # Mirrors enrich.py's catch-all: every load/parse/write/runtime surprise
     # surfaces as a workflow warning and we still exit 0.
     try:
-        model_path = os.environ.get("COLDSTEP_REPORT_MODEL_IN", "")
-        if not model_path:
+        raw_model_path = os.environ.get("COLDSTEP_REPORT_MODEL_IN", "")
+        if not raw_model_path:
             print("enrich_rdns: missing required env var COLDSTEP_REPORT_MODEL_IN",
                   file=sys.stderr)
+            return 0
+        try:
+            model_path = _safe_model_path(raw_model_path)
+        except ValueError as e:
+            print(
+                f"enrich_rdns: refusing COLDSTEP_REPORT_MODEL_IN outside workspace: {e}",
+                file=sys.stderr,
+            )
             return 0
         try:
             wall_ms = int(os.environ.get("COLDSTEP_RDNS_WALL_BUDGET_MS", "5000"))


### PR DESCRIPTION
## Security Fix

### Vulnerability Details
- **ID**: Snyk Code `python/PT`
- **CWE**: CWE-23 (Path Traversal)
- **Severity**: Medium
- **Type**: Code (SAST)
- **File**: `scripts/coldstep_dns/enrich_rdns.py`
- **Instances Fixed**: 2 (lines 53 and 61)

### Root Cause
Sibling issue to the OTX enricher: `enrich_rdns.run()` reads the
report-model path from the `COLDSTEP_REPORT_MODEL_IN` env var (set by the
CI workflow) and passes it straight into both a `Path(...).read_text(...)`
load and a `Path(...).write_text(...)` store. Snyk Code (correctly) treats
env input as untrusted: a poisoned value (`../../etc/passwd`-style) on a
runner could read or overwrite an arbitrary JSON file inside or outside
the workspace.

### Fix
Mirrors PR #37 (the OTX enricher fix). A new `_safe_model_path()` runs
once at the `main()` trust boundary:

1. **Regex allowlist** rejects shell metachars, NULs, newlines, and
   anything that doesn't look like a `*.json` path.
2. **`os.path.realpath` + `os.path.commonpath`** containment pins the
   resolved file under `GITHUB_WORKSPACE` (or `os.getcwd()` outside CI).
   Anything outside the allowed root is refused cleanly while preserving
   the script's always-exit-0 contract.

`run()` is unchanged so the existing tests, which call it directly with
`tempfile.NamedTemporaryFile` paths, keep passing.

### Files Changed
- `scripts/coldstep_dns/enrich_rdns.py` (+30 / -2)

### Validation
- [x] Snyk Code re-scan on the file: `issueCount: 0`
- [x] `python -m unittest scripts.test_coldstep_dns_enrich_rdns` -> 5/5 pass
- [x] No new vulnerabilities introduced
- [x] Commit cryptographically signed (`G` / good signature)

### Related
Same pattern as #37 (OTX enricher).
