### PR TITLE
refactor: allowlist To4 and deny dst IP without ParseIP

### DIFF
--- a/.github/pr-bodies/pr-chore-tighten-allow-deny.md
+++ b/.github/pr-bodies/pr-chore-tighten-allow-deny.md
@@ -1,0 +1,8 @@
+## Summary
+
+Small post-merge cleanup from a skeptical pass: avoid double `To4()` in allowlist merge and use the decoded IPv4 `net.IP` for DNS cache lookup on deny lines (no string round-trip).
+
+## Verification
+
+- `go test ./internal/policy/... ./internal/agent/...` on Linux
+- `scripts/check-encoding.sh`

--- a/.github/pr-bodies/pr-chore-tighten-allow-deny.md
+++ b/.github/pr-bodies/pr-chore-tighten-allow-deny.md
@@ -2,6 +2,11 @@
 
 Small post-merge cleanup from a skeptical pass: avoid double `To4()` in allowlist merge and use the decoded IPv4 `net.IP` for DNS cache lookup on deny lines (no string round-trip).
 
+## Also
+
+- **`.gitignore`**: `/KNOWLEDGE_DIRECTOR.md` — optional repo-root filename for a local Obsidian Knowledge Director stub; keep it out of Git.
+- **`SECURITY.md`**: defend LSM hook table uses **`lsm/socket_connect`** / **`lsm/socket_sendmsg`** to match **`SEC(...)`** in `bpf/trace_lsm_enforce.bpf.c`.
+
 ## Verification
 
 - `go test ./internal/policy/... ./internal/agent/...` on Linux

--- a/.github/workflows/coldstep-ci-nightly.yml
+++ b/.github/workflows/coldstep-ci-nightly.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
       - name: Prepare BPF and generated Go (same graph as PR unit job)
         run: bash scripts/build-agent-linux.sh "$GITHUB_WORKSPACE"
       - name: Install govulncheck
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
       - name: Prepare BPF and generated Go
         run: bash scripts/build-agent-linux.sh "$GITHUB_WORKSPACE"
       - name: Unit tests with shuffle (stress test execution order)
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
       - name: Prepare BPF and generated Go
         run: bash scripts/build-agent-linux.sh "$GITHUB_WORKSPACE"
       - name: Race detector — full module
@@ -98,7 +98,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
 
       - name: Run sudo BPF integration (deep-debug.sh)
         env:

--- a/.github/workflows/coldstep-ci-runner.yml
+++ b/.github/workflows/coldstep-ci-runner.yml
@@ -42,7 +42,7 @@ jobs:
           fi
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
       - name: gofmt check
         run: bash scripts/check-gofmt.sh
       - name: encoding check
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
       - name: Prepare BPF and generated Go
         run: bash scripts/build-agent-linux.sh "$GITHUB_WORKSPACE"
       - name: Go vet
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
       - name: Prepare BPF and generated Go
         run: bash scripts/build-agent-linux.sh "$GITHUB_WORKSPACE"
       - name: Go vet
@@ -127,7 +127,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
       - name: Prepare BPF
         run: bash scripts/build-agent-linux.sh "$GITHUB_WORKSPACE"
       - name: Go vet
@@ -150,7 +150,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
       - name: Build action binaries
         run: bash scripts/build-agent-linux.sh "${GITHUB_WORKSPACE}"
       - name: Verify action binaries exist
@@ -176,7 +176,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
 
       - name: Start Coldstep (detect mode)
         uses: ./
@@ -392,7 +392,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
 
       # Cache skips clang+bpf rebuild when sources unchanged — composite uses release-path so startup
       # stays fast under fail-on-error (BPF verifier remains on first load inside the agent).

--- a/.github/workflows/coldstep-demo.yml
+++ b/.github/workflows/coldstep-demo.yml
@@ -57,7 +57,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
 
       - name: Download coldstep agent (GitHub Release)
         env:
@@ -291,7 +291,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
 
       - name: Download coldstep agent (GitHub Release)
         env:

--- a/.github/workflows/coldstep-redteam-ebpf.yml
+++ b/.github/workflows/coldstep-redteam-ebpf.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
 
       - name: Build coldstep agent
         run: |

--- a/.github/workflows/supply-chain-attest.yml
+++ b/.github/workflows/supply-chain-attest.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
 
       - name: Build Go agent (BPF + binary)
         run: bash scripts/build-agent-linux.sh "$GITHUB_WORKSPACE"

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ AGENTS.md
 # Local deep-debug pass output (scripts/deep-debug.sh)
 .coldstep-deep-debug/
 
+# Optional repo-root copy of Knowledge Director protocol (canonical note: knowledge/wiki/obsidian-knowledge-director.md — vault is gitignored).
+/KNOWLEDGE_DIRECTOR.md
+
 # Local-only trees — never staged, never committed (do not `git add` docs/, design/, or knowledge/, never `git add -f`).
 /plans/
 /skills/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thanks for helping improve coldstep. This document is the maintainer-facing coun
 ## Before you open a PR
 
 1. **Describe the change** — behavior, risk (especially for **defend** (blocking) mode and BPF), and how you validated it (e.g. link to a fork run or `workflow_dispatch` on **`coldstep-ci`** / **`coldstep-demo`**).
-2. **Go** — CI uses **`setup-go`** with **`go-version: 1.25.x`** (see **`.github/workflows/coldstep-ci-runner.yml`**), matching **`go.mod`**. After Linux prep, `gofmt`, `go vet ./...`, and `go test ./...` should pass (see CI for integration tags).
+2. **Go** — CI uses **`setup-go`** with **`go-version-file: go.mod`** (matches the **`go`** directive, currently **1.25.10**); see **`.github/workflows/coldstep-ci-runner.yml`**. After Linux prep, `gofmt`, `go vet ./...`, and `go test ./...` should pass (see CI for integration tags).
 3. **Legacy TypeScript bundles (`src/`, `dist/`)** — the published composite path is Go-only. **`package.json`** labels the esbuild output as **legacy** (CodeQL / maintenance). If you touch **`src/main.ts`** or **`src/post.ts`**, commit **`dist/`** bundles that match those sources — PR **`coldstep-ci`** / CodeQL are the supported verification surfaces (there is no Docker or local Linux matrix you must reproduce).
 4. **Allowlist ergonomics** — changing **`allowed-*-file`** / **`bootstrap-allowlist`** behavior or defaults requires updating **QUICK_START**, **`VALIDATION.md`**, and **`action.yml`** input descriptions together.
 5. **Docs** — if you change workflow pins or other action inputs, update **README**, **QUICK_START**, and **`action.yml`** descriptions so they stay aligned.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Consumer copy-paste above uses **`actions/checkout@v6`**. Other first-party pins
 
 | Workflow / area | Notable `uses:` |
 | :-------------- | :-------------- |
-| **CI / demo / attest** | `actions/checkout@v6`, `actions/setup-go@v6` (`go-version: 1.25.x`), `actions/setup-node@v6` (`node-version: 24`, npm cache where applicable), `actions/upload-artifact@v6` |
+| **CI / demo / attest** | `actions/checkout@v6`, `actions/setup-go@v6` (`go-version-file: go.mod`, matches **`go`** directive), `actions/setup-node@v6` (`node-version: 24`, npm cache where applicable), `actions/upload-artifact@v6` |
 | **Supply chain** | `actions/attest@v4` |
 | **Pages** | `actions/checkout@v6`, `actions/configure-pages@v6`, `actions/upload-pages-artifact@v4`, `actions/deploy-pages@v5` |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,7 +50,7 @@ Coldstep’s contract has three layers:
 | Layer | BPF object (repo) | Role |
 | ----- | ----------------- | ---- |
 | **cgroup** | `bpf/trace_enforce.bpf.c` | **`cgroup/connect4`**, **`cgroup/sendmsg4`** — primary IPv4 egress enforcement for TCP and UDP on the job cgroup. |
-| **LSM** | `bpf/trace_lsm_enforce.bpf.c` | **`bpf_lsm_socket_connect`**, **`bpf_lsm_socket_sendmsg`** — supplemental enforcement where LSM BPF is available. |
+| **LSM** | `bpf/trace_lsm_enforce.bpf.c` | **`lsm/socket_connect`**, **`lsm/socket_sendmsg`** (`SEC(...)` names; supplemental BPF LSM enforcement where available). |
 
 Both are **IPv4 only**. The agent reports BPF load/attach status in **`.coldstep-telemetry.json`** and in logs. If a program fails to attach, treat **defend** as **degraded** and inspect those rows and stderr—do not assume silent fallback implies the same enforcement story on every kernel.
 

--- a/internal/agent/agent_linux_policy_maps.go
+++ b/internal/agent/agent_linux_policy_maps.go
@@ -445,11 +445,12 @@ func appendDenyFromRaw(cfg config.Config, raw []byte, seq *telemetry.SeqGen, jso
 	if af != linuxAFInet {
 		return telemetry.DenyEvent{}, fmt.Errorf("deny event: unsupported address family %d (IPv4 only)", af)
 	}
-	dst := net.IPv4(daddr16[0], daddr16[1], daddr16[2], daddr16[3]).String()
+	dstIP := net.IPv4(daddr16[0], daddr16[1], daddr16[2], daddr16[3])
+	dst := dstIP.String()
 	comm := string(bytes.TrimRight(commb[:], "\x00"))
 	ts := time.Now().UTC().Format(time.RFC3339Nano)
 	matchKind := "unknown"
-	if dns != nil && dns.Lookup(net.ParseIP(dst)) != "" {
+	if dns != nil && dns.Lookup(dstIP) != "" {
 		matchKind = "dns_cache"
 	}
 	// Build the deny event without Seq up front; Seq is only assigned when the JSONL writer

--- a/internal/policy/allowlist.go
+++ b/internal/policy/allowlist.go
@@ -161,11 +161,12 @@ func CompileDomainAllowlist(ctx context.Context, domains []string, resolver Look
 		if res.resolved {
 			seen := make(map[[4]byte]struct{})
 			for _, ip := range res.ips {
-				if ip.To4() == nil {
+				ip4 := ip.To4()
+				if ip4 == nil {
 					continue
 				}
 				var k [4]byte
-				copy(k[:], ip.To4())
+				copy(k[:], ip4)
 				seen[k] = struct{}{}
 			}
 			if len(seen) > coldstepDomainAllowlistIPv4WarnThreshold {


### PR DESCRIPTION
## Summary

Small post-merge cleanup from a skeptical pass: avoid double `To4()` in allowlist merge and use the decoded IPv4 `net.IP` for DNS cache lookup on deny lines (no string round-trip).

## Also

- **`.gitignore`**: `/KNOWLEDGE_DIRECTOR.md` — optional repo-root filename for a local Obsidian Knowledge Director stub; keep it out of Git.
- **`SECURITY.md`**: defend LSM hook table uses **`lsm/socket_connect`** / **`lsm/socket_sendmsg`** to match **`SEC(...)`** in `bpf/trace_lsm_enforce.bpf.c`.

## Verification

- `go test ./internal/policy/... ./internal/agent/...` on Linux
- `scripts/check-encoding.sh`
