### PR TITLE
fix(detect-report): restore severity report rendering in workflow

### DIFF
--- a/scripts/coldstep_detect_report/render_ip_classification_summary.py
+++ b/scripts/coldstep_detect_report/render_ip_classification_summary.py
@@ -8,6 +8,12 @@ import sys
 import tempfile
 from pathlib import Path
 
+# Support direct script execution (python3 scripts/.../render_ip_classification_summary.py)
+# by ensuring repo root is on sys.path before importing `scripts.*`.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
 from scripts.coldstep_detect_report.build_ip_classification_model import project_otx_classification
 
 _SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9_./\\:-]+$")


### PR DESCRIPTION
## Summary
- fix the render step crash in `coldstep-detect-demo-dev` by making `render_ip_classification_summary.py` import-safe when run as a direct script
- resolves `ModuleNotFoundError: No module named ''scripts''` seen in merged run 24684603299

## Test plan
- [x] `python -m unittest scripts.test_coldstep_detect_report_render_ip_classification_summary -v`