### PR TITLE
Release v0.1.5: pins, OTX docs, Job Summary triage

### DIFF
--- a/.github/workflows/coldstep-demo-detect.yml
+++ b/.github/workflows/coldstep-demo-detect.yml
@@ -1,7 +1,7 @@
 # Simplified detect-mode demo (observe-only) with previous-run JSONL diff (`COLDSTEP_DIFF_PREV_RUN`).
 # One real probe per detect capability (same probes as `coldstep-demo.yml` detect-mode). For the full integration
 # workflow including enforce, see `.github/workflows/coldstep-demo.yml`.
-# Consumer pin (elsewhere): `uses: coldstep-io/coldstep@v0.1.4`
+# Consumer pin (elsewhere): `uses: coldstep-io/coldstep@v0.1.5`
 #
 # Agent binary: download `coldstep-linux-amd64` from the repo GitHub Release for `COLDSTEP_AGENT_VERSION`
 # (published by `supply-chain-attest.yml` on version tags). The action uses `release-path` and does not compile.
@@ -18,7 +18,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  COLDSTEP_AGENT_VERSION: v0.1.4
+  COLDSTEP_AGENT_VERSION: v0.1.5
 
 jobs:
   demo:

--- a/.github/workflows/coldstep-demo-enforce.yml
+++ b/.github/workflows/coldstep-demo-enforce.yml
@@ -1,6 +1,6 @@
 # Simplified enforce-mode demo (cgroup egress allowlist). Previous-run JSONL diff uses the same opt-in env as detect
 # (`COLDSTEP_DIFF_PREV_RUN`). Control matrix matches `coldstep-demo.yml` prevent-mode (nmap/nc allow, curl/nc deny).
-# Consumer pin (elsewhere): `uses: coldstep-io/coldstep@v0.1.4`
+# Consumer pin (elsewhere): `uses: coldstep-io/coldstep@v0.1.5`
 #
 # Agent binary: same GitHub Release download + `release-path` as `coldstep-demo-detect.yml`.
 
@@ -16,7 +16,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  COLDSTEP_AGENT_VERSION: v0.1.4
+  COLDSTEP_AGENT_VERSION: v0.1.5
 
 jobs:
   demo:

--- a/.github/workflows/coldstep-demo-marketplace.yml
+++ b/.github/workflows/coldstep-demo-marketplace.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: coldstep-io/coldstep@v0.1.4
+      - uses: coldstep-io/coldstep@v0.1.5
         with:
           mode: detect
           feature-gates: proc_tree=1,tls_sni=1,fs_events=1

--- a/.github/workflows/coldstep-demo.yml
+++ b/.github/workflows/coldstep-demo.yml
@@ -10,7 +10,7 @@
 name: coldstep-demo
 
 # Same-repo demo: use `uses: ./` after checkout so the job always loads repo-root `action.yml`
-# from the workflow ref. Published tags (e.g. v0.1.4) must also ship `action.yml` at the root
+# from the workflow ref. Published tags (e.g. v0.1.5) must also ship `action.yml` at the root
 # for `uses: coldstep-io/coldstep@TAG` to work elsewhere; see coldstep-ci-runner.yml for the same pattern.
 
 on:
@@ -23,7 +23,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  COLDSTEP_AGENT_VERSION: v0.1.4
+  COLDSTEP_AGENT_VERSION: v0.1.5
 
 # Default to least-privilege; the detect-mode job overrides with
 # `permissions: { actions: read, contents: read }` when previous-run baseline

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Thanks for helping improve coldstep. This document is the maintainer-facing coun
 2. **Go** — CI uses **`setup-go`** with **`go-version: 1.24.x`**, matching **`go.mod`**. After Linux prep, `gofmt`, `go vet ./...`, and `go test ./...` should pass (see CI for integration tags).
 3. **TypeScript** — if you edit `src/main.ts` or `src/post.ts`, run `npm run typecheck` and **`npm run build`** (**`ncc`** writes **`dist/main`** and **`dist/post`**) so committed **`dist/`** stays in sync with sources.
 4. **Docs** — if you change workflow pins or action inputs, update **README**, **QUICK_START**, and **`action.yml`** descriptions so they stay aligned.
-5. **Pinning for consumers** — downstream workflows should use a **release tag** (for example **`coldstep-io/coldstep@v0.1.4`**), not **`@main`**, unless they intentionally track head.
+5. **Pinning for consumers** — downstream workflows should use a **release tag** (for example **`coldstep-io/coldstep@v0.1.5`**), not **`@main`**, unless they intentionally track head.
 
 ## Security-sensitive areas
 

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -1,6 +1,6 @@
 # Coldstep Quick Start
 
-**v1:** the composite agent is validated and supported on **`runs-on: ubuntu-latest`** only. Pin the published action at **`coldstep-io/coldstep@v0.1.4`** (or a newer tag you publish). **Repository changes** are validated via **GitHub Actions** (open a PR or use **`workflow_dispatch`** on **`coldstep-ci`**, **`coldstep-demo`**, **`coldstep-demo-detect`**, or **`coldstep-demo-enforce`**); there is no maintained local build path for the Linux agent.
+**v1:** the composite agent is validated and supported on **`runs-on: ubuntu-latest`** only. Pin the published action at **`coldstep-io/coldstep@v0.1.5`** (or a newer tag you publish). **Repository changes** are validated via **GitHub Actions** (open a PR or use **`workflow_dispatch`** on **`coldstep-ci`**, **`coldstep-demo`**, **`coldstep-demo-detect`**, or **`coldstep-demo-enforce`**); there is no maintained local build path for the Linux agent.
 
 ## TL;DR (copy/paste)
 
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: coldstep-io/coldstep@v0.1.4
+      - uses: coldstep-io/coldstep@v0.1.5
 ```
 
 That is enough to get:
@@ -35,8 +35,8 @@ That is enough to get:
 
 ## Versioning
 
-- Prefer **`coldstep-io/coldstep@v0.1.4`** (or a **newer tag** you publish, for example **`v0.2.0`**). **`@main`** tracks the default branch and can change without notice.
-- **`v0.1.0`** is not usable with `uses: coldstep-io/coldstep@v0.1.0` (that tag lacks repo-root **`action.yml`**); use **`v0.1.4`** or later.
+- Prefer **`coldstep-io/coldstep@v0.1.5`** (or a **newer tag** you publish, for example **`v0.2.0`**). **`@main`** tracks the default branch and can change without notice.
+- **`v0.1.0`** is not usable with `uses: coldstep-io/coldstep@v0.1.0` (that tag lacks repo-root **`action.yml`**); use **`v0.1.5`** or later.
 
 **Example workflows in this repo** (all use `uses: ./` and are triggered with **`workflow_dispatch`**): **[`coldstep-demo-detect.yml`](.github/workflows/coldstep-demo-detect.yml)** (minimal detect), **[`coldstep-demo-enforce.yml`](.github/workflows/coldstep-demo-enforce.yml)** (minimal enforce), and **[`coldstep-demo.yml`](.github/workflows/coldstep-demo.yml)** (full integration / drift).
 
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: coldstep-io/coldstep@v0.1.4
+      - uses: coldstep-io/coldstep@v0.1.5
         with:
           feature-gates: proc_tree=1,tls_sni=1,fs_events=1
           report-job-summary: true
@@ -73,10 +73,10 @@ jobs:
 
 ## Enforce mode (optional)
 
-Detect mode is default. For enforce behavior, reuse the same **`env`** / **`checkout`** / **`coldstep-io/coldstep@v0.1.4`** pin as above, then configure `with:`:
+Detect mode is default. For enforce behavior, reuse the same **`env`** / **`checkout`** / **`coldstep-io/coldstep@v0.1.5`** pin as above, then configure `with:`:
 
 ```yaml
-- uses: coldstep-io/coldstep@v0.1.4
+- uses: coldstep-io/coldstep@v0.1.5
   with:
     mode: enforce
     allowed-domains: google.com,github.com
@@ -95,6 +95,10 @@ Denied egress appears as `"type":"deny"` in JSONL and in the digest.
 - **Workspace:** `.coldstep-events.jsonl`, `.coldstep-telemetry.json`.
 
 Start with default **detect**, then add **`feature-gates`** when you need those streams.
+
+### Optional: OTX enrichment (detect reports)
+
+Set repo/org secret **`OTX_API_KEY`** for AlienVault OTX lookups in the detect report pipeline. No secret → enrichment skipped. See **`scripts/coldstep_detect_report/README.md`**.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **coldstep** is a GitHub Action plus a small Linux **eBPF** agent for **GitHub-hosted Ubuntu** runners. It observes process and network activity in **detect** mode (default) and can optionally **enforce** an egress allowlist. Telemetry is written to **JSONL** in the workspace and summarized as **Markdown** (merged into the job **Summary** when enabled).
 
-**Pin workflows to** **`coldstep-io/coldstep@v0.1.4`** (or a newer tag). Listing: [**Coldstep eBPF CI Egress** on GitHub Marketplace](https://github.com/marketplace/actions/coldstep-ebpf-ci-egress).
+**Pin workflows to** **`coldstep-io/coldstep@v0.1.5`** (or a newer tag). Listing: [**Coldstep eBPF CI Egress** on GitHub Marketplace](https://github.com/marketplace/actions/coldstep-ebpf-ci-egress).
 
 [![coldstep-ci](https://github.com/coldstep-io/coldstep/actions/workflows/coldstep-ci.yml/badge.svg)](https://github.com/coldstep-io/coldstep/actions/workflows/coldstep-ci.yml) [![coldstep-demo](https://github.com/coldstep-io/coldstep/actions/workflows/coldstep-demo.yml/badge.svg)](https://github.com/coldstep-io/coldstep/actions/workflows/coldstep-demo.yml)
 
@@ -12,7 +12,7 @@
 
 ## Add it to a workflow
 
-**v1:** use **`runs-on: ubuntu-latest`** (see **Requirements**). Pin the published composite action at **`coldstep-io/coldstep@v0.1.4`** (or a newer tag you publish), not **`@main`**.
+**v1:** use **`runs-on: ubuntu-latest`** (see **Requirements**). Pin the published composite action at **`coldstep-io/coldstep@v0.1.5`** (or a newer tag you publish), not **`@main`**.
 
 ```yaml
 env:
@@ -24,14 +24,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: coldstep-io/coldstep@v0.1.4
+      - uses: coldstep-io/coldstep@v0.1.5
         with:
           fail-on-error: true
           log-level: info
       - run: echo "your build steps"
 ```
 
-**`coldstep-demo`** (`workflow_dispatch`) runs the in-repo action with **`uses: ./`** (same pattern as [`.github/workflows/coldstep-ci-runner.yml`](.github/workflows/coldstep-ci-runner.yml)). Downstream repos should pin **`coldstep-io/coldstep@v0.1.4`** (or a newer tag).
+**`coldstep-demo`** (`workflow_dispatch`) runs the in-repo action with **`uses: ./`** (same pattern as [`.github/workflows/coldstep-ci-runner.yml`](.github/workflows/coldstep-ci-runner.yml)). Downstream repos should pin **`coldstep-io/coldstep@v0.1.5`** (or a newer tag).
 
 ---
 
@@ -73,7 +73,7 @@ Consumer copy-paste above uses **`actions/checkout@v6`**. Other first-party pins
 | File | Role |
 | :--- | :--- |
 | **`.coldstep-events.jsonl`** | Append-only event stream (source of truth for investigations). |
-| **`.coldstep-detect.md`** | Shutdown digest (KPI tables, collapsible sections). |
+| **`.coldstep-detect.md`** | Shutdown digest (triage ribbon, KPI tables, collapsible sections). |
 | **`.coldstep-telemetry.json`** | Shutdown totals and BPF health. |
 
 The **post** step can merge **`.coldstep-detect.md`** into the **Actions Summary** tab (`report-job-summary`, default on). Paths can be overridden with env vars such as `COLDSTEP_EVENTS_LOG`, `COLDSTEP_DETECT_LOG`, `COLDSTEP_TELEMETRY_JSON`. For cgroup BPF attach, **`COLDSTEP_CGROUP_PATH`** overrides the directory passed to **`link.AttachCgroup`** (default: cgroup v2 path from **`/proc/self/cgroup`**, else **`/sys/fs/cgroup`**).
@@ -95,6 +95,10 @@ Full list and defaults: **[`action.yml`](action.yml)**. Frequently used:
 | `report-pr-summary` | Optional PR comment (needs `github-token`). |
 | `ignored-ip-nets` / `no-default-ignored-nets` | Optional RFC1918-style ignore merges for policy and enforce bypass (see `action.yml`). |
 | `smoke-test-egress` | Optional UDP/HTTP probes after startup (default `false`; set `true` for extra digest/JSONL coverage). |
+
+### Optional threat intel (AlienVault OTX)
+
+Detect workflows that build the **report model** (see [`scripts/coldstep_detect_report/README.md`](scripts/coldstep_detect_report/README.md)) can enrich indicators with **AlienVault OTX**. Add a repository or organization secret named **`OTX_API_KEY`**. If the secret is **missing or empty**, enrichment is **skipped** (no outbound calls to OTX; jobs still succeed). Details, env vars, and schema: **`scripts/coldstep_detect_report/README.md`**.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,6 +39,10 @@ Workflow steps run with the **same privileges** as the job (modulo `sudo` elevat
 
 No userland agent can promise **complete** observation of every kernel path on every kernel revision. Consumers needing **audit-grade non-repudiation** must combine Coldstep with **organizational controls** (locked-down workflows, secrets policies, optional additional LSM / host controls outside this project).
 
+### Optional third-party threat intel (OTX)
+
+When a workflow supplies a non-empty **`OTX_API_KEY`** repository secret to the detect-report enrichment step, the runner performs **HTTPS requests** to AlienVault Open Threat Exchange (`otx.alienvault.com`) for indicator lookups. When the secret is **absent or empty**, **no such requests** occur. Enrichment is designed not to fail the job on API errors (see **`scripts/coldstep_detect_report/README.md`**).
+
 ### Further reading
 
 Maintain optional extended design material under **`docs/design/`** in your clone; that tree is **gitignored** and **not** published from Git. The consumer-facing summary is the **GitHub Actions** sections above and **README** → Requirements.

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -13,6 +13,9 @@ import (
 // DefaultMaxRowsPerSection caps each collapsible table in the Job Summary digest.
 const DefaultMaxRowsPerSection = 120
 
+// maxHotEgressEntities caps the ranked "where did traffic go" triage table.
+const maxHotEgressEntities = 15
+
 const summarySoftByteBudget = 950_000
 
 // ExecDigestRow is one exec line in the markdown digest.
@@ -167,6 +170,180 @@ type DigestInput struct {
 	DroppedCounts           map[string]int
 }
 
+// hotEgressAgg aggregates digest rows by destination for the triage table.
+type hotEgressAgg struct {
+	key   string
+	count int
+	kinds map[string]struct{}
+}
+
+func normalizeDigestKey(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.Trim(s, "`")
+	return strings.TrimSpace(s)
+}
+
+func appendHotRow(m map[string]*hotEgressAgg, key, kind string) {
+	k := normalizeDigestKey(key)
+	if k == "" {
+		return
+	}
+	e, ok := m[k]
+	if !ok {
+		e = &hotEgressAgg{key: k, kinds: make(map[string]struct{})}
+		m[k] = e
+	}
+	e.count++
+	e.kinds[kind] = struct{}{}
+}
+
+func buildHotEgressList(in DigestInput) []hotEgressAgg {
+	m := make(map[string]*hotEgressAgg)
+	for _, r := range in.TCPRows {
+		appendHotRow(m, r.Remote, "tcp")
+	}
+	for _, r := range in.UDPRows {
+		if fq := normalizeDigestKey(r.FQDN); fq != "" {
+			appendHotRow(m, fq, "udp")
+		} else {
+			appendHotRow(m, r.Remote, "udp")
+		}
+	}
+	for _, r := range in.HTTPRows {
+		if h := normalizeDigestKey(r.Host); h != "" {
+			appendHotRow(m, h, "http")
+		} else {
+			appendHotRow(m, r.Remote, "http")
+		}
+	}
+	for _, r := range in.TLSRows {
+		if sni := normalizeDigestKey(r.SNI); sni != "" {
+			appendHotRow(m, sni, "tls")
+		} else {
+			appendHotRow(m, r.Remote, "tls")
+		}
+	}
+	out := make([]hotEgressAgg, 0, len(m))
+	for _, v := range m {
+		out = append(out, *v)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].count != out[j].count {
+			return out[i].count > out[j].count
+		}
+		return out[i].key < out[j].key
+	})
+	if len(out) > maxHotEgressEntities {
+		out = out[:maxHotEgressEntities]
+	}
+	return out
+}
+
+func hotKindTags(kinds map[string]struct{}) string {
+	order := []string{"tcp", "udp", "http", "tls"}
+	var tags []string
+	for _, o := range order {
+		if _, ok := kinds[o]; ok {
+			tags = append(tags, o)
+		}
+	}
+	return strings.Join(tags, ", ")
+}
+
+func writeTriageRibbon(b *strings.Builder, in DigestInput) {
+	b.WriteString("### Triage\n\n")
+	b.WriteString("| Question | Answer |\n|:--|:--|\n")
+
+	mode := "detect"
+	if strings.EqualFold(in.EnforcementMode, "enforce") {
+		mode = "enforce"
+	}
+	b.WriteString(fmt.Sprintf("| **Mode** | `%s`", sanitizeCell(mode)))
+	if strings.EqualFold(in.EnforcementMode, "enforce") {
+		b.WriteString(fmt.Sprintf(" — **deny events:** %d", in.EnforcementDenyCount))
+		if in.EnforcementDenyReserveFailures > 0 {
+			b.WriteString(fmt.Sprintf(" (**+%d** deny reserve failures)", in.EnforcementDenyReserveFailures))
+		}
+	}
+	b.WriteString(" |\n")
+
+	bpfOK := true
+	var badBPF []string
+	for _, row := range in.BPF {
+		if !row.OK {
+			bpfOK = false
+			badBPF = append(badBPF, row.Name)
+		}
+	}
+	if len(in.BPF) == 0 {
+		b.WriteString("| **BPF hooks** | *(no status rows)* |\n")
+	} else if bpfOK {
+		b.WriteString("| **BPF hooks** | **OK** — all reported probes loaded |\n")
+	} else {
+		sort.Strings(badBPF)
+		b.WriteString(fmt.Sprintf("| **BPF hooks** | **Review** — degraded: %s |\n", sanitizeCell(strings.Join(badBPF, ", "))))
+	}
+
+	droppedTotal := 0
+	for _, v := range in.DroppedCounts {
+		droppedTotal += v
+	}
+	if droppedTotal == 0 {
+		b.WriteString("| **JSONL decode drops** | **None** |\n")
+	} else {
+		b.WriteString(fmt.Sprintf("| **JSONL decode drops** | **%d** total — see rollups below |\n", droppedTotal))
+	}
+
+	var gapParts []string
+	if in.Connect4TupleUpdateFailures > 0 {
+		gapParts = append(gapParts, fmt.Sprintf("connect4 map failures=%d", in.Connect4TupleUpdateFailures))
+	}
+	if in.UDPRingbufReserveFailures > 0 {
+		gapParts = append(gapParts, fmt.Sprintf("udp ringbuf reserve=%d", in.UDPRingbufReserveFailures))
+	}
+	if in.DNSRingbufReserveFailures > 0 {
+		gapParts = append(gapParts, fmt.Sprintf("dns ringbuf reserve=%d", in.DNSRingbufReserveFailures))
+	}
+	if in.UDPSendmsgMultiIovecObserved > 0 {
+		gapParts = append(gapParts, fmt.Sprintf("udp multi-iovec=%d", in.UDPSendmsgMultiIovecObserved))
+	}
+	if in.TLSWritevMultiIovecObserved > 0 {
+		gapParts = append(gapParts, fmt.Sprintf("tls writev multi-iovec=%d", in.TLSWritevMultiIovecObserved))
+	}
+	if in.UnobservedEgressSyscalls > 0 {
+		gapParts = append(gapParts, fmt.Sprintf("unobserved egress syscalls=%d", in.UnobservedEgressSyscalls))
+	}
+	if len(gapParts) == 0 {
+		b.WriteString("| **Capture gaps** | **None reported** (see footnotes for semantics) |\n")
+	} else {
+		b.WriteString(fmt.Sprintf("| **Capture gaps** | **Review** — %s |\n", sanitizeCell(strings.Join(gapParts, "; "))))
+	}
+
+	b.WriteString("\n")
+	b.WriteString("<sub>Triage is for fast decisions; row-level detail stays in collapsible sections below and in JSONL.</sub>\n\n")
+}
+
+func writeHotEgressTable(b *strings.Builder, in DigestInput) {
+	hot := buildHotEgressList(in)
+	if len(hot) == 0 {
+		return
+	}
+	b.WriteString("### Hot egress destinations\n\n")
+	b.WriteString("Ranked by **event rows in this digest window** (not global uniqueness across the full JSONL). ")
+	b.WriteString("Prefer **Host** / **SNI** / **FQDN** columns when present.\n\n")
+	b.WriteString("| Rank | Entity | Rows | Channels |\n")
+	b.WriteString("|--:|:-|--:|:-|\n")
+	for i, e := range hot {
+		tags := hotKindTags(e.kinds)
+		if tags == "" {
+			tags = "—"
+		}
+		b.WriteString(fmt.Sprintf("| %d | %s | %d | %s |\n",
+			i+1, sanitizeCell(e.key), e.count, sanitizeCell(tags)))
+	}
+	b.WriteString("\n")
+}
+
 // BuildDetectMarkdown returns GFM + limited HTML for `.coldstep-detect.md`.
 func BuildDetectMarkdown(in DigestInput) string {
 	max := in.MaxRowsPerSection
@@ -184,6 +361,8 @@ func BuildDetectMarkdown(in DigestInput) string {
 		b.WriteString("<p align=\"center\"><strong>eBPF runtime audit trail</strong><br/>\n")
 		b.WriteString("<sub>Detect-only: observe, do not block. <code>comm</code> is the kernel task name (16 bytes), not argv. Executable path comes from the tracepoint (BPF-capped).</sub></p>\n\n")
 	}
+	writeTriageRibbon(&b, in)
+	writeHotEgressTable(&b, in)
 	b.WriteString("### KPI\n\n")
 	b.WriteString("| Signal | Count |\n|:--|--:|\n")
 	b.WriteString(fmt.Sprintf("| **exec** | %d |\n", in.ExecTotal))
@@ -366,7 +545,7 @@ func BuildDetectMarkdown(in DigestInput) string {
 	}
 
 	writeExec := func() {
-		b.WriteString("<details open>\n<summary><strong>Exec (recent)</strong></summary>\n\n")
+		b.WriteString("<details>\n<summary><strong>Exec (recent)</strong></summary>\n\n")
 		b.WriteString("| Time (UTC) | PID (TGID) | TID | Comm | Executable (BPF-capped) |\n|:--|--:|--:|:-|:-|\n")
 		for _, r := range in.ExecRows {
 			b.WriteString(fmt.Sprintf("| %s | `%d` | `%d` | `%s` | `%s` |\n",
@@ -390,7 +569,7 @@ func BuildDetectMarkdown(in DigestInput) string {
 		b.WriteString("\n</details>\n\n")
 	}
 	writeTCP := func() {
-		b.WriteString("<details open>\n<summary><strong>TCP connect attempts (recent)</strong></summary>\n\n")
+		b.WriteString("<details>\n<summary><strong>TCP connect attempts (recent)</strong></summary>\n\n")
 		b.WriteString("| Time (UTC) | PID | Comm | Remote | Notes | Policy |\n|:--|--:|:-|:-|:-|:-|\n")
 		if len(in.TCPRows) == 0 {
 			b.WriteString(fmt.Sprintf("| — | — | — | — | — | %s |\n", sanitizeCell(tcpEmptyReason(in))))

--- a/internal/report/digest_test.go
+++ b/internal/report/digest_test.go
@@ -8,6 +8,51 @@ import (
 	"github.com/coldstep-io/coldstep/internal/telemetry"
 )
 
+func TestBuildDetectMarkdown_TriageRibbon_Detect(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{
+		BPF:               []telemetry.BPFStatus{{Name: "sched_process_exec", OK: true}},
+		ExecTotal:         1,
+		TCPTotal:          1,
+		DroppedCounts:     map[string]int{"decode": 2},
+		MaxRowsPerSection: 50,
+	})
+	for _, needle := range []string{"### Triage", "**Mode**", "`detect`", "**JSONL decode drops**", "**2**"} {
+		if !strings.Contains(md, needle) {
+			t.Fatalf("missing %q in:\n%s", needle, md)
+		}
+	}
+}
+
+func TestBuildDetectMarkdown_TriageRibbon_EnforceDeny(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{
+		EnforcementMode:      "enforce",
+		EnforcementDenyCount: 3,
+		BPF:                  []telemetry.BPFStatus{{Name: "connect", OK: true}},
+		MaxRowsPerSection:    50,
+	})
+	if !strings.Contains(md, "**deny events:** 3") {
+		t.Fatalf("missing deny triage:\n%s", md)
+	}
+}
+
+func TestBuildDetectMarkdown_HotEgressDestinations(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{
+		TCPRows: []TCPDigestRow{{
+			TS: "t", PID: 1, Comm: "curl", Remote: "`10.0.0.1:443`", Policy: "monitor",
+		}},
+		HTTPRows: []HTTPDigestRow{{
+			TS: "t", PID: 1, Comm: "curl", Method: "GET", Host: "registry.npmjs.org",
+			Path: "/", Remote: "`104.16.0.0:443`", Policy: "monitor",
+		}},
+		MaxRowsPerSection: 50,
+	})
+	for _, needle := range []string{"### Hot egress destinations", "registry.npmjs.org", "10.0.0.1:443", "tcp", "http"} {
+		if !strings.Contains(md, needle) {
+			t.Fatalf("missing %q in:\n%s", needle, md)
+		}
+	}
+}
+
 func TestBuildDetectMarkdown_PolicyRollupIncludesIgnored(t *testing.T) {
 	md := BuildDetectMarkdown(DigestInput{
 		BPF:               []telemetry.BPFStatus{{Name: "sched_process_exec", OK: true}},

--- a/scripts/check_workflow_action_pins.py
+++ b/scripts/check_workflow_action_pins.py
@@ -15,7 +15,7 @@ import sys
 from pathlib import Path
 
 # Bump when publishing a new consumer-facing tag (same as README marketplace pin).
-MARKETPLACE_COLDSTEP_TAG = "v0.1.4"
+MARKETPLACE_COLDSTEP_TAG = "v0.1.5"
 
 ROOT = Path(__file__).resolve().parent.parent
 WORKFLOWS = ROOT / ".github" / "workflows"

--- a/scripts/coldstep_detect_report/render_step_summary.py
+++ b/scripts/coldstep_detect_report/render_step_summary.py
@@ -82,6 +82,62 @@ def _xy_axis_label(value: object) -> str:
     return '"' + str(value).replace('"', "'") + '"'
 
 
+def _triage_ribbon_md(model: dict) -> str:
+    """Compact decision strip before charts — baseline / OTX / volume."""
+    lines = [
+        "### Detect report · triage",
+        "",
+        "| Question | Answer |",
+        "|---|---|",
+    ]
+    diff = model.get("diff") or {}
+    if diff.get("status") == "ok":
+        new_n = len(diff.get("traffic_new") or [])
+        gone_n = len(diff.get("traffic_gone") or [])
+        ch_n = len(diff.get("traffic_changed") or [])
+        lines.append(
+            f"| **Baseline diff** | **OK** — new={new_n}, gone={gone_n}, changed={ch_n} |"
+        )
+    else:
+        reason = _md_cell(str(diff.get("reason", "unknown")))
+        lines.append(f"| **Baseline diff** | **Unavailable** — {reason} |")
+
+    evs = model.get("events_by_type") or []
+    total_ev = sum(e.get("count", 0) for e in evs)
+    top = evs[0] if evs else None
+    if top is not None:
+        lines.append(
+            "| **Event mix** | "
+            f"**{total_ev}** events — top type `{_md_cell(top['type'])}` ({top['count']}) |"
+        )
+    else:
+        lines.append("| **Event mix** | _No typed events_ |")
+
+    otx = model.get("otx")
+    if not otx:
+        lines.append("| **OTX threat intel** | *(not in model — run enrich step)* |")
+    elif otx.get("skipped"):
+        sr = _md_cell(str(otx.get("skipped_reason") or "unknown"))
+        lines.append(f"| **OTX threat intel** | **Skipped** — {sr} |")
+    else:
+        indicators = otx.get("indicators") or []
+        malicious = sum(1 for r in indicators if r.get("verdict") == "malicious")
+        n_ind = len(indicators)
+        if malicious > 0:
+            lines.append(
+                f"| **OTX threat intel** | **Review** — **{malicious}** malicious / {n_ind} indicators |"
+            )
+        else:
+            lines.append(
+                f"| **OTX threat intel** | **OK** — 0 malicious ({n_ind} indicators) |"
+            )
+
+    lines.append("")
+    lines.append("_Expand sections below for charts, sankey, and diff tables._")
+    lines.append("")
+    return "\n".join(lines)
+
+
 def _capability_matrix_md(model: dict) -> str:
     lines = [
         "### Detect Capability Matrix (GitHub-hosted ubuntu-latest)",
@@ -255,6 +311,7 @@ def _diff_md(model: dict) -> str:
 
 def write_summary(model: dict, summary_path: str) -> None:
     parts = [
+        _triage_ribbon_md(model),
         _capability_matrix_md(model),
         _events_xychart_md(model),
         _egress_sankey_md(model),

--- a/scripts/test_coldstep_detect_report_render_summary.py
+++ b/scripts/test_coldstep_detect_report_render_summary.py
@@ -37,6 +37,9 @@ class StepSummaryRendererTests(unittest.TestCase):
 
     def test_summary_contains_capability_matrix_with_pills(self):
         out = self._render()
+        self.assertIn("### Detect report · triage", out)
+        self.assertIn("| **Baseline diff** | **OK**", out)
+        self.assertIn("| **OTX threat intel** |", out)
         self.assertIn("### Detect Capability Matrix", out)
         self.assertIn("🟢", out)
         self.assertIn("Exec tracing", out)

--- a/website/index.html
+++ b/website/index.html
@@ -6,7 +6,7 @@
     <title>ColdStep — eBPF observability for GitHub-hosted Ubuntu runners</title>
     <meta
       name="description"
-      content="ColdStep is a GitHub Action and Linux eBPF agent that observes process and network activity on ubuntu-latest runners. Detect by default; optional egress enforcement."
+      content="ColdStep is a GitHub Action and Linux eBPF agent for ubuntu-latest runners: detect mode, optional egress enforcement, and optional AlienVault OTX enrichment for detect HTML reports when OTX_API_KEY is set."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -121,14 +121,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: coldstep-io/coldstep@v0.1.4</code></pre>
+      - uses: coldstep-io/coldstep@v0.1.5
+</code></pre>
           </div>
         </section>
 
         <section class="section section--tight-top" aria-labelledby="modes-heading">
           <h2 id="modes-heading">Two modes, one agent</h2>
           <p class="section-intro">
-            Pin a release tag in workflows (for example <code>coldstep-io/coldstep@v0.1.4</code>) instead of tracking
+            Pin a release tag in workflows (for example <code>coldstep-io/coldstep@v0.1.5</code>) instead of tracking
             <code>@main</code> unless you intentionally want churn.
           </p>
           <div class="modes">
@@ -161,11 +162,47 @@ jobs:
             </li>
             <li>
               <code>.coldstep-detect.md</code>
-              <span>Shutdown digest with KPI tables and collapsible sections for quick scans.</span>
+              <span>Shutdown digest with triage ribbon, KPI tables, and collapsible sections for quick scans.</span>
             </li>
             <li>
               <code>.coldstep-telemetry.json</code>
               <span>Totals and BPF health at shutdown for operational dashboards.</span>
+            </li>
+          </ul>
+        </section>
+
+        <section class="section" aria-labelledby="otx-heading">
+          <h2 id="otx-heading">Optional AlienVault OTX enrichment</h2>
+          <p class="section-intro">
+            For <strong>detect</strong> workflows that build the bundled HTML report and job Summary, you can layer
+            <strong>AlienVault Open Threat Exchange (OTX)</strong> lookups on IPv4 and hostname indicators. Results feed
+            verdict columns and charts in the Markdown summary and self-contained HTML artifact—without changing core
+            egress telemetry.
+          </p>
+          <ul class="outputs">
+            <li>
+              <code>OTX_API_KEY</code>
+              <span>
+                Store your key as a repository or organization secret with this name. Create a free OTX account at
+                <a href="https://otx.alienvault.com/">otx.alienvault.com</a> if you need a key.
+              </span>
+            </li>
+            <li>
+              <code>If unset</code>
+              <span>
+                Enrichment is skipped entirely: no calls to OTX, no API usage, and detect jobs still finish
+                successfully. Fork PRs and repos without the secret behave the same way.
+              </span>
+            </li>
+            <li>
+              <code>Best-effort</code>
+              <span>
+                The enrichment step does not fail the job on third-party errors; rate limits and budgets surface as
+                warnings or partial results in the report model. See the pipeline description in
+                <a href="https://github.com/coldstep-io/coldstep/blob/main/scripts/coldstep_detect_report/README.md"
+                  >detect report tooling</a>
+                for environment variables and schema details.
+              </span>
             </li>
           </ul>
         </section>


### PR DESCRIPTION
Bumps consumer pin to **v0.1.5** (README, QUICK_START, CONTRIBUTING, demo workflows, pin checker), documents optional **OTX_API_KEY** in README/QUICK_START and optional OTX outbound in **SECURITY.md**, and ships **triage-first** Job Summary (Go digest + Tier-1 detect report triage block) with **website** copy updates.

**After merge:** tag \0.1.5\ on the merge commit and publish the GitHub Release.

**Note:** \AGENTS.md\ is gitignored locally; maintainers can update the pin with \git add -f AGENTS.md\ in a follow-up if desired.