### PR TITLE
fix(ci): add diagnostics for detect summary marker checks

### DIFF
--- a/.github/workflows/coldstep-detect-demo-dev.yml
+++ b/.github/workflows/coldstep-detect-demo-dev.yml
@@ -282,10 +282,30 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
-          test -f "${GITHUB_STEP_SUMMARY}"
-          grep -q "IP classification" "${GITHUB_STEP_SUMMARY}"
-          grep -q "Decision banner" "${GITHUB_STEP_SUMMARY}"
-          grep -q "Uncertainty and contradictions" "${GITHUB_STEP_SUMMARY}"
+          python3 - <<'PY'
+          import os
+          import sys
+          from pathlib import Path
+
+          summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"])
+          if not summary_path.is_file():
+              print(f"::error::summary file missing: {summary_path}")
+              sys.exit(1)
+
+          body = summary_path.read_text(encoding="utf-8", errors="replace")
+          markers = (
+              "IP classification",
+              "Decision banner",
+              "Uncertainty and contradictions",
+          )
+          missing = [m for m in markers if m not in body]
+          if missing:
+              print(f"::error::missing summary markers: {', '.join(missing)}")
+              print("::group::summary body")
+              print(body)
+              print("::endgroup::")
+              sys.exit(1)
+          PY
 
       - name: Persist detect JSONL baseline artifact
         if: always()


### PR DESCRIPTION
## Summary
- replace grep-only summary marker checks with a Python assertion in `coldstep-detect-demo-dev`
- on failure, emit missing markers and print full summary body in logs for immediate diagnosis

## Why
Current failures exit with code 1 but don't reveal which marker failed or what was actually written to `$GITHUB_STEP_SUMMARY`.

## Test plan
- [x] workflow syntax remains valid (YAML step updated only)
- [ ] run `coldstep-detect-demo-dev` and inspect improved diagnostics if it fails