### PR TITLE
chore(gitignore): hide local-only orchestrator tooling from VCS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@ scripts/__pycache__/
 # Local-only trees — never staged, never committed (do not `git add` docs/ or knowledge/, never `git add -f`).
 /docs/
 /knowledge/
+# Local-only orchestrator package: tooling that operates on the gitignored knowledge/ vault.
+# Lives next to scripts/ but is not part of the shipped product surface.
+/scripts/orchestrator/
+/scripts/test_orchestrator_*.py
 
 # Ignore stray copies under .github only.
 /.github/design/


### PR DESCRIPTION
Add /scripts/orchestrator/ and /scripts/test_orchestrator_*.py to .gitignore. This package is local tooling that operates on the gitignored knowledge/ vault and is not part of the shipped product surface (action.yml, internal/, dist/).

Lives next to scripts/ purely so the Python module path stays clean and tests run via the standard 'python -m unittest discover -s scripts' invocation. Configs live at knowledge/.orchestrator/{tags,persona}.yml (also gitignored).