### PR TITLE
test: expand unit coverage (CLI, action, cgroup, safepath, telemetry)

### DIFF
--- a/.github/pr-bodies/pr-89-description.md
+++ b/.github/pr-bodies/pr-89-description.md
@@ -1,0 +1,14 @@
+## Summary
+
+Expands unit tests across the Go surface area Linux CI cares about: composite action helpers (including `postPRComment` via stub transport), `coldstep` CLI `runCLI` with injectable `agentMain`, `atomicwrite` edge cases, cgroup attach-path helpers on Linux and non-Linux, `safepath` with `RUNNER_TEMP`, and telemetry `NewSigner` / nil signer behavior.
+
+Also extends `.gitignore` for `coverage*.out` profiles.
+
+## Verification
+
+- `go test ./... -short` (local; Windows agent tests may differ from Linux CI)
+- `origin/dev` includes signed commits; merge via this PR to `main`.
+
+## Risk / notes
+
+Does not attempt repo-wide 95% coverage; `internal/agent` and BPF loader packages remain integration-heavy.

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Go coverage profiles (local / CI artifact downloads; Linux CI is the coverage source of truth)
 coverage.out
+coverage*.out
 coverage
 *.coverprofile
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 /bin/
 /node_modules/
 
+# Go coverage profiles (local / CI artifact downloads; Linux CI is the coverage source of truth)
+coverage.out
+coverage
+*.coverprofile
+
 # Local Windows tooling binaries (not published)
 *.exe
 

--- a/cmd/coldstep-action/action_more_test.go
+++ b/cmd/coldstep-action/action_more_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGetenvDefault(t *testing.T) {
+	k := "COLDSTEP_GETENV_DEFAULT_PROBE"
+	t.Setenv(k, "")
+	if getenvDefault(k, "fallback") != "fallback" {
+		t.Fatal("empty env")
+	}
+	t.Setenv(k, "   ")
+	if getenvDefault(k, "fallback") != "fallback" {
+		t.Fatal("whitespace-only env")
+	}
+	t.Setenv(k, " ok ")
+	if getenvDefault(k, "fallback") != "ok" {
+		t.Fatal("trimmed value")
+	}
+}
+
+func TestRuntimeOS_runnerPreferred(t *testing.T) {
+	t.Setenv("RUNNER_OS", "Linux")
+	if runtimeOS() != "linux" {
+		t.Fatalf("got %q", runtimeOS())
+	}
+}
+
+func TestReadReady(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "ready.json")
+	ok, known := readReady(p)
+	if ok || known {
+		t.Fatal("missing file should be unknown")
+	}
+	if err := os.WriteFile(p, []byte(`{"ok":true}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ok, known = readReady(p)
+	if !ok || !known {
+		t.Fatalf("got ok=%v known=%v", ok, known)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestPostPRComment_success(t *testing.T) {
+	old := httpNotifyClient
+	defer func() { httpNotifyClient = old }()
+
+	httpNotifyClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodPost {
+				t.Errorf("method %s", req.Method)
+			}
+			if want := "/repos/acme/demo/issues/7/comments"; req.URL.Path != want {
+				t.Errorf("path %s want %s", req.URL.Path, want)
+			}
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	dir := t.TempDir()
+	eventPath := filepath.Join(dir, "event.json")
+	payload := `{"pull_request":{"number":7}}`
+	if err := os.WriteFile(eventPath, []byte(payload), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GITHUB_REPOSITORY", "acme/demo")
+	t.Setenv("GITHUB_EVENT_PATH", eventPath)
+
+	if err := postPRComment("secret-token", "hello **digest**"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPostPRComment_skipsWithoutRepo(t *testing.T) {
+	t.Setenv("GITHUB_REPOSITORY", "")
+	if err := postPRComment("t", "b"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPostPRComment_skipsWithoutEventPath(t *testing.T) {
+	t.Setenv("GITHUB_REPOSITORY", "a/b")
+	t.Setenv("GITHUB_EVENT_PATH", "")
+	if err := postPRComment("t", "b"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPostPRComment_eventTooLarge(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "big.json")
+	if err := os.WriteFile(p, bytes.Repeat([]byte{'x'}, maxGitHubEventJSONBytes+1), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GITHUB_REPOSITORY", "a/b")
+	t.Setenv("GITHUB_EVENT_PATH", p)
+	if err := postPRComment("t", "b"); err == nil {
+		t.Fatal("expected error for oversized event")
+	}
+}

--- a/cmd/coldstep/main.go
+++ b/cmd/coldstep/main.go
@@ -2,24 +2,32 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/coldstep-io/coldstep/internal/agent"
 )
 
+// agentMain is swapped in tests to avoid running the real agent.
+var agentMain = agent.Main
+
 func main() {
-	if len(os.Args) < 2 {
+	os.Exit(runCLI(os.Args))
+}
+
+func runCLI(args []string) int {
+	if len(args) < 2 {
 		fmt.Fprintln(os.Stderr, "usage: coldstep run")
-		os.Exit(2)
+		return 2
 	}
-	switch os.Args[1] {
+	switch args[1] {
 	case "run":
-		if err := agent.Main(); err != nil {
-			log.Fatal(err)
+		if err := agentMain(); err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			return 1
 		}
+		return 0
 	default:
 		fmt.Fprintln(os.Stderr, "unknown command")
-		os.Exit(2)
+		return 2
 	}
 }

--- a/cmd/coldstep/main_test.go
+++ b/cmd/coldstep/main_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestRunCLI_usage(t *testing.T) {
+	if got := runCLI([]string{"coldstep"}); got != 2 {
+		t.Fatalf("runCLI(coldstep)=%d want 2", got)
+	}
+}
+
+func TestRunCLI_runIgnoresExtraArgs(t *testing.T) {
+	prev := agentMain
+	defer func() { agentMain = prev }()
+	agentMain = func() error { return nil }
+	if got := runCLI([]string{"coldstep", "run", "extra"}); got != 0 {
+		t.Fatalf("got %d want 0", got)
+	}
+}
+
+func TestRunCLI_unknown(t *testing.T) {
+	if got := runCLI([]string{"coldstep", "nope"}); got != 2 {
+		t.Fatalf("got %d want 2", got)
+	}
+}
+
+func TestRunCLI_runSuccess(t *testing.T) {
+	prev := agentMain
+	defer func() { agentMain = prev }()
+	agentMain = func() error { return nil }
+	if got := runCLI([]string{"coldstep", "run"}); got != 0 {
+		t.Fatalf("got %d want 0", got)
+	}
+}
+
+func TestRunCLI_runError(t *testing.T) {
+	prev := agentMain
+	defer func() { agentMain = prev }()
+	agentMain = func() error { return errors.New("boom") }
+	if got := runCLI([]string{"coldstep", "run"}); got != 1 {
+		t.Fatalf("got %d want 1", got)
+	}
+}

--- a/internal/atomicwrite/atomicwrite_test.go
+++ b/internal/atomicwrite/atomicwrite_test.go
@@ -3,6 +3,7 @@ package atomicwrite
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -18,6 +19,28 @@ func TestBytesRoundTrip(t *testing.T) {
 	}
 	if string(raw) != "hello\n" {
 		t.Fatalf("got %q", raw)
+	}
+}
+
+func TestBytesEmptyPath(t *testing.T) {
+	if err := Bytes("", []byte("x"), 0o644); err == nil {
+		t.Fatal("expected error for empty path")
+	}
+}
+
+func TestBytesNonzeroPerm(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "perm.bin")
+	if err := Bytes(p, []byte("data"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	st, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Windows does not preserve Unix chmod bits the same way as Linux.
+	if runtime.GOOS != "windows" && st.Mode().Perm()&0o777 != 0o640 {
+		t.Fatalf("mode %v want 0640", st.Mode())
 	}
 }
 

--- a/internal/cgroup/path_linux_test.go
+++ b/internal/cgroup/path_linux_test.go
@@ -1,0 +1,36 @@
+//go:build linux
+
+package cgroup
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestAttachPath_linux_default(t *testing.T) {
+	got, err := AttachPath("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == "" {
+		t.Fatal("empty attach path")
+	}
+	if !filepath.IsAbs(got) {
+		t.Fatalf("want absolute path, got %q", got)
+	}
+}
+
+func TestAttachPath_linux_override(t *testing.T) {
+	dir := t.TempDir()
+	got, err := AttachPath(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, werr := filepath.Abs(dir)
+	if werr != nil {
+		t.Fatal(werr)
+	}
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}

--- a/internal/cgroup/path_other_test.go
+++ b/internal/cgroup/path_other_test.go
@@ -1,0 +1,42 @@
+//go:build !linux
+
+package cgroup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAttachPath_nonLinux_default(t *testing.T) {
+	p, err := AttachPath("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p != "/sys/fs/cgroup" {
+		t.Fatalf("got %q", p)
+	}
+}
+
+func TestAttachPath_override(t *testing.T) {
+	dir := t.TempDir()
+	got, err := AttachPath(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, _ := filepath.Abs(dir)
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestAttachPath_override_notDir(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "f")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := AttachPath(file); err == nil {
+		t.Fatal("expected error for non-directory override")
+	}
+}

--- a/internal/safepath/safepath_test.go
+++ b/internal/safepath/safepath_test.go
@@ -8,6 +8,16 @@ import (
 	"testing"
 )
 
+func TestWorkspace_acceptsPathUnderRunnerTemp(t *testing.T) {
+	rt := t.TempDir()
+	t.Setenv("GITHUB_WORKSPACE", "")
+	t.Setenv("RUNNER_TEMP", rt)
+	child := filepath.Join(rt, "agent-status.json")
+	if _, err := Workspace(child, "STATUS"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestWorkspaceAcceptsPathsUnderWorkspace(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("GITHUB_WORKSPACE", tmp)

--- a/internal/safepath/safepath_test.go
+++ b/internal/safepath/safepath_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -28,8 +29,20 @@ func TestWorkspaceRejectsPathOutsideTrustedRoots(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("GITHUB_WORKSPACE", tmp)
 	t.Setenv("RUNNER_TEMP", "")
-	t.Setenv("TMPDIR", tmp) // collapse os.TempDir() onto the workspace so a sibling is genuinely outside
-	outside := filepath.Join(filepath.Dir(tmp), "outside.json")
+	t.Setenv("TMPDIR", tmp) // Unix: collapse os.TempDir() onto the workspace so a sibling is genuinely outside
+	var outside string
+	if runtime.GOOS == "windows" {
+		// Windows ignores TMPDIR for os.TempDir() (uses %TEMP%/%TMP%); a sibling of t.TempDir()
+		// often still lies under the real Temp directory and remains trusted. Use a path under
+		// %SystemRoot% which is outside typical workspace/temp/cwd roots for this test layout.
+		root := os.Getenv("SystemRoot")
+		if root == "" {
+			t.Skip("SystemRoot unset")
+		}
+		outside = filepath.Join(root, "coldstep-safepath-outside-root-test.json")
+	} else {
+		outside = filepath.Join(filepath.Dir(tmp), "outside.json")
+	}
 	if _, err := Workspace(outside, "OUT"); err == nil {
 		t.Fatal("Workspace: expected error for path outside trusted roots")
 	} else if !errors.Is(err, ErrInvalidPath) {
@@ -58,6 +71,9 @@ func TestWorkspaceAcceptsNonExistentPathUnderSymlinkedWorkspace(t *testing.T) {
 	}
 	linkWorkspace := filepath.Join(tmp, "workspace-link")
 	if err := os.Symlink(realWorkspace, linkWorkspace); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skip("workspace symlink requires developer-mode symlink privilege or elevation on Windows:", err)
+		}
 		t.Fatalf("setup workspace symlink: %v", err)
 	}
 

--- a/internal/telemetry/sign_test.go
+++ b/internal/telemetry/sign_test.go
@@ -1,0 +1,43 @@
+package telemetry
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func TestNewSigner_empty(t *testing.T) {
+	s, err := NewSigner("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s != nil {
+		t.Fatal("expected nil signer for empty key")
+	}
+}
+
+func TestNewSigner_invalidBase64(t *testing.T) {
+	if _, err := NewSigner("not!!!valid@@@"); err == nil {
+		t.Fatal("expected decode error")
+	}
+}
+
+func TestNewSigner_badLength(t *testing.T) {
+	// 31 bytes — invalid length
+	short := base64.StdEncoding.EncodeToString(make([]byte, 31))
+	if _, err := NewSigner(short); err == nil {
+		t.Fatal("expected length error")
+	}
+}
+
+func TestSigner_nilPublicKey(t *testing.T) {
+	var s *Signer
+	if got := s.PublicKey(); got != "" {
+		t.Fatalf("got %q", got)
+	}
+	if got := s.PublicKeyBytes(); got != nil {
+		t.Fatalf("got %v", got)
+	}
+	if sig, err := s.Sign(map[string]string{"a": "b"}); sig != "" || err != nil {
+		t.Fatalf("Sign(nil) = %q, %v want empty, nil", sig, err)
+	}
+}


### PR DESCRIPTION
## Summary

Expands unit tests across the Go surface area Linux CI cares about: composite action helpers (including `postPRComment` via stub transport), `coldstep` CLI `runCLI` with injectable `agentMain`, `atomicwrite` edge cases, cgroup attach-path helpers on Linux and non-Linux, `safepath` with `RUNNER_TEMP`, and telemetry `NewSigner` / nil signer behavior.

Also extends `.gitignore` for `coverage*.out` profiles.

## Verification

- `go test ./... -short` (local; Windows agent tests may differ from Linux CI)
- `origin/dev` includes signed commits; merge via this PR to `main`.

## Risk / notes

Does not attempt repo-wide 95% coverage; `internal/agent` and BPF loader packages remain integration-heavy.
