### PR TITLE
feat(detect-report): add severity-confidence triage contract

### DIFF
--- a/.github/workflows/coldstep-detect-demo-dev.yml
+++ b/.github/workflows/coldstep-detect-demo-dev.yml
@@ -1,6 +1,6 @@
 # Dev-branch detect demo: same steps as `coldstep-demo-detect.yml`, but triggers on `push` to `dev` plus
 # `workflow_dispatch` so report/summary changes can be exercised without touching `main`.
-# Consumer pin (elsewhere): `uses: coldstep-io/coldstep@v0.1.4`
+# Consumer pin (elsewhere): `uses: coldstep-io/coldstep@v0.1.7`
 #
 # Agent binary: download `coldstep-linux-amd64` from the repo GitHub Release for `COLDSTEP_AGENT_VERSION`
 # (published by `supply-chain-attest.yml` on version tags). The action uses `release-path` and does not compile.
@@ -24,7 +24,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  COLDSTEP_AGENT_VERSION: v0.1.4
+  COLDSTEP_AGENT_VERSION: v0.1.7
 
 jobs:
   demo:
@@ -160,13 +160,11 @@ jobs:
           grep -qi 'process tree' "$f" || { echo "expected process tree section in digest"; exit 1; }
           grep -qi 'Filesystem' "$f" || { echo "expected Filesystem section in digest"; exit 1; }
 
-      # Tier-1 BLUF step summary runs AFTER rDNS + OTX enrich so OTX headlines are accurate.
-      # Full charts/tables live in Tier-2 HTML only. HTML artifact uses the same model file.
-      - name: Build report model
+      - name: Build IP classification model
         env:
           COLDSTEP_REPORT_CURRENT_JSONL: ${{ github.workspace }}/.coldstep-events.jsonl
           COLDSTEP_REPORT_MODEL_OUT: ${{ github.workspace }}/.coldstep-report-model.json
-        run: python3 scripts/coldstep_detect_report/build_report_model.py
+        run: python3 scripts/coldstep_detect_report/build_ip_classification_model.py
 
       - name: Compare detect output with previous successful run (opt-in)
         if: env.COLDSTEP_DIFF_PREV_RUN == '1'
@@ -236,18 +234,8 @@ jobs:
             fail_diff_unavailable "traffic diff script failed"
           fi
 
-          # Re-build the report model now that the baseline JSONL is on disk, so the
-          # downstream HTML artifact carries the diff section too. Without this, the
-          # earlier "Build report model" step ran without baseline_jsonl and emitted
-          # diff.status="unavailable".
-          COLDSTEP_REPORT_CURRENT_JSONL="${current_file}" \
-          COLDSTEP_REPORT_BASELINE_JSONL="${baseline_file}" \
-          COLDSTEP_REPORT_MODEL_OUT="${GITHUB_WORKSPACE}/.coldstep-report-model.json" \
-            python3 "${GITHUB_WORKSPACE}/scripts/coldstep_detect_report/build_report_model.py"
-
-      # rDNS enrichment runs first (no API key needed) so OTX renderers and the
-      # egress sankey can show "8.8.8.8 (dns.google)" instead of just the IP.
-      # continue-on-error + always-exit-0 mirror the OTX step contract.
+      # rDNS enrichment runs before summary render so each deduped IP row can
+      # include reverse lookup context when available.
       - name: Enrich report model with reverse DNS
         if: always()
         env:
@@ -262,10 +250,7 @@ jobs:
             echo "::warning::report model missing, skipping rDNS enrichment"
           fi
 
-      # OTX enrichment runs AFTER the diff step's model rebuild (which adds the
-      # diff buckets) and AFTER rDNS so OTX-table rows can carry hostnames.
-      # Both `continue-on-error` and the script's own always-exit-0 contract
-      # keep the detect job green on third-party failures.
+      # OTX enrichment provides verdict + pulse signal for at-a-glance rows.
       - name: Enrich report model with OTX threat-intel
         if: always()
         env:
@@ -281,40 +266,26 @@ jobs:
             echo "::warning::report model missing, skipping OTX enrichment"
           fi
 
-      - name: Render step summary (BLUF)
+      - name: Render IP classification summary
         if: always()
         env:
           COLDSTEP_REPORT_MODEL_IN: ${{ github.workspace }}/.coldstep-report-model.json
         run: |
           set -euo pipefail
           if [[ -f "${COLDSTEP_REPORT_MODEL_IN}" ]]; then
-            python3 scripts/coldstep_detect_report/render_step_summary.py
+            python3 scripts/coldstep_detect_report/render_ip_classification_summary.py
           else
             echo "::warning::report model missing, skipping step summary render"
           fi
 
-      - name: Render self-contained HTML report
+      - name: Verify IP classification summary output
         if: always()
-        env:
-          COLDSTEP_REPORT_MODEL_IN: ${{ github.workspace }}/.coldstep-report-model.json
-          COLDSTEP_REPORT_HTML_OUT: ${{ github.workspace }}/coldstep-detect-report.html
         run: |
           set -euo pipefail
-          if [[ -f "${COLDSTEP_REPORT_MODEL_IN}" ]]; then
-            python3 scripts/coldstep_detect_report/render_html_report.py
-          else
-            echo "::warning::report model missing, skipping HTML render"
-          fi
-
-      - name: Upload HTML report artifact
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: coldstep-detect-report-html-${{ env.NS_RUNNER_LABEL }}
-          path: ${{ github.workspace }}/coldstep-detect-report.html
-          retention-days: 14
-          if-no-files-found: ignore
-          overwrite: true
+          test -f "${GITHUB_STEP_SUMMARY}"
+          grep -q "IP classification" "${GITHUB_STEP_SUMMARY}"
+          grep -q "Decision banner" "${GITHUB_STEP_SUMMARY}"
+          grep -q "Uncertainty and contradictions" "${GITHUB_STEP_SUMMARY}"
 
       - name: Persist detect JSONL baseline artifact
         if: always()

--- a/scripts/coldstep_detect_report/build_ip_classification_model.py
+++ b/scripts/coldstep_detect_report/build_ip_classification_model.py
@@ -1,0 +1,324 @@
+"""Build a minimal IP/FQDN/rDNS classification model for detect-dev reports."""
+from __future__ import annotations
+
+import datetime as dt
+import ipaddress
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+SCHEMA_VERSION = "ip-classification-v1"
+_SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9_./\\:-]+$")
+_EGRESS_TYPES = {"tcp", "udp", "http", "tls"}
+_SEVERITY_ORDER = {"Critical": 0, "High": 1, "Medium": 2, "Low": 3, "Informational": 4}
+_CONFIDENCE_ORDER = {"A": 0, "B": 1, "C": 2}
+
+
+def _safe_workspace_path(raw: str, *, var_name: str = "path") -> str:
+    if not _SAFE_PATH_RE.match(raw):
+        raise ValueError(f"{var_name} contains disallowed characters")
+    roots: list[str] = []
+    workspace = os.environ.get("GITHUB_WORKSPACE")
+    if workspace:
+        roots.append(os.path.realpath(workspace))
+    runner_temp = os.environ.get("RUNNER_TEMP")
+    if runner_temp:
+        roots.append(os.path.realpath(runner_temp))
+    roots.append(os.path.realpath(tempfile.gettempdir()))
+    if not workspace:
+        roots.append(os.path.realpath(os.getcwd()))
+    resolved = os.path.realpath(raw)
+    for root in roots:
+        if os.path.commonpath([resolved, root]) == root:
+            return resolved
+    raise ValueError(f"{var_name} resolves outside trusted roots: {resolved!r}")
+
+
+def _load_jsonl(path: str) -> list[dict]:
+    out: list[dict] = []
+    with open(path, "r", encoding="utf-8") as f:
+        for raw in f:
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return out
+
+
+def _is_ipv4(value: str) -> bool:
+    try:
+        return isinstance(ipaddress.ip_address(value), ipaddress.IPv4Address)
+    except ValueError:
+        return False
+
+
+def _destination_hint(event: dict) -> str:
+    for key in ("fqdn", "host", "sni"):
+        value = str(event.get(key) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _score_row(*, ip: str, row: dict, otx_indicator: dict | None, dns_lookup: dict) -> dict:
+    if otx_indicator is None and row.get("severity") and row.get("confidence"):
+        return {
+            "severity": str(row.get("severity", "Informational")),
+            "confidence": str(row.get("confidence", "C")),
+            "risk_score": float(row.get("risk_score", 0.0)),
+            "confidence_score": float(row.get("confidence_score", 0.0)),
+            "evidence_flags": [str(v) for v in row.get("evidence_flags", [])],
+            "uncertainty_flags": [str(v) for v in row.get("uncertainty_flags", [])],
+        }
+
+    evidence_flags: list[str] = []
+    uncertainty_flags: list[str] = []
+    risk_score = 0.0
+    confidence_score = 0.0
+    corroboration = 0
+
+    verdict = str(
+        (otx_indicator or {}).get("verdict")
+        or (otx_indicator or {}).get("classification")
+        or row.get("classification")
+        or "unidentified"
+    )
+    pulse_severity = str((otx_indicator or {}).get("pulse_severity") or row.get("pulse_severity") or "Informational")
+    pulse_count = int((otx_indicator or {}).get("pulse_count") or row.get("pulse_count") or 0)
+    otx_conf = str((otx_indicator or {}).get("confidence") or "").strip().lower()
+    rdns = str(dns_lookup.get(ip, row.get("rdns", "")) or "")
+
+    if verdict == "malicious":
+        risk_score += 60
+        confidence_score += 28
+        evidence_flags.append("OTX:strong")
+        corroboration += 1
+        if otx_conf == "high":
+            confidence_score += 18
+            evidence_flags.append("OTXCONF:high")
+            corroboration += 1
+        elif otx_conf == "medium":
+            confidence_score += 10
+            evidence_flags.append("OTXCONF:medium")
+        elif otx_conf == "low":
+            confidence_score += 2
+            evidence_flags.append("OTXCONF:low")
+            uncertainty_flags.append("otx-low-confidence")
+    elif verdict == "clean":
+        risk_score -= 18
+        confidence_score += 6
+        evidence_flags.append("OTX:clean")
+    else:
+        uncertainty_flags.append("otx-unidentified")
+
+    if pulse_severity == "Critical":
+        risk_score += 35
+        confidence_score += 16
+        evidence_flags.append("PULSE:critical")
+        corroboration += 1
+    elif pulse_severity == "High":
+        risk_score += 22
+        confidence_score += 11
+        evidence_flags.append("PULSE:high")
+        corroboration += 1
+    elif pulse_severity == "Medium":
+        risk_score += 12
+        confidence_score += 6
+        evidence_flags.append("PULSE:medium")
+    elif pulse_severity == "Low":
+        risk_score += 6
+        confidence_score += 3
+        evidence_flags.append("PULSE:low")
+
+    if pulse_count >= 25:
+        risk_score += 12
+        confidence_score += 8
+        evidence_flags.append("PULSE:volume")
+        corroboration += 1
+    elif pulse_count >= 8:
+        risk_score += 6
+        confidence_score += 4
+        evidence_flags.append("PULSE:repeat")
+
+    if rdns:
+        confidence_score += 6
+        evidence_flags.append("RDNS:present")
+        corroboration += 1
+    else:
+        confidence_score -= 8
+        uncertainty_flags.append("rdns-missing")
+        evidence_flags.append("RDNS:missing")
+
+    fqdn = str(row.get("fqdn", "") or "")
+    if not fqdn:
+        confidence_score -= 5
+        uncertainty_flags.append("fqdn-missing")
+        evidence_flags.append("FQDN:missing")
+    else:
+        confidence_score += 4
+        evidence_flags.append("FQDN:present")
+
+    if corroboration >= 3:
+        confidence_score += 12
+        evidence_flags.append("CTX:corroborated")
+
+    confidence_score = max(0.0, min(100.0, confidence_score))
+    risk_score = max(0.0, min(100.0, risk_score))
+
+    if confidence_score >= 70:
+        confidence = "A"
+    elif confidence_score >= 45:
+        confidence = "B"
+    else:
+        confidence = "C"
+
+    if risk_score >= 85:
+        severity = "Critical"
+    elif risk_score >= 65:
+        severity = "High"
+    elif risk_score >= 45:
+        severity = "Medium"
+    elif risk_score >= 25:
+        severity = "Low"
+    else:
+        severity = "Informational"
+
+    # Hard guardrail: no single-source critical. Critical requires high confidence
+    # and corroboration across at least two independent factors.
+    if severity == "Critical" and (confidence != "A" or corroboration < 2):
+        severity = "High"
+        uncertainty_flags.append("critical-gate-downgrade")
+        evidence_flags.append("RULE:no-single-source-critical")
+
+    return {
+        "severity": severity,
+        "confidence": confidence,
+        "risk_score": round(risk_score, 1),
+        "confidence_score": round(confidence_score, 1),
+        "evidence_flags": evidence_flags,
+        "uncertainty_flags": sorted(set(uncertainty_flags)),
+    }
+
+
+def build(*, current_jsonl: str, now: dt.datetime | None = None) -> dict:
+    when = now if now is not None else dt.datetime.now(tz=dt.timezone.utc)
+    events = _load_jsonl(current_jsonl)
+    ip_hints: dict[str, dict[str, int]] = {}
+    for ev in events:
+        if ev.get("type") not in _EGRESS_TYPES:
+            continue
+        ip = str(ev.get("dst") or "")
+        if not _is_ipv4(ip):
+            continue
+        hint = _destination_hint(ev)
+        if ip not in ip_hints:
+            ip_hints[ip] = {}
+        if hint:
+            ip_hints[ip][hint] = ip_hints[ip].get(hint, 0) + 1
+
+    rows: list[dict] = []
+    for ip in sorted(ip_hints.keys()):
+        hints = ip_hints[ip]
+        fqdn = ""
+        if hints:
+            # Deterministic tie-break: highest count then lexicographic.
+            fqdn = sorted(hints.items(), key=lambda item: (-item[1], item[0]))[0][0]
+        rows.append(
+            {
+                "ip": ip,
+                "fqdn": fqdn,
+                "rdns": "",
+                "classification": "unidentified",
+                "pulse_severity": "Informational",
+                "pulse_count": 0,
+            }
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": when.isoformat().replace("+00:00", "Z"),
+        "ip_classification": rows,
+        "dns_lookups": {},
+        "otx": None,
+    }
+
+
+def project_otx_classification(model: dict) -> dict:
+    lookup: dict[str, dict] = {}
+    otx = model.get("otx") or {}
+    for row in otx.get("indicators") or []:
+        ind = row.get("indicator")
+        verdict = row.get("verdict")
+        if ind and verdict:
+            lookup[ind] = {
+                "classification": verdict,
+                "pulse_severity": row.get("pulse_severity", "Informational"),
+                "pulse_count": row.get("pulse_count", 0),
+                "confidence": row.get("confidence"),
+            }
+    dns_lookup = model.get("dns_lookups") or {}
+    out = dict(model)
+    items = []
+    for row in model.get("ip_classification") or []:
+        ip = row.get("ip")
+        matched = lookup.get(ip)
+        score = _score_row(ip=str(ip or ""), row=row, otx_indicator=matched, dns_lookup=dns_lookup)
+        items.append(
+            {
+                "ip": ip,
+                "fqdn": row.get("fqdn", ""),
+                "rdns": dns_lookup.get(ip, row.get("rdns", "")),
+                "classification": (matched or {}).get("classification", row.get("classification", "unidentified")),
+                "pulse_severity": (matched or {}).get("pulse_severity", row.get("pulse_severity", "Informational")),
+                "pulse_count": (matched or {}).get("pulse_count", row.get("pulse_count", 0)),
+                "severity": score["severity"],
+                "confidence": score["confidence"],
+                "risk_score": score["risk_score"],
+                "confidence_score": score["confidence_score"],
+                "evidence_flags": score["evidence_flags"],
+                "uncertainty_flags": score["uncertainty_flags"],
+            }
+        )
+    items.sort(
+        key=lambda item: (
+            _SEVERITY_ORDER.get(str(item.get("severity", "Informational")), 99),
+            _CONFIDENCE_ORDER.get(str(item.get("confidence", "C")), 99),
+            -int(item.get("pulse_count", 0)),
+            str(item.get("ip", "")),
+        )
+    )
+    out["ip_classification"] = items
+    return out
+
+
+def main() -> int:
+    raw_cur = os.environ.get("COLDSTEP_REPORT_CURRENT_JSONL", "")
+    raw_out = os.environ.get("COLDSTEP_REPORT_MODEL_OUT", "")
+    if not raw_cur or not raw_out:
+        missing = []
+        if not raw_cur:
+            missing.append("COLDSTEP_REPORT_CURRENT_JSONL")
+        if not raw_out:
+            missing.append("COLDSTEP_REPORT_MODEL_OUT")
+        print(f"build_ip_classification_model: missing required env vars: {', '.join(missing)}", file=sys.stderr)
+        return 1
+    try:
+        cur = _safe_workspace_path(raw_cur, var_name="COLDSTEP_REPORT_CURRENT_JSONL")
+        out = _safe_workspace_path(raw_out, var_name="COLDSTEP_REPORT_MODEL_OUT")
+    except ValueError as e:
+        print(f"build_ip_classification_model: refusing untrusted path: {e}", file=sys.stderr)
+        return 1
+    model = build(current_jsonl=cur)
+    Path(out).parent.mkdir(parents=True, exist_ok=True)
+    Path(out).write_text(json.dumps(model, indent=2), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/coldstep_detect_report/render_ip_classification_summary.py
+++ b/scripts/coldstep_detect_report/render_ip_classification_summary.py
@@ -1,0 +1,170 @@
+"""Render IP/FQDN/rDNS classification summary for detect-dev."""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+from scripts.coldstep_detect_report.build_ip_classification_model import project_otx_classification
+
+_SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9_./\\:-]+$")
+PULSE_GLYPH = {
+    "Critical": "🟥",
+    "High": "🟧",
+    "Medium": "🟨",
+    "Low": "🟩",
+    "Informational": "🟩",
+}
+SEVERITY_GLYPH = {
+    "Critical": "🟥",
+    "High": "🟧",
+    "Medium": "🟨",
+    "Low": "🟩",
+    "Informational": "🟩",
+}
+_SEVERITY_ORDER = {"Critical": 0, "High": 1, "Medium": 2, "Low": 3, "Informational": 4}
+_CONFIDENCE_ORDER = {"A": 0, "B": 1, "C": 2}
+
+
+def _safe_workspace_path(raw: str, *, var_name: str = "path") -> str:
+    if not _SAFE_PATH_RE.match(raw):
+        raise ValueError(f"{var_name} contains disallowed characters")
+    roots: list[str] = []
+    workspace = os.environ.get("GITHUB_WORKSPACE")
+    if workspace:
+        roots.append(os.path.realpath(workspace))
+    runner_temp = os.environ.get("RUNNER_TEMP")
+    if runner_temp:
+        roots.append(os.path.realpath(runner_temp))
+    roots.append(os.path.realpath(tempfile.gettempdir()))
+    if not workspace:
+        roots.append(os.path.realpath(os.getcwd()))
+    resolved = os.path.realpath(raw)
+    for root in roots:
+        if os.path.commonpath([resolved, root]) == root:
+            return resolved
+    raise ValueError(f"{var_name} resolves outside trusted roots: {resolved!r}")
+
+
+def render_markdown(model: dict) -> str:
+    projected = project_otx_classification(model)
+    rows = projected.get("ip_classification") or []
+    rows = sorted(
+        rows,
+        key=lambda item: (
+            _SEVERITY_ORDER.get(str(item.get("severity", "Informational")), 99),
+            _CONFIDENCE_ORDER.get(str(item.get("confidence", "C")), 99),
+            -int(item.get("pulse_count", 0)),
+            str(item.get("ip", "")),
+        ),
+    )
+    top = rows[0] if rows else {}
+    top_sev = str(top.get("severity", "Informational"))
+    top_conf = str(top.get("confidence", "C"))
+    top_flags = [str(f) for f in top.get("evidence_flags", [])[:3]]
+    recommendation = "monitor"
+    if top_sev in {"Critical", "High"}:
+        recommendation = "contain"
+    elif top_sev == "Medium":
+        recommendation = "investigate"
+
+    lines = [
+        "## Coldstep detect - IP classification",
+        "",
+        "### Decision banner",
+        "",
+        f"- Highest severity: {SEVERITY_GLYPH.get(top_sev, '⬜')} {top_sev}",
+        f"- Confidence grade: {top_conf}",
+        f"- Why: {', '.join(top_flags) if top_flags else 'insufficient corroborated signal'}",
+        f"- Immediate action: {recommendation}",
+        "",
+        "| IP | FQDN | rDNS | Classification | Severity | Confidence | Evidence flags | Pulse severity | Pulse count |",
+        "|---|---|---|---|---|---|---|---|---:|",
+    ]
+    uncertainty_rows = 0
+    top_uncertainty: dict[str, int] = {}
+    for row in rows:
+        severity = str(row.get("pulse_severity", "Informational"))
+        sev_with_glyph = f"{PULSE_GLYPH.get(severity, '⬜')} {severity}"
+        risk_sev = str(row.get("severity", "Informational"))
+        risk_with_glyph = f"{SEVERITY_GLYPH.get(risk_sev, '⬜')} {risk_sev}"
+        evidence_flags = ", ".join(str(f) for f in row.get("evidence_flags", []))
+        for flag in row.get("uncertainty_flags", []) or []:
+            flag_s = str(flag)
+            top_uncertainty[flag_s] = top_uncertainty.get(flag_s, 0) + 1
+        if row.get("uncertainty_flags"):
+            uncertainty_rows += 1
+        lines.append(
+            f"| {row.get('ip', '')} | {row.get('fqdn', '')} | {row.get('rdns', '')} | "
+            f"{row.get('classification', 'unidentified')} | {risk_with_glyph} | {row.get('confidence', 'C')} | "
+            f"{evidence_flags} | {sev_with_glyph} | {row.get('pulse_count', 0)} |"
+        )
+    if not rows:
+        lines.append("| (none) |  |  | unidentified | 🟩 Informational | C |  | 🟩 Informational | 0 |")
+    lines.extend(
+        [
+            "",
+            "### Uncertainty and contradictions",
+            "",
+            f"- Rows with uncertainty flags: {uncertainty_rows}",
+            "- Top uncertainty drivers: "
+            + (
+                ", ".join(
+                    f"{name} ({count})"
+                    for name, count in sorted(top_uncertainty.items(), key=lambda item: (-item[1], item[0]))[:3]
+                )
+                if top_uncertainty
+                else "none"
+            ),
+            "",
+            "### Action queue",
+            "",
+        ]
+    )
+    if top_sev in {"Critical", "High"}:
+        lines.append("- [IR] escalate top destination and start containment verification.")
+        lines.append("- [SecEng] validate indicator confidence and check cloud/demotion context.")
+        lines.append("- [Dev] confirm expected egress path and investigate drift.")
+    elif top_sev == "Medium":
+        lines.append("- [SecEng] investigate ambiguous signals and enrichment gaps.")
+        lines.append("- [Dev] verify destination intent against current workflow behavior.")
+    else:
+        lines.append("- [Dev] monitor; no urgent containment action required.")
+        lines.append("- [SecEng] track trend changes across subsequent runs.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_summary(*, model: dict, summary_path: str) -> None:
+    body = render_markdown(model)
+    with open(summary_path, "a", encoding="utf-8") as f:
+        f.write(body + "\n")
+
+
+def main() -> int:
+    raw_model_path = os.environ.get("COLDSTEP_REPORT_MODEL_IN", "")
+    raw_summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "")
+    if not raw_model_path or not raw_summary_path:
+        missing = []
+        if not raw_model_path:
+            missing.append("COLDSTEP_REPORT_MODEL_IN")
+        if not raw_summary_path:
+            missing.append("GITHUB_STEP_SUMMARY")
+        print(f"render_ip_classification_summary: missing required env vars: {', '.join(missing)}", file=sys.stderr)
+        return 1
+    try:
+        model_path = _safe_workspace_path(raw_model_path, var_name="COLDSTEP_REPORT_MODEL_IN")
+        summary_path = _safe_workspace_path(raw_summary_path, var_name="GITHUB_STEP_SUMMARY")
+    except ValueError as e:
+        print(f"render_ip_classification_summary: refusing untrusted path: {e}", file=sys.stderr)
+        return 1
+    model = json.loads(Path(model_path).read_text(encoding="utf-8"))
+    write_summary(model=model, summary_path=summary_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_coldstep_detect_report_build_ip_classification_model.py
+++ b/scripts/test_coldstep_detect_report_build_ip_classification_model.py
@@ -1,0 +1,98 @@
+import datetime as dt
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.coldstep_detect_report.build_ip_classification_model import (
+    build,
+    project_otx_classification,
+)
+
+
+class BuildIPClassificationModelTests(unittest.TestCase):
+    def test_build_dedupes_ipv4_and_keeps_fqdn_hint(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            jsonl = Path(td) / "events.jsonl"
+            jsonl.write_text(
+                '{"type":"tcp","dst":"8.8.8.8","fqdn":"dns.google"}\n'
+                '{"type":"udp","dst":"8.8.8.8"}\n'
+                '{"type":"http","dst":"1.1.1.1","host":"one.one.one.one"}\n'
+                '{"type":"tls","dst":"example.com"}\n',
+                encoding="utf-8",
+            )
+            model = build(current_jsonl=str(jsonl), now=dt.datetime(2026, 4, 20, tzinfo=dt.timezone.utc))
+            rows = model["ip_classification"]
+            self.assertEqual([row["ip"] for row in rows], ["1.1.1.1", "8.8.8.8"])
+            self.assertEqual(rows[0]["fqdn"], "one.one.one.one")
+            self.assertEqual(rows[1]["fqdn"], "dns.google")
+            self.assertEqual(rows[0]["rdns"], "")
+            self.assertEqual(rows[0]["classification"], "unidentified")
+
+    def test_projects_otx_verdict_and_pulse_and_rdns(self) -> None:
+        model = {
+            "ip_classification": [
+                {
+                    "ip": "8.8.8.8",
+                    "fqdn": "dns.google",
+                    "rdns": "",
+                    "classification": "unidentified",
+                    "pulse_severity": "Informational",
+                    "pulse_count": 0,
+                }
+            ],
+            "dns_lookups": {"8.8.8.8": "dns.google"},
+            "otx": {
+                "indicators": [
+                    {
+                        "indicator": "8.8.8.8",
+                        "verdict": "malicious",
+                        "pulse_severity": "Critical",
+                        "pulse_count": 48,
+                    }
+                ]
+            },
+        }
+        projected = project_otx_classification(model)
+        row = projected["ip_classification"][0]
+        self.assertEqual(row["classification"], "malicious")
+        self.assertEqual(row["pulse_severity"], "Critical")
+        self.assertEqual(row["pulse_count"], 48)
+        self.assertEqual(row["rdns"], "dns.google")
+        self.assertEqual(row["severity"], "Critical")
+        self.assertEqual(row["confidence"], "A")
+        self.assertIn("OTX:strong", row["evidence_flags"])
+        self.assertEqual(row["uncertainty_flags"], [])
+
+    def test_critical_gate_downgrades_when_not_corroborated(self) -> None:
+        model = {
+            "ip_classification": [
+                {
+                    "ip": "198.51.100.20",
+                    "fqdn": "",
+                    "rdns": "",
+                    "classification": "unidentified",
+                    "pulse_severity": "Informational",
+                    "pulse_count": 0,
+                }
+            ],
+            "dns_lookups": {},
+            "otx": {
+                "indicators": [
+                    {
+                        "indicator": "198.51.100.20",
+                        "verdict": "malicious",
+                        "pulse_severity": "Critical",
+                        "pulse_count": 0,
+                        "confidence": "low",
+                    }
+                ]
+            },
+        }
+        projected = project_otx_classification(model)
+        row = projected["ip_classification"][0]
+        self.assertEqual(row["severity"], "High")
+        self.assertIn("critical-gate-downgrade", row["uncertainty_flags"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_coldstep_detect_report_render_ip_classification_summary.py
+++ b/scripts/test_coldstep_detect_report_render_ip_classification_summary.py
@@ -1,0 +1,93 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.coldstep_detect_report.render_ip_classification_summary import (
+    render_markdown,
+    write_summary,
+)
+
+
+class RenderIPClassificationSummaryTests(unittest.TestCase):
+    def test_writes_ip_fqdn_rdns_classification_table(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            summary = Path(td) / "summary.md"
+            model = {
+                "ip_classification": [
+                    {
+                        "ip": "1.1.1.1",
+                        "fqdn": "one.one.one.one",
+                        "rdns": "one.one.one.one",
+                        "classification": "clean",
+                        "severity": "Low",
+                        "confidence": "B",
+                        "evidence_flags": ["OTX:clean"],
+                        "uncertainty_flags": [],
+                        "pulse_severity": "Informational",
+                        "pulse_count": 0,
+                    },
+                    {
+                        "ip": "8.8.8.8",
+                        "fqdn": "dns.google",
+                        "rdns": "dns.google",
+                        "classification": "malicious",
+                        "severity": "Critical",
+                        "confidence": "A",
+                        "evidence_flags": ["OTX:strong", "PULSE:volume"],
+                        "uncertainty_flags": [],
+                        "pulse_severity": "High",
+                        "pulse_count": 12,
+                    },
+                ],
+                "dns_lookups": {},
+                "otx": None,
+            }
+            write_summary(model=model, summary_path=str(summary))
+            out = summary.read_text(encoding="utf-8")
+            self.assertIn("## Coldstep detect - IP classification", out)
+            self.assertIn("### Decision banner", out)
+            self.assertIn("Highest severity: 🟥 Critical", out)
+            self.assertIn("| 1.1.1.1 | one.one.one.one | one.one.one.one | clean | 🟩 Low | B | OTX:clean | 🟩 Informational | 0 |", out)
+            self.assertIn("| 8.8.8.8 | dns.google | dns.google | malicious | 🟥 Critical | A | OTX:strong, PULSE:volume | 🟧 High | 12 |", out)
+            self.assertIn("### Uncertainty and contradictions", out)
+            self.assertIn("### Action queue", out)
+            self.assertNotIn("Capabilities", out)
+
+    def test_summary_renders_pulse_glyphs_for_quick_scan(self) -> None:
+        model = {
+            "ip_classification": [
+                {
+                    "ip": "8.8.8.8",
+                    "fqdn": "dns.google",
+                    "rdns": "dns.google",
+                    "classification": "malicious",
+                    "severity": "Critical",
+                    "confidence": "A",
+                    "evidence_flags": ["OTX:strong"],
+                    "uncertainty_flags": [],
+                    "pulse_severity": "Critical",
+                    "pulse_count": 20,
+                },
+                {
+                    "ip": "1.1.1.1",
+                    "fqdn": "one.one.one.one",
+                    "rdns": "one.one.one.one",
+                    "classification": "clean",
+                    "severity": "Informational",
+                    "confidence": "B",
+                    "evidence_flags": ["OTX:clean"],
+                    "uncertainty_flags": [],
+                    "pulse_severity": "Informational",
+                    "pulse_count": 0,
+                },
+            ],
+            "dns_lookups": {},
+            "otx": None,
+        }
+        out = render_markdown(model)
+        self.assertIn("🟥 Critical", out)
+        self.assertIn("🟩 Informational", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reimage `coldstep-detect-demo-dev` reporting with a confidence-first severity model and a hard no-single-source-critical gate
- expand IP classification rows with severity, confidence, risk/confidence scores, evidence flags, and uncertainty flags, then render decision banner/uncertainty/action queue sections
- update workflow summary verification markers and add regression tests for critical gating and the new summary contract

## Test plan
- [x] `python -m unittest scripts.test_coldstep_detect_report_build_ip_classification_model scripts.test_coldstep_detect_report_render_ip_classification_summary -v`