### PR TITLE
release: v0.1.6 documentation and pin alignment

### DIFF
--- a/.github/workflows/coldstep-demo-detect.yml
+++ b/.github/workflows/coldstep-demo-detect.yml
@@ -1,7 +1,7 @@
 # Simplified detect-mode demo (observe-only) with previous-run JSONL diff (`COLDSTEP_DIFF_PREV_RUN`).
 # One real probe per detect capability (same probes as `coldstep-demo.yml` detect-mode). For the full integration
 # workflow including enforce, see `.github/workflows/coldstep-demo.yml`.
-# Consumer pin (elsewhere): `uses: coldstep-io/coldstep@v0.1.5`
+# Consumer pin (elsewhere): `uses: coldstep-io/coldstep@v0.1.6`
 #
 # Agent binary: download `coldstep-linux-amd64` from the repo GitHub Release for `COLDSTEP_AGENT_VERSION`
 # (published by `supply-chain-attest.yml` on version tags). The action uses `release-path` and does not compile.
@@ -18,7 +18,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  COLDSTEP_AGENT_VERSION: v0.1.5
+  COLDSTEP_AGENT_VERSION: v0.1.6
 
 jobs:
   demo:

--- a/.github/workflows/coldstep-demo-enforce.yml
+++ b/.github/workflows/coldstep-demo-enforce.yml
@@ -1,6 +1,6 @@
 # Simplified enforce-mode demo (cgroup egress allowlist). Previous-run JSONL diff uses the same opt-in env as detect
 # (`COLDSTEP_DIFF_PREV_RUN`). Control matrix matches `coldstep-demo.yml` prevent-mode (nmap/nc allow, curl/nc deny).
-# Consumer pin (elsewhere): `uses: coldstep-io/coldstep@v0.1.5`
+# Consumer pin (elsewhere): `uses: coldstep-io/coldstep@v0.1.6`
 #
 # Agent binary: same GitHub Release download + `release-path` as `coldstep-demo-detect.yml`.
 
@@ -16,7 +16,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  COLDSTEP_AGENT_VERSION: v0.1.5
+  COLDSTEP_AGENT_VERSION: v0.1.6
 
 jobs:
   demo:

--- a/.github/workflows/coldstep-demo-marketplace.yml
+++ b/.github/workflows/coldstep-demo-marketplace.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: coldstep-io/coldstep@v0.1.5
+      - uses: coldstep-io/coldstep@v0.1.6
         with:
           mode: detect
           feature-gates: proc_tree=1,tls_sni=1,fs_events=1

--- a/.github/workflows/coldstep-demo.yml
+++ b/.github/workflows/coldstep-demo.yml
@@ -10,7 +10,7 @@
 name: coldstep-demo
 
 # Same-repo demo: use `uses: ./` after checkout so the job always loads repo-root `action.yml`
-# from the workflow ref. Published tags (e.g. v0.1.5) must also ship `action.yml` at the root
+# from the workflow ref. Published tags (e.g. v0.1.6) must also ship `action.yml` at the root
 # for `uses: coldstep-io/coldstep@TAG` to work elsewhere; see coldstep-ci-runner.yml for the same pattern.
 
 on:
@@ -23,7 +23,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  COLDSTEP_AGENT_VERSION: v0.1.5
+  COLDSTEP_AGENT_VERSION: v0.1.6
 
 # Default to least-privilege; the detect-mode job overrides with
 # `permissions: { actions: read, contents: read }` when previous-run baseline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,77 @@
+# Changelog
+
+Notable changes to Coldstep follow this file. Releases are tagged as `v*.*.*` ([compare on GitHub](https://github.com/coldstep-io/coldstep/compare)).
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+Nothing listed yet — add changes here before tagging the next release, then roll them under a dated version heading.
+
+---
+
+## [0.1.6] — 2026-04-20
+
+Re-dock the **recommended consumer tag** and in-repo demo **`COLDSTEP_AGENT_VERSION`** to **`v0.1.6`**. No application or eBPF changes in this bump—documentation, website, workflows, **`AGENTS.md`** pin, and the workflow pin checker only.
+
+### Why publish **v0.1.6**
+
+GitHub Releases can be **immutable**. If **`v0.1.5`** was finalized before **`supply-chain-attest`** uploaded **`coldstep-linux-amd64`**, later upload attempts could return **HTTP 422**. **`main`** now continues the workflow in that situation so attestations and downloadable artifacts still publish (change shipped after **PR #47**). Pin **`coldstep-io/coldstep@v0.1.6`** (or a newer tag) for new installs, then **create tag `v0.1.6`** and run **`supply-chain-attest`** (tag push or **`workflow_dispatch`**) so the Release and binary line up.
+
+### Changed
+
+- README, QUICK_START, CONTRIBUTING, website, **`AGENTS.md`**, **`scripts/check_workflow_action_pins.py`**, **`coldstep-demo-marketplace.yml`**, and demo workflows (**`COLDSTEP_AGENT_VERSION`**) use **`v0.1.6`**.
+
+---
+
+## [0.1.5] — 2026-04-19
+
+Detect-mode reporting matured with a two-tier pipeline (Tier-1 GitHub Actions step summary + Tier-2 offline HTML artifact), AlienVault OTX enrichment with incremental schema upgrades, tighter security hardening across helpers, and sustained eBPF/agent/CI reliability work. Documentation and consumer pins consistently reference **`coldstep-io/coldstep@v0.1.5`**.
+
+### Added
+
+- **Detect-mode report pipeline (PR #29):** `report-model.json` builder (`build_report_model.py`), Tier-1 GFM/Mermaid step summary (`render_step_summary.py`), Tier-2 self-contained **`report.html`** (`render_html_report.py`, templates, pinned Plot/d3 vendors with SRI); designer-handoff README under `scripts/coldstep_detect_report/README.md`.
+- **OTX threat-intel enrichment (PR #30, extended in PR #43):** `scripts/coldstep_otx/` — client, verdicts (`malicious` / `clean` / `unidentified`), confidence tiers (schema **v2.1**), integration in `coldstep-demo-detect` with optional `secrets.OTX_API_KEY` and skip when unset.
+- **Reverse DNS enrichment:** `scripts/coldstep_dns/` (`rdns.py`, `enrich_rdns.py`) wired into the detect report flow.
+- **Job Summary / digest — triage-first output:** `internal/report/digest.go` and summary rendering emphasize IR-style triage (ribbon, collapsed technical detail, hot egress) for faster review; aligned Python/GFM tier (release train).
+- **CI coverage:** Multi-distro matrix (ubuntu LTS x64 + arm), `coldstep-ci-nightly` (govulncheck, shuffle, optional race), **`coldstep-deep-debug`** + `Dockerfile.deep-debug` / helper scripts for staged deep triage.
+- **Workflow guardrails:** `scripts/check_workflow_action_pins.py` + CI hook; shell markers test for JSONL diff summaries.
+- **`supply-chain-attest`:** Continued publishing of **`coldstep-linux-amd64`** on matching tags (consumer demos align `COLDSTEP_AGENT_VERSION`).
+- **`coldstep-demo-marketplace.yml`:** Minimal Marketplace-style consumer workflow.
+
+### Changed
+
+- **Consumer pins:** README, QUICK_START, CONTRIBUTING, website, and demo workflows pin **`@v0.1.5`** (replacing **`@v0.1.4`** guidance).
+- **Composite action (`action.yml`, `src/main.ts`, `src/post.ts`):** Fail-fast readiness polling with extended bounded waits for BPF verifier latency; clearer stderr capture; ordering fixes so **`ok:true`** reflects syscall trace attachment in enforce mode; reduced noisy IPv6 probe step in fail-on-error path.
+- **Agent (`internal/agent/*`):** Readiness/status file semantics (**0644**), syscall trace vs optional BPF ordering, ringbuf/exec lifecycle cleanup, policy allowlist merge behavior with DNS-derived literals, richer ring-buffer drop telemetry for digests.
+- **Policy / enforce:** IPv4-centric allowlist compilation; **compile-time IPv6 cgroup hooks for enforce mode removed** — **breaking** for workflows that relied on IPv6 enforcement on GitHub-hosted runners (IPv4-only v1 scope documented).
+- **eBPF (`bpf/`, generated loaders):** UDP `sendmsg` observability paths; multi-iovec counters; syscall coverage and visibility counters; LPM trie for CIDR allowlists (vs HASH-only literals); portability and **Ubuntu 22.04 verifier** fixes (bounded `probe_read_user` paths, single-read msghdr/sockaddr patterns); cgroup attach helpers; ABI `_Static_assert` / wire-size pairing with Go.
+- **Telemetry:** Query-sensitive URI sanitization (`sanitize_request_uri`), Slack token shape redaction, Copilot autofix alignment in tests.
+- **JSONL traffic diff (`ci_coldstep_jsonl_traffic_diff.py`):** Stricter decode health, configurable strictness via workflow inputs, baseline resolution improvements for PRs (**`GITHUB_HEAD_REF`**).
+- **Dependencies:** `esbuild` / `typescript` bumps; `golang.org/x/sync`; `actions/cache@v5`, `actions/upload-pages-artifact@v5` where applicable; `LICENSE.md` inventory touch-up.
+- **`dist/`:** Regenerated bundles for composite `main`/`post` (large diff; review source in `src/`).
+
+### Fixed
+
+- **Security (path & output):** Sanitized `COLDSTEP_REPORT_MODEL_IN` in rDNS enricher and related helpers (PR #37–#38); broad Snyk/CodeQL-driven fixes across detect/diff helpers, HTML/XSS-oriented hardening in report rendering, `.snyk` policy for vendored **dist** noise (PR #36, #40).
+- **Code review remediation (PR #42):** Escaping/HTML generation fixes (including `{{ GENERATED_AT }}` handling), sanitizer parity, bounded job-related timeouts.
+- **CI / workflows:** JSONL baseline lookup fallback (`coldstep-ci.yml` + `main`); Tier-1 detect summary ordering after baseline diff (#44); demo install probes aligned with runtime preflight; race fixes in prevent-mode tests and BPF wait paths.
+- **BPF verifier / probes:** Constant-size userspace reads for TLS/DNS/UDP paths across 5.15–6.x kernels used on GitHub runners.
+
+### Security
+
+- Documented **GitHub Actions threat model and consumer mitigations** in **`SECURITY.md`** (including outbound OTX when API keys are configured).
+- Reduced sensitive material in telemetry URIs while preserving triage-relevant host/path signal.
+
+---
+
+## [0.1.4] — 2026-04-14
+
+Baseline for comparison with **0.1.5**. Highlights included publishing **`coldstep-linux-amd64`** from release-tag workflows, pinning consumer docs to **`@v0.1.4`**, and demo workflows consuming the prebuilt GitHub Release binary where applicable.
+
+See [comparison **v0.1.4…v0.1.5**](https://github.com/coldstep-io/coldstep/compare/v0.1.4...v0.1.5).
+
+[Unreleased]: https://github.com/coldstep-io/coldstep/compare/v0.1.6...HEAD
+[0.1.6]: https://github.com/coldstep-io/coldstep/releases/tag/v0.1.6
+[0.1.5]: https://github.com/coldstep-io/coldstep/releases/tag/v0.1.5
+[0.1.4]: https://github.com/coldstep-io/coldstep/releases/tag/v0.1.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Thanks for helping improve coldstep. This document is the maintainer-facing coun
 2. **Go** — CI uses **`setup-go`** with **`go-version: 1.24.x`**, matching **`go.mod`**. After Linux prep, `gofmt`, `go vet ./...`, and `go test ./...` should pass (see CI for integration tags).
 3. **TypeScript** — if you edit `src/main.ts` or `src/post.ts`, run `npm run typecheck` and **`npm run build`** (**`ncc`** writes **`dist/main`** and **`dist/post`**) so committed **`dist/`** stays in sync with sources.
 4. **Docs** — if you change workflow pins or action inputs, update **README**, **QUICK_START**, and **`action.yml`** descriptions so they stay aligned.
-5. **Pinning for consumers** — downstream workflows should use a **release tag** (for example **`coldstep-io/coldstep@v0.1.5`**), not **`@main`**, unless they intentionally track head.
+5. **Pinning for consumers** — downstream workflows should use a **release tag** (for example **`coldstep-io/coldstep@v0.1.6`**), not **`@main`**, unless they intentionally track head.
 
 ## Security-sensitive areas
 

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -1,6 +1,6 @@
 # Coldstep Quick Start
 
-**v1:** the composite agent is validated and supported on **`runs-on: ubuntu-latest`** only. Pin the published action at **`coldstep-io/coldstep@v0.1.5`** (or a newer tag you publish). **Repository changes** are validated via **GitHub Actions** (open a PR or use **`workflow_dispatch`** on **`coldstep-ci`**, **`coldstep-demo`**, **`coldstep-demo-detect`**, or **`coldstep-demo-enforce`**); there is no maintained local build path for the Linux agent.
+**v1:** the composite agent is validated and supported on **`runs-on: ubuntu-latest`** only. Pin the published action at **`coldstep-io/coldstep@v0.1.6`** (or a newer tag you publish). **Repository changes** are validated via **GitHub Actions** (open a PR or use **`workflow_dispatch`** on **`coldstep-ci`**, **`coldstep-demo`**, **`coldstep-demo-detect`**, or **`coldstep-demo-enforce`**); there is no maintained local build path for the Linux agent.
 
 ## TL;DR (copy/paste)
 
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: coldstep-io/coldstep@v0.1.5
+      - uses: coldstep-io/coldstep@v0.1.6
 ```
 
 That is enough to get:
@@ -35,8 +35,8 @@ That is enough to get:
 
 ## Versioning
 
-- Prefer **`coldstep-io/coldstep@v0.1.5`** (or a **newer tag** you publish, for example **`v0.2.0`**). **`@main`** tracks the default branch and can change without notice.
-- **`v0.1.0`** is not usable with `uses: coldstep-io/coldstep@v0.1.0` (that tag lacks repo-root **`action.yml`**); use **`v0.1.5`** or later.
+- Prefer **`coldstep-io/coldstep@v0.1.6`** (or a **newer tag** you publish, for example **`v0.2.0`**). **`@main`** tracks the default branch and can change without notice.
+- **`v0.1.0`** is not usable with `uses: coldstep-io/coldstep@v0.1.0` (that tag lacks repo-root **`action.yml`**); use **`v0.1.6`** or later.
 
 **Example workflows in this repo** (all use `uses: ./` and are triggered with **`workflow_dispatch`**): **[`coldstep-demo-detect.yml`](.github/workflows/coldstep-demo-detect.yml)** (minimal detect), **[`coldstep-demo-enforce.yml`](.github/workflows/coldstep-demo-enforce.yml)** (minimal enforce), and **[`coldstep-demo.yml`](.github/workflows/coldstep-demo.yml)** (full integration / drift).
 
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: coldstep-io/coldstep@v0.1.5
+      - uses: coldstep-io/coldstep@v0.1.6
         with:
           feature-gates: proc_tree=1,tls_sni=1,fs_events=1
           report-job-summary: true
@@ -73,10 +73,10 @@ jobs:
 
 ## Enforce mode (optional)
 
-Detect mode is default. For enforce behavior, reuse the same **`env`** / **`checkout`** / **`coldstep-io/coldstep@v0.1.5`** pin as above, then configure `with:`:
+Detect mode is default. For enforce behavior, reuse the same **`env`** / **`checkout`** / **`coldstep-io/coldstep@v0.1.6`** pin as above, then configure `with:`:
 
 ```yaml
-- uses: coldstep-io/coldstep@v0.1.5
+- uses: coldstep-io/coldstep@v0.1.6
   with:
     mode: enforce
     allowed-domains: google.com,github.com

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **coldstep** is a GitHub Action plus a small Linux **eBPF** agent for **GitHub-hosted Ubuntu** runners. It observes process and network activity in **detect** mode (default) and can optionally **enforce** an egress allowlist. Telemetry is written to **JSONL** in the workspace and summarized as **Markdown** (merged into the job **Summary** when enabled).
 
-**Pin workflows to** **`coldstep-io/coldstep@v0.1.5`** (or a newer tag). Listing: [**Coldstep eBPF CI Egress** on GitHub Marketplace](https://github.com/marketplace/actions/coldstep-ebpf-ci-egress).
+**Pin workflows to** **`coldstep-io/coldstep@v0.1.6`** (or a newer tag). Listing: [**Coldstep eBPF CI Egress** on GitHub Marketplace](https://github.com/marketplace/actions/coldstep-ebpf-ci-egress).
 
 [![coldstep-ci](https://github.com/coldstep-io/coldstep/actions/workflows/coldstep-ci.yml/badge.svg)](https://github.com/coldstep-io/coldstep/actions/workflows/coldstep-ci.yml) [![coldstep-demo](https://github.com/coldstep-io/coldstep/actions/workflows/coldstep-demo.yml/badge.svg)](https://github.com/coldstep-io/coldstep/actions/workflows/coldstep-demo.yml)
 
@@ -12,7 +12,7 @@
 
 ## Add it to a workflow
 
-**v1:** use **`runs-on: ubuntu-latest`** (see **Requirements**). Pin the published composite action at **`coldstep-io/coldstep@v0.1.5`** (or a newer tag you publish), not **`@main`**.
+**v1:** use **`runs-on: ubuntu-latest`** (see **Requirements**). Pin the published composite action at **`coldstep-io/coldstep@v0.1.6`** (or a newer tag you publish), not **`@main`**.
 
 ```yaml
 env:
@@ -24,14 +24,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: coldstep-io/coldstep@v0.1.5
+      - uses: coldstep-io/coldstep@v0.1.6
         with:
           fail-on-error: true
           log-level: info
       - run: echo "your build steps"
 ```
 
-**`coldstep-demo`** (`workflow_dispatch`) runs the in-repo action with **`uses: ./`** (same pattern as [`.github/workflows/coldstep-ci-runner.yml`](.github/workflows/coldstep-ci-runner.yml)). Downstream repos should pin **`coldstep-io/coldstep@v0.1.5`** (or a newer tag).
+**`coldstep-demo`** (`workflow_dispatch`) runs the in-repo action with **`uses: ./`** (same pattern as [`.github/workflows/coldstep-ci-runner.yml`](.github/workflows/coldstep-ci-runner.yml)). Downstream repos should pin **`coldstep-io/coldstep@v0.1.6`** (or a newer tag).
 
 ---
 

--- a/scripts/check_workflow_action_pins.py
+++ b/scripts/check_workflow_action_pins.py
@@ -15,7 +15,7 @@ import sys
 from pathlib import Path
 
 # Bump when publishing a new consumer-facing tag (same as README marketplace pin).
-MARKETPLACE_COLDSTEP_TAG = "v0.1.5"
+MARKETPLACE_COLDSTEP_TAG = "v0.1.6"
 
 ROOT = Path(__file__).resolve().parent.parent
 WORKFLOWS = ROOT / ".github" / "workflows"

--- a/website/index.html
+++ b/website/index.html
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: coldstep-io/coldstep@v0.1.5
+      - uses: coldstep-io/coldstep@v0.1.6
 </code></pre>
           </div>
         </section>
@@ -129,7 +129,7 @@ jobs:
         <section class="section section--tight-top" aria-labelledby="modes-heading">
           <h2 id="modes-heading">Two modes, one agent</h2>
           <p class="section-intro">
-            Pin a release tag in workflows (for example <code>coldstep-io/coldstep@v0.1.5</code>) instead of tracking
+            Pin a release tag in workflows (for example <code>coldstep-io/coldstep@v0.1.6</code>) instead of tracking
             <code>@main</code> unless you intentionally want churn.
           </p>
           <div class="modes">


### PR DESCRIPTION
## Summary

Patch release (**no code/agent/BPF changes**) that moves the documented consumer pin and in-repo demo \COLDSTEP_AGENT_VERSION\ from **v0.1.5** to **v0.1.6**.

## Why v0.1.6

GitHub Releases may be **immutable**. If **v0.1.5** was finalized before **supply-chain-attest** uploaded \coldstep-linux-amd64\, CI could hit HTTP 422 on upload. **main** already tolerates that failure so attestations still succeed (merged after PR #47). Publishing **v0.1.6** gives consumers a fresh tag whose Release pipeline should attach the Linux binary under the current workflow.

## Changed files

- \README.md\, \QUICK_START.md\, \CONTRIBUTING.md\, \website/index.html\
- Demo workflows: \coldstep-demo*.yml\ (\COLDSTEP_AGENT_VERSION\ + comments)
- \scripts/check_workflow_action_pins.py\ canonical tag
- \CHANGELOG.md\ (new; includes **0.1.6** + historical **0.1.5** section)

## After merge

1. Tag **v0.1.6** on **main** and push tags (or create the GitHub Release from the tag).
2. Confirm **supply-chain-attest** completes (tag push triggers it; use **workflow_dispatch** on **main** if needed).
3. **coldstep-pages** will refresh the site from **main** on its trigger.

---

**Note:** Local-only gitignored preference files that mention the composite pin should be updated manually to **v0.1.6** if you keep them.