### PR TITLE
release: v0.1.7 pre-release (pin alignment)

### DIFF
--- a/.github/workflows/coldstep-demo-detect.yml
+++ b/.github/workflows/coldstep-demo-detect.yml
@@ -1,7 +1,7 @@
 # Simplified detect-mode demo (observe-only) with previous-run JSONL diff (`COLDSTEP_DIFF_PREV_RUN`).
 # One real probe per detect capability (same probes as `coldstep-demo.yml` detect-mode). For the full integration
 # workflow including enforce, see `.github/workflows/coldstep-demo.yml`.
-# Consumer pin (elsewhere): `uses: coldstep-io/coldstep@v0.1.6`
+# Consumer pin (elsewhere): `uses: coldstep-io/coldstep@v0.1.7`
 #
 # Agent binary: download `coldstep-linux-amd64` from the repo GitHub Release for `COLDSTEP_AGENT_VERSION`
 # (published by `supply-chain-attest.yml` on version tags). The action uses `release-path` and does not compile.
@@ -18,7 +18,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  COLDSTEP_AGENT_VERSION: v0.1.6
+  COLDSTEP_AGENT_VERSION: v0.1.7
 
 jobs:
   demo:

--- a/.github/workflows/coldstep-demo-enforce.yml
+++ b/.github/workflows/coldstep-demo-enforce.yml
@@ -1,6 +1,6 @@
 # Simplified enforce-mode demo (cgroup egress allowlist). Previous-run JSONL diff uses the same opt-in env as detect
 # (`COLDSTEP_DIFF_PREV_RUN`). Control matrix matches `coldstep-demo.yml` prevent-mode (nmap/nc allow, curl/nc deny).
-# Consumer pin (elsewhere): `uses: coldstep-io/coldstep@v0.1.6`
+# Consumer pin (elsewhere): `uses: coldstep-io/coldstep@v0.1.7`
 #
 # Agent binary: same GitHub Release download + `release-path` as `coldstep-demo-detect.yml`.
 
@@ -16,7 +16,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  COLDSTEP_AGENT_VERSION: v0.1.6
+  COLDSTEP_AGENT_VERSION: v0.1.7
 
 jobs:
   demo:

--- a/.github/workflows/coldstep-demo-marketplace.yml
+++ b/.github/workflows/coldstep-demo-marketplace.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: coldstep-io/coldstep@v0.1.6
+      - uses: coldstep-io/coldstep@v0.1.7
         with:
           mode: detect
           feature-gates: proc_tree=1,tls_sni=1,fs_events=1

--- a/.github/workflows/coldstep-demo.yml
+++ b/.github/workflows/coldstep-demo.yml
@@ -10,7 +10,7 @@
 name: coldstep-demo
 
 # Same-repo demo: use `uses: ./` after checkout so the job always loads repo-root `action.yml`
-# from the workflow ref. Published tags (e.g. v0.1.6) must also ship `action.yml` at the root
+# from the workflow ref. Published tags (e.g. v0.1.7) must also ship `action.yml` at the root
 # for `uses: coldstep-io/coldstep@TAG` to work elsewhere; see coldstep-ci-runner.yml for the same pattern.
 
 on:
@@ -23,7 +23,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  COLDSTEP_AGENT_VERSION: v0.1.6
+  COLDSTEP_AGENT_VERSION: v0.1.7
 
 # Default to least-privilege; the detect-mode job overrides with
 # `permissions: { actions: read, contents: read }` when previous-run baseline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,21 @@ Nothing listed yet — add changes here before tagging the next release, then ro
 
 ---
 
+## [0.1.7] — 2026-04-20
+
+**Pre-release** — pin alignment only (no Go agent, BPF, or composite TypeScript changes in this PR). Documentation, website, **`scripts/check_workflow_action_pins.py`**, Marketplace demo, and **`COLDSTEP_AGENT_VERSION`** on **`coldstep-demo*`** workflows now target **`v0.1.7`**.
+
+### Publishing this pre-release
+
+1. Merge the release PR to **`main`**.
+2. **`git tag -s v0.1.7 -m "…"`** and **`git push origin v0.1.7`** — triggers **`supply-chain-attest`** (binary + SBOM + attestations).
+3. **GitHub → Releases → v0.1.7 → Edit** — enable **Set as pre-release** until soak tests pass; attach notes from **`CHANGELOG`**. Clear pre-release when promoting to **Latest**.
+
+---
+
 ## [0.1.6] — 2026-04-20
 
-Re-dock the **recommended consumer tag** and in-repo demo **`COLDSTEP_AGENT_VERSION`** to **`v0.1.6`**. No application or eBPF changes in this bump—documentation, website, workflows, **`AGENTS.md`** pin, and the workflow pin checker only.
+Re-dock the **recommended consumer tag** and in-repo demo **`COLDSTEP_AGENT_VERSION`** to **`v0.1.6`**. No application or eBPF changes in this bump—documentation, website, workflows, and the workflow pin checker only.
 
 ### Why publish **v0.1.6**
 
@@ -20,7 +32,7 @@ GitHub Releases can be **immutable**. If **`v0.1.5`** was finalized before **`su
 
 ### Changed
 
-- README, QUICK_START, CONTRIBUTING, website, **`AGENTS.md`**, **`scripts/check_workflow_action_pins.py`**, **`coldstep-demo-marketplace.yml`**, and demo workflows (**`COLDSTEP_AGENT_VERSION`**) use **`v0.1.6`**.
+- README, QUICK_START, CONTRIBUTING, website, **`scripts/check_workflow_action_pins.py`**, **`coldstep-demo-marketplace.yml`**, and demo workflows (**`COLDSTEP_AGENT_VERSION`**) use **`v0.1.6`**.
 
 ---
 
@@ -71,7 +83,8 @@ Baseline for comparison with **0.1.5**. Highlights included publishing **`coldst
 
 See [comparison **v0.1.4…v0.1.5**](https://github.com/coldstep-io/coldstep/compare/v0.1.4...v0.1.5).
 
-[Unreleased]: https://github.com/coldstep-io/coldstep/compare/v0.1.6...HEAD
+[Unreleased]: https://github.com/coldstep-io/coldstep/compare/v0.1.7...HEAD
+[0.1.7]: https://github.com/coldstep-io/coldstep/releases/tag/v0.1.7
 [0.1.6]: https://github.com/coldstep-io/coldstep/releases/tag/v0.1.6
 [0.1.5]: https://github.com/coldstep-io/coldstep/releases/tag/v0.1.5
 [0.1.4]: https://github.com/coldstep-io/coldstep/releases/tag/v0.1.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Thanks for helping improve coldstep. This document is the maintainer-facing coun
 2. **Go** — CI uses **`setup-go`** with **`go-version: 1.24.x`**, matching **`go.mod`**. After Linux prep, `gofmt`, `go vet ./...`, and `go test ./...` should pass (see CI for integration tags).
 3. **TypeScript** — if you edit `src/main.ts` or `src/post.ts`, run `npm run typecheck` and **`npm run build`** (**`ncc`** writes **`dist/main`** and **`dist/post`**) so committed **`dist/`** stays in sync with sources.
 4. **Docs** — if you change workflow pins or action inputs, update **README**, **QUICK_START**, and **`action.yml`** descriptions so they stay aligned.
-5. **Pinning for consumers** — downstream workflows should use a **release tag** (for example **`coldstep-io/coldstep@v0.1.6`**), not **`@main`**, unless they intentionally track head.
+5. **Pinning for consumers** — downstream workflows should use a **release tag** (for example **`coldstep-io/coldstep@v0.1.7`**), not **`@main`**, unless they intentionally track head.
 
 ## Security-sensitive areas
 

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -1,6 +1,6 @@
 # Coldstep Quick Start
 
-**v1:** the composite agent is validated and supported on **`runs-on: ubuntu-latest`** only. Pin the published action at **`coldstep-io/coldstep@v0.1.6`** (or a newer tag you publish). **Repository changes** are validated via **GitHub Actions** (open a PR or use **`workflow_dispatch`** on **`coldstep-ci`**, **`coldstep-demo`**, **`coldstep-demo-detect`**, or **`coldstep-demo-enforce`**); there is no maintained local build path for the Linux agent.
+**v1:** the composite agent is validated and supported on **`runs-on: ubuntu-latest`** only. Pin the published action at **`coldstep-io/coldstep@v0.1.7`** (or a newer tag you publish). **Repository changes** are validated via **GitHub Actions** (open a PR or use **`workflow_dispatch`** on **`coldstep-ci`**, **`coldstep-demo`**, **`coldstep-demo-detect`**, or **`coldstep-demo-enforce`**); there is no maintained local build path for the Linux agent.
 
 ## TL;DR (copy/paste)
 
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: coldstep-io/coldstep@v0.1.6
+      - uses: coldstep-io/coldstep@v0.1.7
 ```
 
 That is enough to get:
@@ -35,8 +35,8 @@ That is enough to get:
 
 ## Versioning
 
-- Prefer **`coldstep-io/coldstep@v0.1.6`** (or a **newer tag** you publish, for example **`v0.2.0`**). **`@main`** tracks the default branch and can change without notice.
-- **`v0.1.0`** is not usable with `uses: coldstep-io/coldstep@v0.1.0` (that tag lacks repo-root **`action.yml`**); use **`v0.1.6`** or later.
+- Prefer **`coldstep-io/coldstep@v0.1.7`** (or a **newer tag** you publish, for example **`v0.2.0`**). **`@main`** tracks the default branch and can change without notice.
+- **`v0.1.0`** is not usable with `uses: coldstep-io/coldstep@v0.1.0` (that tag lacks repo-root **`action.yml`**); use **`v0.1.7`** or later.
 
 **Example workflows in this repo** (all use `uses: ./` and are triggered with **`workflow_dispatch`**): **[`coldstep-demo-detect.yml`](.github/workflows/coldstep-demo-detect.yml)** (minimal detect), **[`coldstep-demo-enforce.yml`](.github/workflows/coldstep-demo-enforce.yml)** (minimal enforce), and **[`coldstep-demo.yml`](.github/workflows/coldstep-demo.yml)** (full integration / drift).
 
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: coldstep-io/coldstep@v0.1.6
+      - uses: coldstep-io/coldstep@v0.1.7
         with:
           feature-gates: proc_tree=1,tls_sni=1,fs_events=1
           report-job-summary: true
@@ -73,10 +73,10 @@ jobs:
 
 ## Enforce mode (optional)
 
-Detect mode is default. For enforce behavior, reuse the same **`env`** / **`checkout`** / **`coldstep-io/coldstep@v0.1.6`** pin as above, then configure `with:`:
+Detect mode is default. For enforce behavior, reuse the same **`env`** / **`checkout`** / **`coldstep-io/coldstep@v0.1.7`** pin as above, then configure `with:`:
 
 ```yaml
-- uses: coldstep-io/coldstep@v0.1.6
+- uses: coldstep-io/coldstep@v0.1.7
   with:
     mode: enforce
     allowed-domains: google.com,github.com

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **coldstep** is a GitHub Action plus a small Linux **eBPF** agent for **GitHub-hosted Ubuntu** runners. It observes process and network activity in **detect** mode (default) and can optionally **enforce** an egress allowlist. Telemetry is written to **JSONL** in the workspace and summarized as **Markdown** (merged into the job **Summary** when enabled).
 
-**Pin workflows to** **`coldstep-io/coldstep@v0.1.6`** (or a newer tag). Listing: [**Coldstep eBPF CI Egress** on GitHub Marketplace](https://github.com/marketplace/actions/coldstep-ebpf-ci-egress).
+**Pin workflows to** **`coldstep-io/coldstep@v0.1.7`** (or a newer tag). Listing: [**Coldstep eBPF CI Egress** on GitHub Marketplace](https://github.com/marketplace/actions/coldstep-ebpf-ci-egress).
 
 [![coldstep-ci](https://github.com/coldstep-io/coldstep/actions/workflows/coldstep-ci.yml/badge.svg)](https://github.com/coldstep-io/coldstep/actions/workflows/coldstep-ci.yml) [![coldstep-demo](https://github.com/coldstep-io/coldstep/actions/workflows/coldstep-demo.yml/badge.svg)](https://github.com/coldstep-io/coldstep/actions/workflows/coldstep-demo.yml)
 
@@ -12,7 +12,7 @@
 
 ## Add it to a workflow
 
-**v1:** use **`runs-on: ubuntu-latest`** (see **Requirements**). Pin the published composite action at **`coldstep-io/coldstep@v0.1.6`** (or a newer tag you publish), not **`@main`**.
+**v1:** use **`runs-on: ubuntu-latest`** (see **Requirements**). Pin the published composite action at **`coldstep-io/coldstep@v0.1.7`** (or a newer tag you publish), not **`@main`**.
 
 ```yaml
 env:
@@ -24,14 +24,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: coldstep-io/coldstep@v0.1.6
+      - uses: coldstep-io/coldstep@v0.1.7
         with:
           fail-on-error: true
           log-level: info
       - run: echo "your build steps"
 ```
 
-**`coldstep-demo`** (`workflow_dispatch`) runs the in-repo action with **`uses: ./`** (same pattern as [`.github/workflows/coldstep-ci-runner.yml`](.github/workflows/coldstep-ci-runner.yml)). Downstream repos should pin **`coldstep-io/coldstep@v0.1.6`** (or a newer tag).
+**`coldstep-demo`** (`workflow_dispatch`) runs the in-repo action with **`uses: ./`** (same pattern as [`.github/workflows/coldstep-ci-runner.yml`](.github/workflows/coldstep-ci-runner.yml)). Downstream repos should pin **`coldstep-io/coldstep@v0.1.7`** (or a newer tag).
 
 ---
 

--- a/scripts/check_workflow_action_pins.py
+++ b/scripts/check_workflow_action_pins.py
@@ -15,7 +15,7 @@ import sys
 from pathlib import Path
 
 # Bump when publishing a new consumer-facing tag (same as README marketplace pin).
-MARKETPLACE_COLDSTEP_TAG = "v0.1.6"
+MARKETPLACE_COLDSTEP_TAG = "v0.1.7"
 
 ROOT = Path(__file__).resolve().parent.parent
 WORKFLOWS = ROOT / ".github" / "workflows"

--- a/website/index.html
+++ b/website/index.html
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: coldstep-io/coldstep@v0.1.6
+      - uses: coldstep-io/coldstep@v0.1.7
 </code></pre>
           </div>
         </section>
@@ -129,7 +129,7 @@ jobs:
         <section class="section section--tight-top" aria-labelledby="modes-heading">
           <h2 id="modes-heading">Two modes, one agent</h2>
           <p class="section-intro">
-            Pin a release tag in workflows (for example <code>coldstep-io/coldstep@v0.1.6</code>) instead of tracking
+            Pin a release tag in workflows (for example <code>coldstep-io/coldstep@v0.1.7</code>) instead of tracking
             <code>@main</code> unless you intentionally want churn.
           </p>
           <div class="modes">


### PR DESCRIPTION
## Summary

**Pre-release** train: bump consumer pins and demo \COLDSTEP_AGENT_VERSION\ from **v0.1.6** → **v0.1.7** (README, QUICK_START, CONTRIBUTING, website, workflows, pin guard). No \src/\, BPF, or Go agent logic changes.

## CHANGELOG

- New **[0.1.7]** section with **pre-release** publishing steps (merge → signed tag → \supply-chain-attest\ → GitHub Release **pre-release** checkbox).

## Verification (local)

- \go build ./...\
- \
pm run typecheck\ / \
pm run build\ — **no \dist/\ diff** (no TypeScript edits)
- \python scripts/check_workflow_action_pins.py\ exit 0
- \python -m unittest scripts.test_check_workflow_action_pins -v\

## After merge

1. **Tag** \0.1.7\ on merge commit and \git push origin v0.1.7\.
2. Confirm **supply-chain-attest** run is green; **coldstep-linux-amd64** on Release when upload succeeds.
3. **GitHub Release**: enable **Set as pre-release** until soak; promote to Latest when ready.

Second-brain draft (local \knowledge/\): evergreen hub **versioned-releases-and-prerelease** + report **2026-04-20-pre-release-v0.1.7-process**.