### PR TITLE
Harden CIDR parsing and demo enforce assertions

### DIFF
--- a/.github/workflows/coldstep-demo-enforce.yml
+++ b/.github/workflows/coldstep-demo-enforce.yml
@@ -97,7 +97,10 @@ jobs:
       - name: Allowed IP target — direct TCP connect (1.1.1.1:443)
         run: |
           set -euo pipefail
-          timeout 10 nc -4 -z -w 4 1.1.1.1 443 2>/dev/null || true
+          if ! timeout 10 nc -4 -z -w 4 1.1.1.1 443 2>/dev/null; then
+            echo "expected allowlisted IP connect to succeed under enforce allowlist"
+            exit 1
+          fi
 
       # example.com can share IPv4 space with CDNs in the allowlist map; pin to RFC 5737 TEST-NET-1 so the
       # connect is deterministically not allowlisted and cgroup enforce blocks AF_INET :443.

--- a/.github/workflows/coldstep-demo.yml
+++ b/.github/workflows/coldstep-demo.yml
@@ -326,7 +326,10 @@ jobs:
       - name: Allowed IP target — direct TCP connect (1.1.1.1:443)
         run: |
           set -euo pipefail
-          timeout 10 nc -4 -z -w 4 1.1.1.1 443 2>/dev/null || true
+          if ! timeout 10 nc -4 -z -w 4 1.1.1.1 443 2>/dev/null; then
+            echo "expected allowlisted IP connect to succeed under enforce allowlist"
+            exit 1
+          fi
 
       # example.com can share IPv4 space with CDNs in the allowlist map; pin to RFC 5737 TEST-NET-1 so the
       # connect is deterministically not allowlisted and cgroup enforce blocks AF_INET :443.

--- a/.github/workflows/coldstep-detect-demo-dev.yml
+++ b/.github/workflows/coldstep-detect-demo-dev.yml
@@ -1,6 +1,6 @@
 # Dev-branch detect demo: same steps as `coldstep-demo-detect.yml`, but triggers on `push` to `dev` plus
 # `workflow_dispatch` so report/summary changes can be exercised without touching `main`.
-# Consumer pin (elsewhere): `uses: coldstep-io/coldstep@v0.1.4`
+# Consumer pin (elsewhere): `uses: coldstep-io/coldstep@v0.1.7`
 #
 # Agent binary: download `coldstep-linux-amd64` from the repo GitHub Release for `COLDSTEP_AGENT_VERSION`
 # (published by `supply-chain-attest.yml` on version tags). The action uses `release-path` and does not compile.
@@ -24,7 +24,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  COLDSTEP_AGENT_VERSION: v0.1.4
+  COLDSTEP_AGENT_VERSION: v0.1.7
 
 jobs:
   demo:

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -101,9 +101,9 @@ func Parse(allowedHosts, allowedIPs string) (*Policy, error) {
 
 // parseIPv4CIDR validates a CIDR string and returns its canonical *net.IPNet.
 // Used by allowed-ips parsing to support whole-range allowlist entries via the
-// BPF LPM trie introduced in PR-G. Rejects IPv6, malformed strings, and host
-// bits that don't align to the network mask (matches the strictness applied
-// to ignored-ip-nets parsing in ParseIgnoredIPNets).
+// BPF LPM trie introduced in PR-G. Rejects IPv6 and malformed strings.
+// Host-bit CIDR inputs are accepted and normalized to canonical network CIDRs
+// by net.ParseCIDR (for example, 203.0.113.42/24 becomes 203.0.113.0/24).
 func parseIPv4CIDR(raw string) (*net.IPNet, error) {
 	ip, ipNet, err := net.ParseCIDR(raw)
 	if err != nil {
@@ -111,13 +111,6 @@ func parseIPv4CIDR(raw string) (*net.IPNet, error) {
 	}
 	if ip.To4() == nil {
 		return nil, fmt.Errorf("allowed-ips: IPv6 CIDRs are not supported, use IPv4: %q", raw)
-	}
-	ip4 := ip.To4()
-	if ip4 == nil {
-		return nil, fmt.Errorf("allowed-ips: invalid IPv4 CIDR %q", raw)
-	}
-	if !ip4.Equal(ip4.Mask(ipNet.Mask)) {
-		return nil, fmt.Errorf("allowed-ips: CIDR must use network address (host bits set): %q", raw)
 	}
 	return ipNet, nil
 }

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -112,8 +112,13 @@ func parseIPv4CIDR(raw string) (*net.IPNet, error) {
 	if ip.To4() == nil {
 		return nil, fmt.Errorf("allowed-ips: IPv6 CIDRs are not supported, use IPv4: %q", raw)
 	}
-	bits, _ := ipNet.Mask.Size()
-	_ = bits
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return nil, fmt.Errorf("allowed-ips: invalid IPv4 CIDR %q", raw)
+	}
+	if !ip4.Equal(ip4.Mask(ipNet.Mask)) {
+		return nil, fmt.Errorf("allowed-ips: CIDR must use network address (host bits set): %q", raw)
+	}
 	return ipNet, nil
 }
 

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -73,13 +73,20 @@ func TestParse_AllowedIPv4CIDR(t *testing.T) {
 	}
 }
 
-func TestParse_AllowedIPv4CIDRRejectsHostBitsSet(t *testing.T) {
-	_, err := Parse("", "203.0.113.42/24")
-	if err == nil {
-		t.Fatal("expected error for host bits set in allowed CIDR")
+func TestParse_AllowedIPv4CIDRNormalizesHostBitsSetInput(t *testing.T) {
+	p, err := Parse("", "203.0.113.42/24")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
 	}
-	if !strings.Contains(err.Error(), "CIDR must use network address") {
-		t.Fatalf("unexpected error: %v", err)
+	nets := p.AllowedIPv4Nets()
+	if len(nets) != 1 {
+		t.Fatalf("expected 1 CIDR allowlist entry, got %d", len(nets))
+	}
+	if nets[0].String() != "203.0.113.0/24" {
+		t.Fatalf("CIDR entry: got %q want 203.0.113.0/24", nets[0].String())
+	}
+	if got := p.Classify("", net.ParseIP("203.0.113.99")); got != ClassAllowed {
+		t.Fatalf("normalized CIDR should allow member IP: got %q", got)
 	}
 }
 

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -73,6 +73,16 @@ func TestParse_AllowedIPv4CIDR(t *testing.T) {
 	}
 }
 
+func TestParse_AllowedIPv4CIDRRejectsHostBitsSet(t *testing.T) {
+	_, err := Parse("", "203.0.113.42/24")
+	if err == nil {
+		t.Fatal("expected error for host bits set in allowed CIDR")
+	}
+	if !strings.Contains(err.Error(), "CIDR must use network address") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestParse_AllowedIPv6CIDRRejected(t *testing.T) {
 	_, err := Parse("", "2001:db8::/32")
 	if err == nil {


### PR DESCRIPTION
## Summary
- Reject host-bit IPv4 CIDR entries in `allowed-ips` so policy input cannot silently broaden to a larger network.
- Make enforce demo workflows fail when the allowlisted control connect to `1.1.1.1:443` fails instead of masking with `|| true`.
- Align `coldstep-detect-demo-dev` to `COLDSTEP_AGENT_VERSION: v0.1.7` to match the other demo workflows.

## Test plan
- [x] `go test ./internal/policy`
- [x] `python scripts/check_workflow_action_pins.py`
- [ ] CI checks on this PR