### PR TITLE
chore(ci): trim detect summary failure diagnostics

### DIFF
--- a/.github/workflows/coldstep-detect-demo-dev.yml
+++ b/.github/workflows/coldstep-detect-demo-dev.yml
@@ -325,8 +325,14 @@ jobs:
           missing = [m for m in markers if m not in body]
           if missing:
               print(f"::error::missing summary markers: {', '.join(missing)}")
+              print(f"::notice::summary path: {summary_path}")
+              print(f"::notice::summary bytes: {len(body.encode('utf-8', errors='replace'))}")
               print("::group::summary body")
-              print(body)
+              # Keep diagnostics readable in CI logs.
+              max_chars = 4000
+              print(body[:max_chars])
+              if len(body) > max_chars:
+                  print(f"... [truncated {len(body) - max_chars} chars]")
               print("::endgroup::")
               sys.exit(1)
           PY


### PR DESCRIPTION
## Summary
- keep strict summary marker guards in `coldstep-detect-demo-dev`
- reduce CI log noise by truncating dumped summary body to 4k chars on failure
- add concise notices for summary path and byte size

## Why
Now that core failures are fixed, full-body dumps are overly verbose in CI. This keeps diagnostics useful without flooding logs.