### PR TITLE
fix(ci): red-team integrity canaries, bpf audit ordering, upload-artifact v6

### DIFF
--- a/.github/pr-bodies/README.md
+++ b/.github/pr-bodies/README.md
@@ -1,0 +1,16 @@
+# PR description bodies (UTF-8)
+
+Use **tracked `.md` files here** for GitHub PR descriptions so text is not corrupted by shell quoting (especially **PowerShell** passing `--body "..."` to `gh`, which can mangle backticks and Unicode).
+
+## Rules
+
+1. Save files as **UTF-8** (no accidental Latin-1 / Windows code pages).
+2. Prefer **ASCII** for bullets; avoid curly quotes unless you verify the file bytes.
+3. Apply to GitHub with **`gh` body-file**, never inline `--body` for long text on Windows:
+
+```bash
+gh pr create --draft --base main --head dev --title "..." --body-file .github/pr-bodies/my-pr.md
+gh pr edit 88 --body-file .github/pr-bodies/my-pr.md
+```
+
+CI **`scripts/check-encoding.sh`** rejects **U+FFFD** replacement bytes (**`EF BF BD`**) and known mojibake in tracked sources including these files.

--- a/.github/pr-bodies/pr-88-description.md
+++ b/.github/pr-bodies/pr-88-description.md
@@ -1,0 +1,23 @@
+## Summary
+
+This change tightens detect-mode integrity on **coldstep-redteam-ebpf** and removes Node 20 / forced Node 24 mismatch warnings for **upload-artifact**.
+
+## Changes
+
+- **internal/agent/agent_linux.go:** Attach **raw_tp/sys_enter (bpf audit)** only after fork and fs BPF collections finish loading, so Coldstep's own **bpf(2)** bursts during load cannot fill the small audit ringbuf before **readBPFAuditRing** runs (restores **bpftool** JSONL canaries).
+
+- **.github/workflows/coldstep-redteam-ebpf.yml:** Run **apt-get** (runtime tools) before composite **phase: start** so package installs do not exhaust the **fs_event** JSONL cap before the intentional **chmod** probe; add **openssl s_client** TLS probe; longer settle; resolve **bpftool** via **command -v** / **/usr/sbin/bpftool**; pin **actions/upload-artifact@v6**.
+
+- **Other workflows:** **actions/upload-artifact@v4** to **@v6** where used (demo, ci-runner, ci-nightly, supply-chain-attest).
+
+- **README.md / CHANGELOG.md:** Pin table and Unreleased notes.
+
+## Verification
+
+- **coldstep-redteam-ebpf** (push to **dev**): https://github.com/coldstep-io/coldstep/actions/runs/25292478576 -- success
+
+- **coldstep-ci** (**workflow_dispatch** on **dev**, full matrix): https://github.com/coldstep-io/coldstep/actions/runs/25292682376 -- success
+
+## Notes
+
+- Local knowledge vault entry (not in git): **knowledge/reports/2026-05-03-ci-redteam-integrity-canaries-and-gha-node24.md**.

--- a/.github/workflows/coldstep-ci-nightly.yml
+++ b/.github/workflows/coldstep-ci-nightly.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload deep-debug output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coldstep-deep-debug-${{ github.run_id }}
           path: .coldstep-deep-debug/

--- a/.github/workflows/coldstep-ci-runner.yml
+++ b/.github/workflows/coldstep-ci-runner.yml
@@ -366,7 +366,7 @@ jobs:
         run: ./bin/coldstep-report render-summary
       - name: Persist detect JSONL baseline artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coldstep-events-baseline-ubuntu-latest
           path: ${{ github.workspace }}/.coldstep-events.jsonl

--- a/.github/workflows/coldstep-demo.yml
+++ b/.github/workflows/coldstep-demo.yml
@@ -265,7 +265,7 @@ jobs:
 
       - name: Persist detect JSONL baseline artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coldstep-events-baseline-${{ env.NS_RUNNER_LABEL }}
           path: ${{ github.workspace }}/.coldstep-events.jsonl

--- a/.github/workflows/coldstep-redteam-ebpf.yml
+++ b/.github/workflows/coldstep-redteam-ebpf.yml
@@ -45,6 +45,14 @@ jobs:
           # For release-path compatibility in next step
           cp bin/coldstep-built bin/coldstep
 
+      # Install packages before starting Coldstep so apt/dpkg filesystem noise
+      # does not exhaust the agent's fs_event JSONL cap (5k lines) before canary chmod.
+      - name: Install runtime tools
+        run: |
+          set -euo pipefail
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq nmap dnsutils linux-tools-common linux-tools-generic linux-tools-azure
+
       - name: Start Coldstep (detect mode with full audit gates)
         uses: ./
         with:
@@ -55,12 +63,6 @@ jobs:
           allowed-hosts: theclouddj.com, *.ubuntu.com
           feature-gates: proc_tree=1,tls_sni=1,fs_events=1
           release-path: bin/coldstep
-
-      - name: Install runtime tools
-        run: |
-          set -euo pipefail
-          sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq nmap dnsutils linux-tools-common linux-tools-generic linux-tools-azure
 
       - name: Red-team probes (Generate Telemetry)
         run: |
@@ -77,9 +79,16 @@ jobs:
           dig @8.8.8.8 google.com +short >/dev/null || true
           
           echo "--- BPF AUDIT PROBE ---"
-          # Trigger BPF audit events (if supported by runner kernel)
-          sudo bpftool map show >/dev/null 2>&1 || echo "bpftool map show failed; best effort audit signal"
-          sudo bpftool prog show >/dev/null 2>&1 || echo "bpftool prog show failed; best effort audit signal"
+          # Prefer real binary path so comm=bpftool matches integrity canaries (not a shell wrapper).
+          BPFTOOL_BIN="$(command -v bpftool || true)"
+          if [[ -z "${BPFTOOL_BIN}" && -x /usr/sbin/bpftool ]]; then BPFTOOL_BIN=/usr/sbin/bpftool; fi
+          if [[ -n "${BPFTOOL_BIN}" ]]; then
+            sudo "${BPFTOOL_BIN}" map show >/dev/null 2>&1 || echo "bpftool map show failed; best effort audit signal"
+            sudo "${BPFTOOL_BIN}" prog show >/dev/null 2>&1 || echo "bpftool prog show failed; best effort audit signal"
+            sudo "${BPFTOOL_BIN}" map show >/dev/null 2>&1 || true
+          else
+            echo "bpftool not found; skipping bpf audit probe"
+          fi
           
           echo "--- NETWORK EGRESS PROBE (TLS) ---"
           # TLS connect (SNI: theclouddj.com); -4 so agent records IPv4 TLS (JSONL filters non-IPv4).
@@ -87,16 +96,20 @@ jobs:
             curl -4 --http1.1 -s -I --max-time 8 https://theclouddj.com >/dev/null && break || true
             sleep 1
           done
+          # Second probe: OpenSSL often emits ClientHello in one write (helps when curl path misses SNI sniff).
+          if command -v openssl >/dev/null 2>&1; then
+            timeout 8 openssl s_client -4 -connect theclouddj.com:443 -servername theclouddj.com </dev/null >/dev/null 2>&1 || true
+          fi
           
           echo "--- FS EVENT PROBE ---"
-          # Filesystem events
+          # Filesystem events (glibc chmod uses fchmodat, which trace_fs hooks).
           TMP_F=$(mktemp)
           echo "redteam" > "${TMP_F}"
-          chmod 400 "${TMP_F}"
+          /bin/chmod 400 "${TMP_F}"
           rm "${TMP_F}"
 
           # Give ring readers time to drain telemetry before stop.
-          sleep 2
+          sleep 5
       - name: Stop Coldstep (flush digest)
         uses: ./
         with:
@@ -131,7 +144,7 @@ jobs:
 
       - name: Upload Redteam Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coldstep-redteam-report
           path: ${{ github.workspace }}/coldstep-redteam-report.html

--- a/.github/workflows/supply-chain-attest.yml
+++ b/.github/workflows/supply-chain-attest.yml
@@ -126,7 +126,7 @@ jobs:
           fi
 
       - name: Upload attestable artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: supply-chain-artifacts-${{ github.run_id }}
           path: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+# Optional: install with `pip install pre-commit` then `pre-commit install`.
+# Mirrors the hosted-linux "encoding check" job (scripts/check-encoding.sh).
+
+repos:
+  - repo: local
+    hooks:
+      - id: encoding-check
+        name: encoding check (mojibake + U+FFFD)
+        entry: bash scripts/check-encoding.sh
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - **`coldstep-demo`:** defend-mode verification matches **`coldstep-ci-runner`** deny-JSONL variance rules (warn when absent unless **`COLDSTEP_DEFEND_DENY_JSONL_STRICT=1`**). Detect-mode: **`smoke-test-egress`**, OpenSSL **`s_client`** probes, longer TLS settle/retry, and digest fallback when **`tls`** JSONL is delayed but the Markdown digest still shows TLS context.
+- **BPF audit canary (CI):** defer **`raw_tp/sys_enter (bpf audit)`** attach until after fork/fs BPF loads so startup **`bpf(2)`** bursts do not fill the audit ringbuf before **`readBPFAuditRing`** runs (restores **`bpftool`** JSONL canaries on **`coldstep-redteam-ebpf`**).
+- **`coldstep-redteam-ebpf`:** run **`apt-get`** before **`phase: start`** so package installs do not exhaust the fs-event JSONL cap before the intentional **`chmod`** probe; add OpenSSL TLS probe, longer post-probe settle, and explicit **`bpftool`** path.
+- **Workflows:** `actions/upload-artifact@v4` → **`@v6`** everywhere it was pinned (native Node 24; clears deprecation warnings when **`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`** is set).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **`.github/pr-bodies/`** — tracked UTF-8 templates for **`gh pr create` / `gh pr edit --body-file`** so PR descriptions are not corrupted by shell quoting (especially PowerShell); **`scripts/gh-pr-body.ps1`** wraps **`gh pr edit --body-file`** on Windows.
+- **Optional `.pre-commit-config.yaml`** — runs **`scripts/check-encoding.sh`** on **`pre-commit install`** (same guard as CI **`gofmt`** job).
+
 ### Fixed
 
+- **`scripts/check-encoding.sh`:** CI now also fails on UTF-8 **U+FFFD** replacement bytes (**`EF BF BD`**) in tracked sources (catches corrupt Unicode / paste damage).
 - **`coldstep-demo`:** defend-mode verification matches **`coldstep-ci-runner`** deny-JSONL variance rules (warn when absent unless **`COLDSTEP_DEFEND_DENY_JSONL_STRICT=1`**). Detect-mode: **`smoke-test-egress`**, OpenSSL **`s_client`** probes, longer TLS settle/retry, and digest fallback when **`tls`** JSONL is delayed but the Markdown digest still shows TLS context.
 - **BPF audit canary (CI):** defer **`raw_tp/sys_enter (bpf audit)`** attach until after fork/fs BPF loads so startup **`bpf(2)`** bursts do not fill the audit ringbuf before **`readBPFAuditRing`** runs (restores **`bpftool`** JSONL canaries on **`coldstep-redteam-ebpf`**).
 - **`coldstep-redteam-ebpf`:** run **`apt-get`** before **`phase: start`** so package installs do not exhaust the fs-event JSONL cap before the intentional **`chmod`** probe; add OpenSSL TLS probe, longer post-probe settle, and explicit **`bpftool`** path.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Consumer copy-paste above uses **`actions/checkout@v6`**. Other first-party pins
 
 | Workflow / area | Notable `uses:` |
 | :-------------- | :-------------- |
-| **CI / demo / attest** | `actions/checkout@v6`, `actions/setup-go@v6` (`go-version: 1.25.x`), `actions/setup-node@v6` (`node-version: 24`, npm cache where applicable), `actions/upload-artifact@v7` |
+| **CI / demo / attest** | `actions/checkout@v6`, `actions/setup-go@v6` (`go-version: 1.25.x`), `actions/setup-node@v6` (`node-version: 24`, npm cache where applicable), `actions/upload-artifact@v6` |
 | **Supply chain** | `actions/attest@v4` |
 | **Pages** | `actions/checkout@v6`, `actions/configure-pages@v6`, `actions/upload-pages-artifact@v4`, `actions/deploy-pages@v5` |
 

--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -408,21 +408,6 @@ func Run(ctx context.Context, cfg config.Config) error {
 	defer closeBPFAuditRd()
 	var bpfAuditObjs *tracebpfaudit.TracebpfauditObjects
 	var bpfAuditLnk link.Link
-	if bR, bO, bL, err := startBPFAuditTrace(); err != nil {
-		slog.Info("bpf audit trace disabled", "err", err)
-		bpfSt = append(bpfSt, telemetry.BPFStatus{Name: "raw_tp/sys_enter (bpf audit)", OK: false, Detail: bpfDetail(err)})
-	} else {
-		bpfAuditRd, bpfAuditObjs, bpfAuditLnk = bR, bO, bL
-		bpfSt = append(bpfSt, telemetry.BPFStatus{Name: "raw_tp/sys_enter (bpf audit)", OK: true})
-		slog.Info("tracing bpf() syscall audit (raw_tp/sys_enter)")
-		defer bpfAuditObjs.Close()
-		defer bpfAuditLnk.Close()
-		defer func() {
-			if bpfAuditObjs != nil {
-				stats.setBPFAuditRingbufReserveFailures(readBPFAuditRingbufReserveFailureCount(bpfAuditObjs))
-			}
-		}()
-	}
 
 	var forkRd *ringbuf.Reader
 	var forkRdOnce sync.Once
@@ -559,6 +544,25 @@ func Run(ctx context.Context, cfg config.Config) error {
 				}
 			}
 		}
+	}
+
+	// Attach bpf() audit tracing only after other BPF collections finish loading.
+	// Otherwise coldstep's own bpf(2) syscalls during object load can fill the small
+	// audit ringbuf before readBPFAuditRing starts, dropping later canary traffic (e.g. bpftool).
+	if bR, bO, bL, err := startBPFAuditTrace(); err != nil {
+		slog.Info("bpf audit trace disabled", "err", err)
+		bpfSt = append(bpfSt, telemetry.BPFStatus{Name: "raw_tp/sys_enter (bpf audit)", OK: false, Detail: bpfDetail(err)})
+	} else {
+		bpfAuditRd, bpfAuditObjs, bpfAuditLnk = bR, bO, bL
+		bpfSt = append(bpfSt, telemetry.BPFStatus{Name: "raw_tp/sys_enter (bpf audit)", OK: true})
+		slog.Info("tracing bpf() syscall audit (raw_tp/sys_enter)")
+		defer bpfAuditObjs.Close()
+		defer bpfAuditLnk.Close()
+		defer func() {
+			if bpfAuditObjs != nil {
+				stats.setBPFAuditRingbufReserveFailures(readBPFAuditRingbufReserveFailureCount(bpfAuditObjs))
+			}
+		}()
 	}
 
 	if cfg.EventsLogPath != "" {

--- a/scripts/check-encoding.sh
+++ b/scripts/check-encoding.sh
@@ -1,54 +1,84 @@
 #!/usr/bin/env bash
-# check-encoding.sh — scan tracked source files for known mojibake byte sequences.
+# check-encoding.sh — scan tracked source files for known mojibake byte sequences and
+# UTF-8 encoding of U+FFFD (replacement character), which usually indicates corrupt UTF-8
+# or shell/gh mangling (e.g. PowerShell --body "..." to gh).
 #
-# The em-dash U+2014 (UTF-8: E2 80 94) silently corrupts into the three-codepoint
-# Windows-1252 mojibake sequence (bytes CE 93 C3 87 C3 B6) when files are saved
-# in a non-UTF-8 editor or copy-pasted from Windows terminals. Fail CI if found.
+# Mojibake: em-dash U+2014 (UTF-8: E2 80 94) corrupting to CE 93 C3 87 C3 B6 (Windows-1252 path).
+# Replacement: U+FFFD UTF-8 EF BF BD — almost never intentional in repo sources.
 set -euo pipefail
 
 # Mojibake bytes (must match CI guard in AGENTS.md / knowledge/wiki).
 MOJ=$'\xce\x93\xc3\x87\xc3\xb6'
 
-scan_python() {
+scan_python_combined() {
   git ls-files -- '*.go' '*.sh' '*.yml' '*.yaml' '*.ts' '*.md' | python3 -c "
-import sys, os
+import sys
 moj = bytes([0xce, 0x93, 0xc3, 0x87, 0xc3, 0xb6])
-bad = []
+repl = bytes([0xef, 0xbf, 0xbd])
+bad_moj, bad_repl = [], []
 for f in sys.stdin.read().splitlines():
     try:
-        if moj in open(f, 'rb').read():
-            bad.append(f)
+        raw = open(f, 'rb').read()
     except OSError:
-        pass
-print('\n'.join(bad))
+        continue
+    if moj in raw:
+        bad_moj.append(f)
+    if repl in raw:
+        bad_repl.append(f)
+err = False
+if bad_moj:
+    err = True
+    print('::error::Mojibake em-dash sequence (bytes CE93 C387 C3B6) found in tracked files:', file=sys.stderr)
+    print('\n'.join(bad_moj), file=sys.stderr)
+    print('', file=sys.stderr)
+    print('Fix: replace with proper em-dash (U+2014, UTF-8 E2 80 94) or ASCII \" - \".', file=sys.stderr)
+if bad_repl:
+    err = True
+    print('::error::Unicode replacement character U+FFFD (UTF-8 bytes EF BF BD) found - corrupt UTF-8 or paste/shell damage:', file=sys.stderr)
+    print('\n'.join(bad_repl), file=sys.stderr)
+    print('', file=sys.stderr)
+    print('Fix: re-save as UTF-8. For gh PR text use: gh pr create/edit --body-file .github/pr-bodies/your.md (see .github/pr-bodies/README.md).', file=sys.stderr)
+sys.exit(1 if err else 0)
 "
 }
 
-scan_grep() {
-  # Single grep -rl pass across all tracked files — much faster than one grep per file.
+scan_grep_moj() {
   git ls-files -- '*.go' '*.sh' '*.yml' '*.yaml' '*.ts' '*.md' \
     | xargs grep -Frl "${MOJ}" 2>/dev/null || true
 }
 
-# Windows may advertise python3 via App Execution Alias while the stub fails at runtime.
+# Scan for UTF-8 U+FFFD without Python (best-effort): grep fixed-string binary-ish
+scan_grep_repl() {
+  # shellcheck disable=SC2059
+  git ls-files -- '*.go' '*.sh' '*.yml' '*.yaml' '*.ts' '*.md' \
+    | while read -r f; do
+        grep -Fq "$(printf '\357\277\275')" "$f" 2>/dev/null && echo "$f"
+      done || true
+}
+
 use_python=false
 if command -v python3 >/dev/null 2>&1 && python3 -c "import sys" >/dev/null 2>&1; then
   use_python=true
 fi
 
 if [ "${use_python}" = true ]; then
-  hits=$(scan_python)
+  if ! scan_python_combined; then
+    exit 1
+  fi
 else
-  hits=$(scan_grep)
+  hits=$(scan_grep_moj)
+  if [ -n "${hits}" ]; then
+    echo "::error::Mojibake em-dash (bytes CE93 C387 C3B6) found in tracked files:"
+    echo "${hits}"
+    exit 1
+  fi
+  hits_repl=$(scan_grep_repl)
+  if [ -n "${hits_repl}" ]; then
+    echo "::error::Unicode replacement U+FFFD (UTF-8 EF BF BD) found (install python3 for full encoding scan):"
+    echo "${hits_repl}"
+    exit 1
+  fi
+  echo "::warning::python3 unavailable — only mojibake + grep replacement scan ran; install python3 for combined CI parity."
 fi
 
-if [ -n "${hits}" ]; then
-  echo "::error::Mojibake em-dash (bytes CE93 C387 C3B6) found in tracked files:"
-  echo "${hits}"
-  echo ""
-  echo "Fix: replace the byte sequence with the proper em-dash (U+2014, UTF-8: E2 80 94)"
-  echo "     or ASCII ' - '. Use binary-safe replacement: python open(f,'rb').read().replace(bytes([0xce,0x93,0xc3,0x87,0xc3,0xb6]), chr(0x2014).encode())"
-  exit 1
-fi
-
-echo "encoding check passed — no mojibake sequences found"
+echo "encoding check passed — no mojibake or U+FFFD replacement sequences found"

--- a/scripts/gh-pr-body.ps1
+++ b/scripts/gh-pr-body.ps1
@@ -1,0 +1,21 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Edit a GitHub PR description from a UTF-8 file (avoids PowerShell mangling gh --body "...").
+
+.EXAMPLE
+  ./scripts/gh-pr-body.ps1 -Number 88 -BodyFile .github/pr-bodies/pr-88-description.md
+#>
+param(
+    [Parameter(Mandatory)][int] $Number,
+    [Parameter(Mandatory)][string] $BodyFile,
+    [string] $Repo = "coldstep-io/coldstep"
+)
+
+$path = Resolve-Path -LiteralPath $BodyFile
+if (-not (Test-Path -LiteralPath $path)) {
+    Write-Error "Body file not found: $BodyFile"
+    exit 1
+}
+
+gh pr edit $Number --repo $Repo --body-file $path


### PR DESCRIPTION
## Summary

This change tightens detect-mode integrity on **coldstep-redteam-ebpf** and removes Node 20 / forced Node 24 mismatch warnings for **upload-artifact**.

## Changes

- **internal/agent/agent_linux.go:** Attach **raw_tp/sys_enter (bpf audit)** only after fork and fs BPF collections finish loading, so Coldstep's own **bpf(2)** bursts during load cannot fill the small audit ringbuf before **readBPFAuditRing** runs (restores **bpftool** JSONL canaries).

- **.github/workflows/coldstep-redteam-ebpf.yml:** Run **apt-get** (runtime tools) before composite **phase: start** so package installs do not exhaust the **fs_event** JSONL cap before the intentional **chmod** probe; add **openssl s_client** TLS probe; longer settle; resolve **bpftool** via **command -v** / **/usr/sbin/bpftool**; pin **actions/upload-artifact@v6**.

- **Other workflows:** **actions/upload-artifact@v4** to **@v6** where used (demo, ci-runner, ci-nightly, supply-chain-attest).

- **README.md / CHANGELOG.md:** Pin table and Unreleased notes.

## Verification

- **coldstep-redteam-ebpf** (push to **dev**): https://github.com/coldstep-io/coldstep/actions/runs/25292478576 -- success

- **coldstep-ci** (**workflow_dispatch** on **dev**, full matrix): https://github.com/coldstep-io/coldstep/actions/runs/25292682376 -- success

## Notes

- Local knowledge vault entry (not in git): **knowledge/reports/2026-05-03-ci-redteam-integrity-canaries-and-gha-node24.md**.
