### PR TITLE
fix(otx,rdns): enrich ip_classification rows on detect-dev

### DIFF
--- a/scripts/coldstep_dns/enrich_rdns.py
+++ b/scripts/coldstep_dns/enrich_rdns.py
@@ -1,8 +1,9 @@
 """Reverse-DNS enrichment orchestrator.
 
 Reads a coldstep report-model.json, gathers every IPv4 indicator from the
-egress sankey + diff buckets, runs a best-effort PTR batch via the rdns
-resolver, and writes `model.dns_lookups: {ip: hostname}` back in place.
+egress sankey + diff buckets **and from `ip_classification`** (IP-only
+detect-dev model), runs a best-effort PTR batch via the rdns resolver, and
+writes `model.dns_lookups: {ip: hostname}` back in place.
 
 Contract mirrors the OTX enricher:
 - Always exits 0 (third-party / I/O issues never fail the detect job).
@@ -23,7 +24,16 @@ import tempfile
 from pathlib import Path
 from typing import Iterable, Optional
 
+import ipaddress
+
 from scripts.coldstep_dns.rdns import Resolver, _default_resolver, lookup_batch
+
+
+def _is_ipv4(value: str) -> bool:
+    try:
+        return isinstance(ipaddress.ip_address(value), ipaddress.IPv4Address)
+    except ValueError:
+        return False
 
 
 def _gather_ipv4_indicators(model: dict) -> list[str]:
@@ -41,6 +51,14 @@ def _gather_ipv4_indicators(model: dict) -> list[str]:
     for bucket in ("traffic_new", "traffic_gone", "traffic_changed"):
         for entry in (model.get("diff") or {}).get(bucket, []):
             add_iter(entry.get("indicators") or [])
+    for row in model.get("ip_classification") or []:
+        if not isinstance(row, dict):
+            continue
+        ind = str(row.get("ip") or "").strip()
+        if not ind or not _is_ipv4(ind) or ind in seen:
+            continue
+        seen.add(ind)
+        out.append(ind)
     return out
 
 

--- a/scripts/coldstep_otx/enrich.py
+++ b/scripts/coldstep_otx/enrich.py
@@ -1,8 +1,9 @@
 """OTX enrichment orchestrator.
 
 Reads a coldstep report-model.json (schema v2 with `otx: null` placeholder),
-walks every indicator-bearing slot (egress sankey + diff buckets), classifies
-each unique indicator via OTX, and writes the enriched model back in place.
+walks every indicator-bearing slot (**egress sankey**, **diff buckets**, and
+**ip_classification** rows from the IP-only detect-dev model), classifies each
+unique indicator via OTX, and writes the enriched model back in place.
 
 Constraints:
 - Wall-clock budget (default 30s). Budget exhaustion -> partial_results: true,
@@ -69,6 +70,15 @@ def _gather_indicators(model: dict) -> list[tuple[str, str]]:
     for bucket in ("traffic_new", "traffic_gone", "traffic_changed"):
         for entry in (model.get("diff") or {}).get(bucket, []):
             add_iter(entry.get("indicators") or [])
+    # IP classification model (coldstep-detect-demo-dev): deduped IPs + FQDN hints only.
+    for row in model.get("ip_classification") or []:
+        if not isinstance(row, dict):
+            continue
+        for key in ("ip", "fqdn"):
+            ind = str(row.get(key) or "").strip()
+            if not ind or ind in seen:
+                continue
+            seen[ind] = "IPv4" if _is_ipv4(ind) else "hostname"
     # Stable sort: IPv4 first, then hostnames; within each, alphabetical.
     return sorted(seen.items(), key=lambda kv: (kv[1] != "IPv4", kv[0]))
 

--- a/scripts/test_coldstep_dns_enrich_rdns.py
+++ b/scripts/test_coldstep_dns_enrich_rdns.py
@@ -61,6 +61,27 @@ class EnrichRdnsTests(unittest.TestCase):
         finally:
             os.unlink(path)
 
+    def test_ip_classification_rows_supply_ipv4_for_rdns(self):
+        model = {
+            "schema_version": "ip-classification-v1",
+            "ip_classification": [
+                {"ip": "8.8.8.8", "fqdn": "dns.google"},
+            ],
+        }
+        path = self._write_model(model)
+        try:
+            rc = enrich_rdns.run(
+                model_path=path,
+                resolver=lambda ip: "dns.google" if ip == "8.8.8.8" else None,
+                wall_budget_s=2.0,
+                stderr=io.StringIO(),
+            )
+            self.assertEqual(rc, 0)
+            data = json.loads(Path(path).read_text(encoding="utf-8"))
+            self.assertEqual(data["dns_lookups"]["8.8.8.8"], "dns.google")
+        finally:
+            os.unlink(path)
+
     def test_no_resolvable_ips_writes_empty_dict(self):
         path = self._write_model(_v2_model())
         try:

--- a/scripts/test_coldstep_otx_enrich.py
+++ b/scripts/test_coldstep_otx_enrich.py
@@ -393,6 +393,46 @@ class EnrichOrchestratorTests(unittest.TestCase):
         finally:
             os.unlink(path)
 
+    def test_ip_classification_rows_supply_otx_indicators(self):
+        """coldstep-detect-demo-dev builds ip_classification-only models; enrich must query OTX."""
+        clean = _fix("general-clean.json")
+        fake = _FakeClient({"8.8.8.8": clean, "dns.google": clean})
+        model = {
+            "schema_version": "ip-classification-v1",
+            "generated_at": "2026-04-20T00:00:00Z",
+            "ip_classification": [
+                {
+                    "ip": "8.8.8.8",
+                    "fqdn": "dns.google",
+                    "rdns": "",
+                    "classification": "unidentified",
+                    "pulse_severity": "Informational",
+                    "pulse_count": 0,
+                }
+            ],
+            "dns_lookups": {},
+            "otx": None,
+        }
+        path = self._write_model(model)
+        try:
+            rc = enrich.run(
+                model_path=path,
+                api_key="k",
+                client_factory=lambda k: fake,
+                stderr=io.StringIO(),
+                now_monotonic=lambda: 0.0,
+                wall_budget_ms=30000,
+            )
+            self.assertEqual(rc, 0)
+            data = json.loads(Path(path).read_text(encoding="utf-8"))
+            self.assertFalse(data["otx"]["skipped"])
+            inds = {row["indicator"]: row for row in data["otx"]["indicators"]}
+            self.assertEqual(inds["8.8.8.8"]["verdict"], "clean")
+            self.assertEqual(inds["dns.google"]["verdict"], "clean")
+            self.assertEqual(len(fake.calls), 2)
+        finally:
+            os.unlink(path)
+
 
 class EnrichSanitizationParityTests(unittest.TestCase):
     """F-P2-01: enrich.py must accept paths under the same trusted-root set as


### PR DESCRIPTION
## Problem
coldstep-detect-demo-dev builds a minimal report model with only \ip_classification\. OTX and rDNS enrichers gathered indicators only from \egress_sankey\ + diff buckets, so enrichment was skipped (\
o indicators in model\) and pulse/rDNS stayed empty.

## Change
- **OTX:** also collect \ip\ and \qdn\ from each \ip_classification\ row.
- **rDNS:** also collect IPv4 \ip\ values from \ip_classification\ for PTR batch.

## Tests
\python -m unittest scripts.test_coldstep_otx_enrich.EnrichOrchestratorTests scripts.test_coldstep_dns_enrich_rdns.EnrichRdnsTests\ (22 tests, pass)
