### PR TITLE
fix(ci): verify detect summary via persistent workspace snapshot

### DIFF
--- a/.github/workflows/coldstep-detect-demo-dev.yml
+++ b/.github/workflows/coldstep-detect-demo-dev.yml
@@ -293,6 +293,7 @@ jobs:
         if: always()
         env:
           COLDSTEP_REPORT_MODEL_IN: ${{ github.workspace }}/.coldstep-report-model.json
+          COLDSTEP_REPORT_SUMMARY_OUT: ${{ github.workspace }}/.coldstep-step-summary.md
         run: |
           set -euo pipefail
           if [[ -s "${COLDSTEP_REPORT_MODEL_IN}" ]]; then
@@ -310,7 +311,7 @@ jobs:
           import sys
           from pathlib import Path
 
-          summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"])
+          summary_path = Path(os.environ["GITHUB_WORKSPACE"]) / ".coldstep-step-summary.md"
           if not summary_path.is_file():
               print(f"::error::summary file missing: {summary_path}")
               sys.exit(1)

--- a/scripts/coldstep_detect_report/render_ip_classification_summary.py
+++ b/scripts/coldstep_detect_report/render_ip_classification_summary.py
@@ -168,7 +168,17 @@ def main() -> int:
         print(f"render_ip_classification_summary: refusing untrusted path: {e}", file=sys.stderr)
         return 1
     model = json.loads(Path(model_path).read_text(encoding="utf-8"))
-    write_summary(model=model, summary_path=summary_path)
+    body = render_markdown(model)
+    with open(summary_path, "a", encoding="utf-8") as f:
+        f.write(body + "\n")
+    raw_copy_path = os.environ.get("COLDSTEP_REPORT_SUMMARY_OUT", "").strip()
+    if raw_copy_path:
+        try:
+            copy_path = _safe_workspace_path(raw_copy_path, var_name="COLDSTEP_REPORT_SUMMARY_OUT")
+        except ValueError as e:
+            print(f"render_ip_classification_summary: refusing untrusted summary copy path: {e}", file=sys.stderr)
+            return 1
+        Path(copy_path).write_text(body + "\n", encoding="utf-8")
     return 0
 
 


### PR DESCRIPTION
## Summary
- fix false summary verification failures caused by step-scoped `GITHUB_STEP_SUMMARY`
- write a persistent workspace summary snapshot from render step (`COLDSTEP_REPORT_SUMMARY_OUT`)
- validate that workspace snapshot in verify step

## Test plan
- [x] `python -m unittest scripts.test_coldstep_detect_report_render_ip_classification_summary -v`
- [ ] run `coldstep-detect-demo-dev` on dev and confirm marker checks pass