### PR TITLE
Detect report: visual triage strip (HTML) + Tier-1 Visual scan tip

### DIFF
--- a/scripts/coldstep_detect_report/README.md
+++ b/scripts/coldstep_detect_report/README.md
@@ -19,6 +19,8 @@ Two-tier report driven by a single `report-model.json` (schema **v2.1** — stri
 | **Tier 1** — `$GITHUB_STEP_SUMMARY` (short BLUF Markdown, no Mermaid) | `render_step_summary.py` | Workflow run page, automatically | Engineering / agent |
 | **Tier 2** — `report.html` (Observable Plot + d3) | `render_html_report.py` | Run page → Artifacts → download ZIP → unzip → open in a browser | **Frontend designer** |
 
+At the top of Tier-2 HTML, **What to look at first** is a three-card triage strip (capabilities → baseline diff → OTX) with green / amber / red borders so the scan path matches the Job Summary pulses above the charts.
+
 > GitHub does **not** preview HTML artifacts inline. The Tier-2 file ships as a downloadable artifact, not as a clickable surface inside the run UI. The Tier-1 summary is the always-visible counterpart that needs no clicks. If we ever want a clickable rich URL, see `knowledge/wiki/gha-reports-formats.md` (local) for the GitHub-Pages route — that's a deferred follow-up, not a v1 concern.
 
 ## Data contract (`report-model.json`, schema v2.1)

--- a/scripts/coldstep_detect_report/render_step_summary.py
+++ b/scripts/coldstep_detect_report/render_step_summary.py
@@ -212,8 +212,15 @@ def _triage_alert_md(model: dict) -> str | None:
     return "\n".join(lines)
 
 
+_BLUF_VISUAL_TIP = (
+    "> [!TIP]\n"
+    "> **Visual scan:** Read the pulse lines below **in order** — they match **section titles** in "
+    "**`coldstep-detect-report.html`** (use **What to look at first** at the top of that page).\n"
+)
+
+
 def _bluf_summary_md(model: dict) -> str:
-    chunks: list[str] = ["## Coldstep detect — summary", ""]
+    chunks: list[str] = ["## Coldstep detect — summary", "", _BLUF_VISUAL_TIP, ""]
     run_b = _run_context_bullet()
     if run_b:
         chunks.extend([run_b, ""])

--- a/scripts/coldstep_detect_report/templates/report.html
+++ b/scripts/coldstep_detect_report/templates/report.html
@@ -15,6 +15,7 @@
   <nav class="report-toc" aria-label="On this page">
     <h2 class="toc-title">On this page</h2>
     <ul>
+      <li><a href="#triage-first">What to look at first</a></li>
       <li><a href="#capabilities">Capabilities</a></li>
       <li><a href="#events">Events by type</a></li>
       <li><a href="#egress">Egress flow</a></li>
@@ -24,6 +25,12 @@
   </nav>
 
   <main>
+    <section id="triage-first" class="report-triage report-triage--ok" aria-labelledby="triage-first-title">
+      <h2 id="triage-first-title" class="triage-heading">What to look at first</h2>
+      <p class="triage-lead">Three cards match the Job Summary pulses (capabilities → diff → threat intel). Anything marked <strong class="triage-strong-bad">needs attention</strong> is worth opening below.</p>
+      <div class="triage-cards" data-mount="triage-first"></div>
+    </section>
+
     <section id="capabilities">
       <h2>Detect Capability Matrix</h2>
       <div data-mount="capabilities"></div>
@@ -90,6 +97,108 @@
   <script type="module">
     const model = JSON.parse(document.getElementById("coldstep-report-model").textContent);
     const $ = (sel) => document.querySelector(sel);
+
+    // 0. Visual triage strip — scan order before charts (pairs with Tier-1 BLUF pulses).
+    {
+      const mount = $('[data-mount="triage-first"]');
+      mount.replaceChildren();
+      const strip = document.getElementById("triage-first");
+      let attention = false;
+
+      function makeCard(stepNum, title, href, tone, bodyText) {
+        const art = document.createElement("article");
+        art.className = "triage-card triage-card--" + tone;
+        const h3 = document.createElement("h3");
+        h3.className = "triage-card-title";
+        h3.textContent = stepNum + " · " + title;
+        const p = document.createElement("p");
+        p.className = "triage-card-body";
+        p.textContent = bodyText;
+        const a = document.createElement("a");
+        a.href = href;
+        a.className = "triage-card-jump";
+        a.textContent = "Jump to section →";
+        art.appendChild(h3);
+        art.appendChild(p);
+        art.appendChild(a);
+        return art;
+      }
+
+      const grid = document.createElement("div");
+      grid.className = "triage-grid";
+
+      const matrix = model.capability_matrix || [];
+      let nFail = 0;
+      let nWarn = 0;
+      for (const r of matrix) {
+        if (r.status === "fail") nFail += 1;
+        if (r.status === "warn") nWarn += 1;
+      }
+      let capTone = "ok";
+      let capText = "All required probes observed.";
+      if (nFail > 0) {
+        capTone = "bad";
+        capText =
+          String(nFail) +
+          " capability row(s) failed" +
+          (nWarn ? ", " + String(nWarn) + " warned" : "") +
+          ".";
+        attention = true;
+      } else if (nWarn > 0) {
+        capTone = "warn";
+        capText = String(nWarn) + " capability row(s) in warn state.";
+      }
+      grid.appendChild(makeCard("1", "Capabilities", "#capabilities", capTone, capText));
+
+      const d = model.diff || {};
+      let diffTone = "ok";
+      let diffText = "";
+      if (d.status === "ok") {
+        const tn = (d.traffic_new || []).length;
+        const tg = (d.traffic_gone || []).length;
+        const tc = (d.traffic_changed || []).length;
+        diffText = "OK — new " + String(tn) + ", gone " + String(tg) + ", changed " + String(tc) + ".";
+      } else {
+        diffTone = "warn";
+        diffText =
+          "Unavailable — " +
+          (d.reason != null && String(d.reason).length ? String(d.reason) : "unknown") +
+          ".";
+      }
+      grid.appendChild(makeCard("2", "Baseline diff", "#diff", diffTone, diffText));
+
+      const otx = model.otx;
+      let otxTone = "ok";
+      let otxText = "";
+      if (!otx) {
+        otxTone = "warn";
+        otxText = "Not in model (run enrich step).";
+      } else if (otx.skipped) {
+        otxTone = "warn";
+        otxText =
+          "Skipped — " +
+          (otx.skipped_reason != null && String(otx.skipped_reason).length
+            ? String(otx.skipped_reason)
+            : "skipped") +
+          ".";
+      } else {
+        const mal = Number((otx.summary || {}).malicious || 0);
+        const api = Number(otx.api_calls || 0);
+        otxText =
+          "Queried " + String(api) + " indicator(s); " + String(mal) + " malicious in summary.";
+        if (mal > 0) {
+          otxTone = "bad";
+          attention = true;
+        }
+      }
+      grid.appendChild(makeCard("3", "Threat intel (OTX)", "#otx", otxTone, otxText));
+
+      mount.appendChild(grid);
+      if (strip) {
+        strip.classList.remove("report-triage--ok", "report-triage--attention");
+        strip.classList.add(attention ? "report-triage--attention" : "report-triage--ok");
+      }
+    }
 
     // 1. Capability matrix as a small table.
     // Built via createElement + textContent so adding any future user-derived

--- a/scripts/coldstep_detect_report/templates/styles.css
+++ b/scripts/coldstep_detect_report/templates/styles.css
@@ -167,3 +167,70 @@ code {
   outline: 2px solid #0969da;
   outline-offset: 2px;
 }
+
+/* Visual triage strip — matches Tier-1 pulse order */
+.report-triage {
+  margin: 0 0 1.75rem;
+  padding: 1rem 1.15rem 1.25rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+}
+.report-triage--ok {
+  background: linear-gradient(135deg, #f6fff8 0%, #fff 55%);
+  border-color: #bbf7cc;
+}
+.report-triage--attention {
+  background: linear-gradient(135deg, #fff8f6 0%, #fff 55%);
+  border-color: #f5b5a8;
+}
+.triage-heading {
+  margin: 0 0 .35rem;
+  font-size: 1.2rem;
+  border-bottom: none;
+  padding-bottom: 0;
+}
+.triage-lead {
+  margin: 0 0 1rem;
+  font-size: .92rem;
+  color: var(--muted);
+  max-width: 52rem;
+}
+.triage-strong-bad {
+  color: var(--fail);
+  font-weight: 600;
+}
+.triage-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 0.75rem;
+}
+.triage-card {
+  border-radius: 6px;
+  padding: 0.65rem 0.85rem;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  box-shadow: 0 1px 2px rgba(30, 30, 30, 0.06);
+}
+.triage-card--ok {
+  border-left: 4px solid var(--pass);
+}
+.triage-card--warn {
+  border-left: 4px solid var(--warn);
+}
+.triage-card--bad {
+  border-left: 4px solid var(--fail);
+  background: #fffafb;
+}
+.triage-card-title {
+  margin: 0 0 0.35rem;
+  font-size: 0.95rem;
+}
+.triage-card-body {
+  margin: 0 0 0.5rem;
+  font-size: 0.88rem;
+  line-height: 1.35;
+}
+.triage-card-jump {
+  font-size: 0.82rem;
+  font-weight: 600;
+}

--- a/scripts/test_coldstep_detect_report_render_html.py
+++ b/scripts/test_coldstep_detect_report_render_html.py
@@ -78,7 +78,10 @@ class HtmlReportRendererTests(unittest.TestCase):
 
     def test_template_has_report_toc_nav(self):
         html = (PKG_DIR / "templates" / "report.html").read_text(encoding="utf-8")
+        self.assertIn('id="triage-first"', html)
+        self.assertIn('data-mount="triage-first"', html)
         self.assertIn('class="report-toc"', html)
+        self.assertIn('href="#triage-first"', html)
         self.assertIn('href="#capabilities"', html)
         self.assertIn('href="#events"', html)
         self.assertIn('href="#egress"', html)
@@ -97,6 +100,8 @@ class HtmlReportRendererTests(unittest.TestCase):
         css = (PKG_DIR / "templates" / "styles.css").read_text(encoding="utf-8")
         self.assertIn(".report-toc", css)
         self.assertIn(".report-toc a:focus-visible", css)
+        self.assertIn(".report-triage", css)
+        self.assertIn(".triage-grid", css)
 
     def test_dns_lookups_round_trip_into_json_island(self):
         # rDNS enrichment writes model.dns_lookups; the HTML renderer must

--- a/scripts/test_coldstep_detect_report_render_summary.py
+++ b/scripts/test_coldstep_detect_report_render_summary.py
@@ -39,6 +39,8 @@ class StepSummaryRendererTests(unittest.TestCase):
     def test_bluf_contains_headings_and_capability_line(self):
         out = self._render()
         self.assertIn("## Coldstep detect — summary", out)
+        self.assertIn("> [!TIP]", out)
+        self.assertIn("**Visual scan:**", out)
         self.assertIn("**Capabilities:**", out)
         self.assertIn("all pass", out.lower())
 


### PR DESCRIPTION
## Summary

Adds **visual-first triage** aligned with Tier-1 BLUF:

- **Job Summary:** `> [!TIP]` **Visual scan** block so readers know pulses match HTML section order.
- **Tier-2 HTML:** New **What to look at first** strip (`#triage-first`) — three cards (Capabilities → Baseline diff → OTX) with **green / amber / red** borders; strip background shifts when anything needs **attention**.

## Files

- `render_step_summary.py`, `templates/report.html`, `templates/styles.css`, detect-report README, tests

## Verification

`python -m unittest scripts.test_coldstep_detect_report_render_summary scripts.test_coldstep_detect_report_render_html -v`
