### PR TITLE
feat(detect-report): improve OTX triage signal and destination context

### DIFF
--- a/scripts/coldstep_detect_report/build_ip_classification_model.py
+++ b/scripts/coldstep_detect_report/build_ip_classification_model.py
@@ -15,6 +15,42 @@ _SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9_./\\:-]+$")
 _EGRESS_TYPES = {"tcp", "udp", "http", "tls"}
 _SEVERITY_ORDER = {"Critical": 0, "High": 1, "Medium": 2, "Low": 3, "Informational": 4}
 _CONFIDENCE_ORDER = {"A": 0, "B": 1, "C": 2}
+_KNOWN_DESTINATION_HINTS = {
+    "1.1.1.1": "one.one.one.one",
+    "1.0.0.1": "one.one.one.one",
+    "8.8.8.8": "dns.google",
+    "8.8.4.4": "dns.google",
+    "9.9.9.9": "dns.quad9.net",
+    "149.112.112.112": "dns.quad9.net",
+    "208.67.222.222": "resolver1.opendns.com",
+    "208.67.220.220": "resolver2.opendns.com",
+    "127.0.0.1": "localhost",
+    "127.0.0.53": "localhost.systemd-resolved",
+    "168.63.129.16": "azure-platform-dns",
+}
+
+
+def classify_destination_context(*, ip: str, fqdn: str, rdns: str) -> str:
+    if ip.startswith("127."):
+        return "Localhost"
+    if ip == "168.63.129.16":
+        return "Platform DNS"
+    known_resolver_ips = {
+        "1.1.1.1",
+        "1.0.0.1",
+        "8.8.8.8",
+        "8.8.4.4",
+        "9.9.9.9",
+        "149.112.112.112",
+        "208.67.222.222",
+        "208.67.220.220",
+    }
+    if ip in known_resolver_ips:
+        return "Known Public Resolver"
+    name = (fqdn or rdns or "").lower()
+    if any(token in name for token in ("resolver", "dns.google", "one.one.one.one", "quad9", "opendns")):
+        return "Known Public Resolver"
+    return "External"
 
 
 def _safe_workspace_path(raw: str, *, var_name: str = "path") -> str:
@@ -146,20 +182,27 @@ def _score_row(*, ip: str, row: dict, otx_indicator: dict | None, dns_lookup: di
         confidence_score += 4
         evidence_flags.append("PULSE:repeat")
 
+    has_threat_signal = (
+        verdict == "malicious"
+        or pulse_severity in {"Critical", "High", "Medium"}
+        or pulse_count > 0
+    )
+
     if rdns:
         confidence_score += 6
         evidence_flags.append("RDNS:present")
         corroboration += 1
-    else:
+    elif has_threat_signal:
         confidence_score -= 8
         uncertainty_flags.append("rdns-missing")
         evidence_flags.append("RDNS:missing")
 
     fqdn = str(row.get("fqdn", "") or "")
     if not fqdn:
-        confidence_score -= 5
-        uncertainty_flags.append("fqdn-missing")
-        evidence_flags.append("FQDN:missing")
+        if has_threat_signal:
+            confidence_score -= 5
+            uncertainty_flags.append("fqdn-missing")
+            evidence_flags.append("FQDN:missing")
     else:
         confidence_score += 4
         evidence_flags.append("FQDN:present")
@@ -229,6 +272,10 @@ def build(*, current_jsonl: str, now: dt.datetime | None = None) -> dict:
         if hints:
             # Deterministic tie-break: highest count then lexicographic.
             fqdn = sorted(hints.items(), key=lambda item: (-item[1], item[0]))[0][0]
+        elif ip in _KNOWN_DESTINATION_HINTS:
+            # Deterministic fallback for known infra/resolver destinations when
+            # event-level hints and rDNS are absent.
+            fqdn = _KNOWN_DESTINATION_HINTS[ip]
         rows.append(
             {
                 "ip": ip,
@@ -283,6 +330,11 @@ def project_otx_classification(model: dict) -> dict:
                 "confidence_score": score["confidence_score"],
                 "evidence_flags": score["evidence_flags"],
                 "uncertainty_flags": score["uncertainty_flags"],
+                "context": classify_destination_context(
+                    ip=str(ip or ""),
+                    fqdn=str(row.get("fqdn", "") or ""),
+                    rdns=str(dns_lookup.get(ip, row.get("rdns", "")) or ""),
+                ),
             }
         )
     items.sort(

--- a/scripts/coldstep_detect_report/render_ip_classification_summary.py
+++ b/scripts/coldstep_detect_report/render_ip_classification_summary.py
@@ -14,7 +14,10 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from scripts.coldstep_detect_report.build_ip_classification_model import project_otx_classification
+from scripts.coldstep_detect_report.build_ip_classification_model import (
+    classify_destination_context,
+    project_otx_classification,
+)
 
 _SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9_./\\:-]+$")
 PULSE_GLYPH = {
@@ -33,6 +36,13 @@ SEVERITY_GLYPH = {
 }
 _SEVERITY_ORDER = {"Critical": 0, "High": 1, "Medium": 2, "Low": 3, "Informational": 4}
 _CONFIDENCE_ORDER = {"A": 0, "B": 1, "C": 2}
+_PULSE_SEVERITY_ORDER = ("Critical", "High", "Medium", "Low", "Informational")
+_KNOWN_INFRA_SUFFIXES = (
+    ".githubapp.com",
+    ".cloudapp.azure.com",
+    ".google.com",
+    ".google",
+)
 
 
 def _safe_workspace_path(raw: str, *, var_name: str = "path") -> str:
@@ -53,6 +63,34 @@ def _safe_workspace_path(raw: str, *, var_name: str = "path") -> str:
         if os.path.commonpath([resolved, root]) == root:
             return resolved
     raise ValueError(f"{var_name} resolves outside trusted roots: {resolved!r}")
+
+
+def _spark(value: int, max_value: int, *, width: int = 12) -> str:
+    if max_value <= 0 or value <= 0:
+        return " " * width
+    filled = max(1, int(round((value / max_value) * width)))
+    filled = min(width, filled)
+    return ("#" * filled).ljust(width)
+
+
+def _is_known_infra_row(row: dict) -> bool:
+    context = str(row.get("context", "") or "")
+    if context in {"Localhost", "Platform DNS", "Known Public Resolver"}:
+        return True
+    ip = str(row.get("ip", ""))
+    fqdn = str(row.get("fqdn", "")).lower()
+    rdns = str(row.get("rdns", "")).lower()
+    if ip.startswith("127."):
+        return True
+    if ip == "168.63.129.16":
+        return True
+    names = [fqdn, rdns]
+    for name in names:
+        if not name:
+            continue
+        if any(name.endswith(suffix) for suffix in _KNOWN_INFRA_SUFFIXES):
+            return True
+    return False
 
 
 def render_markdown(model: dict) -> str:
@@ -77,6 +115,10 @@ def render_markdown(model: dict) -> str:
     elif top_sev == "Medium":
         recommendation = "investigate"
 
+    suspicious_rows = [
+        row for row in rows if str(row.get("severity", "Informational")) not in {"Informational", "Low"}
+    ]
+    known_infra_rows = [row for row in rows if _is_known_infra_row(row)]
     lines = [
         "## Coldstep detect - IP classification",
         "",
@@ -86,9 +128,11 @@ def render_markdown(model: dict) -> str:
         f"- Confidence grade: {top_conf}",
         f"- Why: {', '.join(top_flags) if top_flags else 'insufficient corroborated signal'}",
         f"- Immediate action: {recommendation}",
+        f"- Triage signal rows: {len(suspicious_rows)} / {len(rows)}",
+        f"- Known infra rows: {len(known_infra_rows)}",
         "",
-        "| IP | FQDN | rDNS | Classification | Severity | Confidence | Evidence flags | Pulse severity | Pulse count |",
-        "|---|---|---|---|---|---|---|---|---:|",
+        "| IP | FQDN | rDNS | Classification | Context | Severity | Confidence | Evidence flags | Pulse severity | Pulse count |",
+        "|---|---|---|---|---|---|---|---|---|---:|",
     ]
     uncertainty_rows = 0
     top_uncertainty: dict[str, int] = {}
@@ -97,7 +141,7 @@ def render_markdown(model: dict) -> str:
         sev_with_glyph = f"{PULSE_GLYPH.get(severity, '⬜')} {severity}"
         risk_sev = str(row.get("severity", "Informational"))
         risk_with_glyph = f"{SEVERITY_GLYPH.get(risk_sev, '⬜')} {risk_sev}"
-        evidence_flags = ", ".join(str(f) for f in row.get("evidence_flags", []))
+        evidence_flags = ", ".join(str(f) for f in row.get("evidence_flags", [])) or "-"
         for flag in row.get("uncertainty_flags", []) or []:
             flag_s = str(flag)
             top_uncertainty[flag_s] = top_uncertainty.get(flag_s, 0) + 1
@@ -105,11 +149,79 @@ def render_markdown(model: dict) -> str:
             uncertainty_rows += 1
         lines.append(
             f"| {row.get('ip', '')} | {row.get('fqdn', '')} | {row.get('rdns', '')} | "
-            f"{row.get('classification', 'unidentified')} | {risk_with_glyph} | {row.get('confidence', 'C')} | "
+            f"{row.get('classification', 'unidentified')} | "
+            f"{row.get('context') or classify_destination_context(ip=str(row.get('ip', '') or ''), fqdn=str(row.get('fqdn', '') or ''), rdns=str(row.get('rdns', '') or ''))} | "
+            f"{risk_with_glyph} | {row.get('confidence', 'C')} | "
             f"{evidence_flags} | {sev_with_glyph} | {row.get('pulse_count', 0)} |"
         )
     if not rows:
-        lines.append("| (none) |  |  | unidentified | 🟩 Informational | C |  | 🟩 Informational | 0 |")
+        lines.append("| (none) |  |  | unidentified | External | 🟩 Informational | C |  | 🟩 Informational | 0 |")
+
+    lines.extend(
+        [
+            "",
+            "### Known infra snapshot",
+            "",
+            f"- Rows classified as baseline infra/noise candidates: {len(known_infra_rows)}",
+        ]
+    )
+    if known_infra_rows:
+        top_known = sorted(
+            known_infra_rows,
+            key=lambda item: (-int(item.get("pulse_count", 0)), str(item.get("ip", ""))),
+        )[:5]
+        for row in top_known:
+            label = str(row.get("ip", ""))
+            fqdn = str(row.get("fqdn", ""))
+            if fqdn:
+                label = f"{label} ({fqdn})"
+            lines.append(f"- `{label}` pulse={int(row.get('pulse_count', 0))}")
+    else:
+        lines.append("- No known infra rows identified in this run.")
+
+    pulse_totals: dict[str, int] = {name: 0 for name in _PULSE_SEVERITY_ORDER}
+    for row in rows:
+        sev = str(row.get("pulse_severity", "Informational"))
+        if sev not in pulse_totals:
+            pulse_totals[sev] = 0
+        pulse_totals[sev] += int(row.get("pulse_count", 0))
+    max_pulse = max(pulse_totals.values()) if pulse_totals else 0
+    total_pulses = sum(pulse_totals.values())
+    lines.extend(
+        [
+            "",
+            "### OTX pulse chart",
+            "",
+            f"- Total pulse count observed: {total_pulses}",
+            "",
+            "| Pulse severity | Pulse volume | Count |",
+            "|---|---|---:|",
+        ]
+    )
+    for sev in _PULSE_SEVERITY_ORDER:
+        volume = pulse_totals.get(sev, 0)
+        glyph = PULSE_GLYPH.get(sev, "⬜")
+        lines.append(f"| {glyph} {sev} | `{_spark(volume, max_pulse)}` | {volume} |")
+
+    top_pulse_rows = [r for r in rows if int(r.get("pulse_count", 0)) > 0]
+    top_pulse_rows.sort(key=lambda item: (-int(item.get("pulse_count", 0)), str(item.get("ip", ""))))
+    lines.extend(
+        [
+            "",
+            "#### Top pulse-backed destinations",
+            "",
+        ]
+    )
+    if top_pulse_rows:
+        max_top = int(top_pulse_rows[0].get("pulse_count", 0))
+        for row in top_pulse_rows[:5]:
+            ip = str(row.get("ip", ""))
+            fqdn = str(row.get("fqdn", ""))
+            pulse_count = int(row.get("pulse_count", 0))
+            label = f"{ip} ({fqdn})" if fqdn else ip
+            lines.append(f"- `{label}` `{_spark(pulse_count, max_top)}` {pulse_count}")
+    else:
+        lines.append("- No pulse-backed destinations in this run.")
     lines.extend(
         [
             "",

--- a/scripts/test_coldstep_detect_report_build_ip_classification_model.py
+++ b/scripts/test_coldstep_detect_report_build_ip_classification_model.py
@@ -62,6 +62,20 @@ class BuildIPClassificationModelTests(unittest.TestCase):
         self.assertEqual(row["confidence"], "A")
         self.assertIn("OTX:strong", row["evidence_flags"])
         self.assertEqual(row["uncertainty_flags"], [])
+        self.assertEqual(row["context"], "Known Public Resolver")
+
+    def test_build_applies_known_destination_fallback_hints(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            jsonl = Path(td) / "events.jsonl"
+            jsonl.write_text(
+                '{"type":"udp","dst":"8.8.8.8"}\n'
+                '{"type":"udp","dst":"127.0.0.1"}\n',
+                encoding="utf-8",
+            )
+            model = build(current_jsonl=str(jsonl), now=dt.datetime(2026, 4, 20, tzinfo=dt.timezone.utc))
+            rows = {row["ip"]: row for row in model["ip_classification"]}
+            self.assertEqual(rows["8.8.8.8"]["fqdn"], "dns.google")
+            self.assertEqual(rows["127.0.0.1"]["fqdn"], "localhost")
 
     def test_critical_gate_downgrades_when_not_corroborated(self) -> None:
         model = {
@@ -92,6 +106,28 @@ class BuildIPClassificationModelTests(unittest.TestCase):
         row = projected["ip_classification"][0]
         self.assertEqual(row["severity"], "High")
         self.assertIn("critical-gate-downgrade", row["uncertainty_flags"])
+
+    def test_does_not_flag_missing_rdns_or_fqdn_for_informational_rows(self) -> None:
+        model = {
+            "ip_classification": [
+                {
+                    "ip": "203.0.113.5",
+                    "fqdn": "",
+                    "rdns": "",
+                    "classification": "unidentified",
+                    "pulse_severity": "Informational",
+                    "pulse_count": 0,
+                }
+            ],
+            "dns_lookups": {},
+            "otx": {"indicators": []},
+        }
+        projected = project_otx_classification(model)
+        row = projected["ip_classification"][0]
+        self.assertEqual(row["severity"], "Informational")
+        self.assertEqual(row["evidence_flags"], [])
+        self.assertNotIn("rdns-missing", row["uncertainty_flags"])
+        self.assertNotIn("fqdn-missing", row["uncertainty_flags"])
 
 
 if __name__ == "__main__":

--- a/scripts/test_coldstep_detect_report_render_ip_classification_summary.py
+++ b/scripts/test_coldstep_detect_report_render_ip_classification_summary.py
@@ -47,8 +47,16 @@ class RenderIPClassificationSummaryTests(unittest.TestCase):
             self.assertIn("## Coldstep detect - IP classification", out)
             self.assertIn("### Decision banner", out)
             self.assertIn("Highest severity: 🟥 Critical", out)
-            self.assertIn("| 1.1.1.1 | one.one.one.one | one.one.one.one | clean | 🟩 Low | B | OTX:clean | 🟩 Informational | 0 |", out)
-            self.assertIn("| 8.8.8.8 | dns.google | dns.google | malicious | 🟥 Critical | A | OTX:strong, PULSE:volume | 🟧 High | 12 |", out)
+            self.assertIn("Triage signal rows:", out)
+            self.assertIn("Known infra rows:", out)
+            self.assertIn("| 1.1.1.1 | one.one.one.one | one.one.one.one | clean | Known Public Resolver | 🟩 Low | B | OTX:clean | 🟩 Informational | 0 |", out)
+            self.assertIn("| 8.8.8.8 | dns.google | dns.google | malicious | Known Public Resolver | 🟥 Critical | A | OTX:strong, PULSE:volume | 🟧 High | 12 |", out)
+            self.assertIn("### Known infra snapshot", out)
+            self.assertIn("`8.8.8.8 (dns.google)` pulse=12", out)
+            self.assertIn("### OTX pulse chart", out)
+            self.assertIn("| 🟧 High |", out)
+            self.assertIn("#### Top pulse-backed destinations", out)
+            self.assertIn("`8.8.8.8 (dns.google)`", out)
             self.assertIn("### Uncertainty and contradictions", out)
             self.assertIn("### Action queue", out)
             self.assertNotIn("Capabilities", out)
@@ -87,6 +95,52 @@ class RenderIPClassificationSummaryTests(unittest.TestCase):
         out = render_markdown(model)
         self.assertIn("🟥 Critical", out)
         self.assertIn("🟩 Informational", out)
+
+    def test_pulse_chart_handles_no_pulses(self) -> None:
+        model = {
+            "ip_classification": [
+                {
+                    "ip": "203.0.113.5",
+                    "fqdn": "",
+                    "rdns": "",
+                    "classification": "unidentified",
+                    "severity": "Informational",
+                    "confidence": "C",
+                    "evidence_flags": [],
+                    "uncertainty_flags": [],
+                    "pulse_severity": "Informational",
+                    "pulse_count": 0,
+                }
+            ],
+            "dns_lookups": {},
+            "otx": None,
+        }
+        out = render_markdown(model)
+        self.assertIn("### OTX pulse chart", out)
+        self.assertIn("Total pulse count observed: 0", out)
+        self.assertIn("No pulse-backed destinations in this run.", out)
+
+    def test_summary_renders_dash_when_evidence_flags_empty(self) -> None:
+        model = {
+            "ip_classification": [
+                {
+                    "ip": "203.0.113.5",
+                    "fqdn": "",
+                    "rdns": "",
+                    "classification": "unidentified",
+                    "severity": "Informational",
+                    "confidence": "C",
+                    "evidence_flags": [],
+                    "uncertainty_flags": [],
+                    "pulse_severity": "Informational",
+                    "pulse_count": 0,
+                }
+            ],
+            "dns_lookups": {},
+            "otx": None,
+        }
+        out = render_markdown(model)
+        self.assertIn("| 203.0.113.5 |  |  | unidentified | External | 🟩 Informational | C | - | 🟩 Informational | 0 |", out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add deterministic known destination fallback hints (Google DNS, Quad9, OpenDNS, localhost, systemd-resolved stub, Azure platform DNS).
- Emit **Context** per row (Localhost, Platform DNS, Known Public Resolver, External) and show it in the step summary table.
- Add **OTX pulse chart**: pulse volume by severity plus top pulse-backed destinations (ASCII spark bars).
- Reduce noise: missing FQDN/DNS penalties only when there is threat signal (malicious verdict or elevated pulse).

## Test plan
- python -m unittest scripts.test_coldstep_detect_report_build_ip_classification_model scripts.test_coldstep_detect_report_render_ip_classification_summary (9 tests, pass)

## Note
coldstep-detect-demo-dev will pick this up on merge; no workflow file change in this PR.
