### PR TITLE
fix(ci): replace mojibake em-dashes and add encoding CI guard

### DIFF
--- a/.github/workflows/coldstep-ci-runner.yml
+++ b/.github/workflows/coldstep-ci-runner.yml
@@ -42,6 +42,8 @@ jobs:
           go-version: '1.25.x'
       - name: gofmt check
         run: bash scripts/check-gofmt.sh
+      - name: encoding check
+        run: bash scripts/check-encoding.sh
 
   action_manifest:
     runs-on: ubuntu-latest
@@ -263,7 +265,7 @@ jobs:
           # pull_request uses GITHUB_REF_NAME like "21/merge"; use the head branch so gh finds prior runs.
           branch="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
           # This job lives in a reusable workflow; runs are indexed under the entry workflow (coldstep-ci.yml), not
-          # coldstep-ci-runner.yml ΓÇö listing by the callee filename returns no rows and breaks baseline diff.
+          # coldstep-ci-runner.yml — listing by the callee filename returns no rows and breaks baseline diff.
           entry_workflow="coldstep-ci.yml"
           baseline_run="$(
             gh run list --workflow "${entry_workflow}" --branch "${branch}" --status success --limit 30 --json databaseId \
@@ -389,7 +391,7 @@ jobs:
         with:
           go-version: '1.25.x'
 
-      # Cache skips clang+bpf rebuild when sources unchanged ΓÇö composite uses release-path so startup
+      # Cache skips clang+bpf rebuild when sources unchanged — composite uses release-path so startup
       # stays fast under fail-on-error (BPF verifier remains on first load inside the agent).
       - uses: actions/cache@v5
         id: coldstep-bin-cache
@@ -422,7 +424,7 @@ jobs:
           test -n "${ip}"
           echo "${ip} theclouddj.com" | sudo tee -a /etc/hosts >/dev/null
 
-      - name: Start Coldstep (defend ΓÇö blocks non-allowlisted IPv4 egress)
+      - name: Start Coldstep (defend — blocks non-allowlisted IPv4 egress)
         uses: ./
         with:
           phase: start
@@ -433,12 +435,12 @@ jobs:
           allowed-domains: theclouddj.com archive.ubuntu.com azure.archive.ubuntu.com
           allowed-ips: 1.1.1.1
 
-      - name: Allowed target ΓÇö nmap port 80 (theclouddj.com)
+      - name: Allowed target — nmap port 80 (theclouddj.com)
         run: |
           set -euo pipefail
           nmap -4 -Pn -p 80 --max-retries 1 --host-timeout 60s theclouddj.com
 
-      - name: Allowed IP target ΓÇö direct TCP connect (1.1.1.1:443)
+      - name: Allowed IP target — direct TCP connect (1.1.1.1:443)
         run: |
           set -euo pipefail
           if ! timeout 10 nc -4 -z -w 4 1.1.1.1 443 2>/dev/null; then
@@ -451,7 +453,7 @@ jobs:
           set -euo pipefail
           echo '192.0.2.1 example.com' | sudo tee -a /etc/hosts >/dev/null
 
-      - name: Disallowed target ΓÇö curl example.com (expect deny, not a successful fetch)
+      - name: Disallowed target — curl example.com (expect deny, not a successful fetch)
         run: |
           set -euo pipefail
           if curl -4 -fsS --max-time 20 --connect-timeout 8 https://example.com/ >/dev/null 2>&1; then
@@ -459,7 +461,7 @@ jobs:
             exit 1
           fi
 
-      - name: Disallowed IP target ΓÇö direct TCP connect (93.184.216.34:443, expect deny)
+      - name: Disallowed IP target — direct TCP connect (93.184.216.34:443, expect deny)
         run: |
           set -euo pipefail
           if timeout 10 nc -4 -z -w 4 93.184.216.34 443 2>/dev/null; then

--- a/.github/workflows/coldstep-demo.yml
+++ b/.github/workflows/coldstep-demo.yml
@@ -1,6 +1,6 @@
-# Job `detect-mode`: observe-only (`mode: detect`). Host allowlist affects policy labels only ΓÇö it does NOT block traffic.
+# Job `detect-mode`: observe-only (`mode: detect`). Host allowlist affects policy labels only — it does NOT block traffic.
 #
-# Job `defend-mode` (defend mode ΓÇö CI egress-block smoke): same BPF stack as product `mode: defend` (cgroup block non-allowlisted egress). apt runs before the
+# Job `defend-mode` (defend mode — CI egress-block smoke): same BPF stack as product `mode: defend` (cgroup block non-allowlisted egress). apt runs before the
 # agent (stub DNS / mirrors break once enforce is up). theclouddj.com is allowlisted; hosts pins avoid resolver UDP
 # after enforce. example.com is pinned to TEST-NET-1 (192.0.2.1) so curl is deterministically denied.
 #
@@ -169,7 +169,7 @@ jobs:
           {
             echo "## Detect verification"
             echo ""
-            echo "- **Result:** pass ΓÇö required JSONL types and digest sections present (\`ubuntu-latest\`). Full matrix is redundant here; inspect \`.coldstep-detect.md\` if needed."
+            echo "- **Result:** pass — required JSONL types and digest sections present (\`ubuntu-latest\`). Full matrix is redundant here; inspect \`.coldstep-detect.md\` if needed."
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Compare detect output with previous successful run (opt-in)
@@ -311,7 +311,7 @@ jobs:
           test -n "${ip}"
           echo "${ip} theclouddj.com" | sudo tee -a /etc/hosts >/dev/null
 
-      - name: Start Coldstep (defend ΓÇö blocks non-allowlisted IPv4 egress)
+      - name: Start Coldstep (defend — blocks non-allowlisted IPv4 egress)
         uses: ./
         with:
           phase: start
@@ -323,12 +323,12 @@ jobs:
           allowed-ips: 1.1.1.1
           release-path: bin/coldstep
 
-      - name: Allowed target ΓÇö nmap port 80 (theclouddj.com)
+      - name: Allowed target — nmap port 80 (theclouddj.com)
         run: |
           set -euo pipefail
           nmap -4 -Pn -p 80 --max-retries 1 --host-timeout 60s theclouddj.com
 
-      - name: Allowed IP target ΓÇö direct TCP connect (1.1.1.1:443)
+      - name: Allowed IP target — direct TCP connect (1.1.1.1:443)
         run: |
           set -euo pipefail
           if ! timeout 10 nc -4 -z -w 4 1.1.1.1 443 2>/dev/null; then
@@ -343,7 +343,7 @@ jobs:
           set -euo pipefail
           echo '192.0.2.1 example.com' | sudo tee -a /etc/hosts >/dev/null
 
-      - name: Disallowed target ΓÇö curl example.com (expect deny, not a successful fetch)
+      - name: Disallowed target — curl example.com (expect deny, not a successful fetch)
         run: |
           set -euo pipefail
           if curl -4 -fsS --max-time 20 --connect-timeout 8 https://example.com/ >/dev/null 2>&1; then
@@ -351,7 +351,7 @@ jobs:
             exit 1
           fi
 
-      - name: Disallowed IP target ΓÇö direct TCP connect (93.184.216.34:443, expect deny)
+      - name: Disallowed IP target — direct TCP connect (93.184.216.34:443, expect deny)
         run: |
           set -euo pipefail
           if timeout 10 nc -4 -z -w 4 93.184.216.34 443 2>/dev/null; then

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -30,7 +30,7 @@ The table below summarizes **third-party and co-licensed material** that appears
 
 | Component | Where | License(s) |
 | :-------- | :---- | :----------- |
-| **eBPF programs** (`bpf/*.bpf.c`, included `*.inc`) | In-tree | **`Dual BSD/GPL`** via `char LICENSE[] SEC("license") = "Dual BSD/GPL";` ΓÇö the usual Linux kernel dual license so programs can be used under **GPL-2.0-only** (kernel context) or **BSD-2-Clause** (see kernel documentation on dual-licensed modules). |
+| **eBPF programs** (`bpf/*.bpf.c`, included `*.inc`) | In-tree | **`Dual BSD/GPL`** via `char LICENSE[] SEC("license") = "Dual BSD/GPL";` — the usual Linux kernel dual license so programs can be used under **GPL-2.0-only** (kernel context) or **BSD-2-Clause** (see kernel documentation on dual-licensed modules). |
 | **[`github.com/cilium/ebpf`](https://github.com/cilium/ebpf)** v0.21.0 | Go module | **MIT** |
 | **[`golang.org/x/sys`](https://pkg.go.dev/golang.org/x/sys)** v0.43.0 | Go module | **BSD-3-Clause** (Go Authors; same style of license as the Go toolchain ecosystem) |
 | **GitHub Actions SDK** (`@actions/core`, `@actions/github`, `@actions/http-client`, `@actions/exec`, `@actions/io`) | npm / bundled `dist/` | **MIT** |
@@ -42,7 +42,7 @@ The table below summarizes **third-party and co-licensed material** that appears
 
 ### Notes
 
-- **Distributed action bundle (release):** tag-triggered **`supply-chain-attest`** publishes an archive that includes **`action.yml`**, **`bin/coldstep`**, **`bin/coldstep-action`**, **`bin/coldstep-report`**, **`scripts/build-agent-linux.sh`**, and optional **`scripts/coldstep_bootstrap/`** text packs ΓÇö the composite consumers actually ship and run. Treat any bundled **`dist/`** output from the legacy esbuild/npm toolchain as a maintenance artifact checked into the repo for CodeQL (**same npm licenses** as above when present).
+- **Distributed action bundle (release):** tag-triggered **`supply-chain-attest`** publishes an archive that includes **`action.yml`**, **`bin/coldstep`**, **`bin/coldstep-action`**, **`bin/coldstep-report`**, **`scripts/build-agent-linux.sh`**, and optional **`scripts/coldstep_bootstrap/`** text packs — the composite consumers actually ship and run. Treat any bundled **`dist/`** output from the legacy esbuild/npm toolchain as a maintenance artifact checked into the repo for CodeQL (**same npm licenses** as above when present).
 - **Kernel / BTF at build time:** `scripts/build-agent-linux.sh` may generate **`bpf/vmlinux.h`** from the **running kernelΓÇÖs BTF**. That header is derived from kernel metadata; building or loading BPF against a given kernel does not re-license this repoΓÇÖs Go/TS sources, but downstream packaging should respect **kernel COPYING** and **GPL** obligations where they apply to combined or derivative works (consult your counsel for distribution scenarios).
 
 If you believe an entry is missing or a license changed upstream, please open an issue or pull request with a pointer to the upstream `LICENSE` file or SPDX metadata.

--- a/scripts/check-encoding.sh
+++ b/scripts/check-encoding.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# check-encoding.sh — scan tracked source files for known mojibake byte sequences.
+#
+# The em-dash U+2014 (—, UTF-8: E2 80 94) silently corrupts into the three-codepoint
+# Windows-1252 mojibake sequence "ΓÇö" (bytes CE 93 C3 87 C3 B6) when files are saved
+# in a non-UTF-8 editor or copy-pasted from Windows terminals. Fail CI if found.
+set -euo pipefail
+
+hits=$(git ls-files -- '*.go' '*.sh' '*.yml' '*.yaml' '*.ts' '*.md' | python3 -c "
+import sys, os
+moj = bytes([0xce, 0x93, 0xc3, 0x87, 0xc3, 0xb6])
+bad = []
+for f in sys.stdin.read().splitlines():
+    try:
+        if moj in open(f, 'rb').read():
+            bad.append(f)
+    except OSError:
+        pass
+print('\n'.join(bad))
+")
+
+if [ -n "$hits" ]; then
+  echo "::error::Mojibake em-dash (ΓÇö, bytes CE93 C387 C3B6) found in tracked files:"
+  echo "$hits"
+  echo ""
+  echo "Fix: replace the byte sequence with the proper em-dash '—' (U+2014, UTF-8: E2 80 94)"
+  echo "     or ASCII ' - '. Use binary-safe replacement (e.g. python open(f,'rb').replace)."
+  exit 1
+fi
+
+echo "encoding check passed — no mojibake sequences found"

--- a/scripts/check-encoding.sh
+++ b/scripts/check-encoding.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # check-encoding.sh — scan tracked source files for known mojibake byte sequences.
 #
-# The em-dash U+2014 (—, UTF-8: E2 80 94) silently corrupts into the three-codepoint
-# Windows-1252 mojibake sequence "ΓÇö" (bytes CE 93 C3 87 C3 B6) when files are saved
+# The em-dash U+2014 (UTF-8: E2 80 94) silently corrupts into the three-codepoint
+# Windows-1252 mojibake sequence (bytes CE 93 C3 87 C3 B6) when files are saved
 # in a non-UTF-8 editor or copy-pasted from Windows terminals. Fail CI if found.
 set -euo pipefail
 
@@ -20,11 +20,11 @@ print('\n'.join(bad))
 ")
 
 if [ -n "$hits" ]; then
-  echo "::error::Mojibake em-dash (ΓÇö, bytes CE93 C387 C3B6) found in tracked files:"
+  echo "::error::Mojibake em-dash (bytes CE93 C387 C3B6) found in tracked files:"
   echo "$hits"
   echo ""
-  echo "Fix: replace the byte sequence with the proper em-dash '—' (U+2014, UTF-8: E2 80 94)"
-  echo "     or ASCII ' - '. Use binary-safe replacement (e.g. python open(f,'rb').replace)."
+  echo "Fix: replace the byte sequence with the proper em-dash (U+2014, UTF-8: E2 80 94)"
+  echo "     or ASCII ' - '. Use binary-safe replacement: python open(f,'rb').read().replace(bytes([0xce,0x93,0xc3,0x87,0xc3,0xb6]), chr(0x2014).encode())"
   exit 1
 fi
 

--- a/src/post.ts
+++ b/src/post.ts
@@ -62,20 +62,20 @@ function parseAgentPidFromFile(contents: string): number | null {
  * code-block breakouts into the GitHub-rendered Markdown surface (F-T1 /
  * F-T3 from the 2026-04-19 review).
  *
- * Strategy (order matters ΓÇö backslash MUST be escaped first so subsequent
+ * Strategy (order matters — backslash MUST be escaped first so subsequent
  * `\`` and `\~` escapes are not defeated by an attacker-supplied `\` prefix;
  * CodeQL js/incomplete-sanitization caught the original ordering bug):
  *   - normalise CRLF/CR -> LF
  *   - strip BOM
  *   - cap each line at 4 KiB to bound rendering work
- *   - escape `\` -> `\\` (FIRST ΓÇö prevents the markdown parser from eating
+ *   - escape `\` -> `\\` (FIRST — prevents the markdown parser from eating
  *     a single backslash as the escape for a following backtick / tilde)
  *   - escape `<` so raw HTML elements can't render
  *   - escape ``` ` ``` runs of >= 3 backticks AND `~` runs of >= 3 tildes so
  *     the digest can't break out of any fenced-code block a caller wraps it in
  *
  * Out of scope (different threat class than F-T1 / F-T3): markdown link /
- * image phishing ΓÇö `[text](url)` and `![](url)` still render through. Wrap
+ * image phishing — `[text](url)` and `![](url)` still render through. Wrap
  * the sanitised body in a fenced code block at the call site if you need
  * that mitigation too; the helper now escapes both fence flavours so the
  * wrap is safe against breakout.
@@ -154,7 +154,7 @@ function flushDetectLogToJobSummary(body: string): void {
     );
     return;
   }
-  // Append succeeded ΓÇö clean up the workspace digest.
+  // Append succeeded — clean up the workspace digest.
   try {
     fs.unlinkSync(logPath);
   } catch (e) {


### PR DESCRIPTION
## Summary

- Replace all Windows-1252 mojibake em-dash sequences (\ΓÇö\, bytes \CE 93 C3 87 C3 B6\) with proper em-dash U+2014 in four tracked files: \coldstep-demo.yml\, \coldstep-ci-runner.yml\, \LICENSE.md\, \src/post.ts\
- Add \scripts/check-encoding.sh\ — Python raw-byte scan that fails CI if the mojibake sequence is found in any tracked source/config file
- Wire encoding check into the \gofmt\ CI job so it gates all downstream jobs

## Why

The em-dash fix was previously applied on \dev\ post-merge but was lost when \dev\ was reset to match \main\ after PR #80 merged. This PR lands the fix permanently on \main\.

## Test plan

- [ ] \hosted-linux / Go format\ CI job runs \scripts/check-encoding.sh\ and passes
- [ ] No \ΓÇö\ sequences in any tracked file