### PR TITLE
fix(ci,harness): Docker daemon preflight and optional integration skip

### DIFF
--- a/.github/workflows/coldstep-ci-runner.yml
+++ b/.github/workflows/coldstep-ci-runner.yml
@@ -114,7 +114,10 @@ jobs:
       - name: Race detector (Go agent)
         run: go test -race -count=1 ./internal/agent/... -timeout 15m
 
+  # Skip on locked-down runners: set repository variable COLDSTEP_SKIP_INTEGRATION=1
+  # (Settings → Secrets and variables → Actions → Variables).
   integration:
+    if: ${{ vars.COLDSTEP_SKIP_INTEGRATION != '1' }}
     name: integration (${{ matrix.os }})
     needs: [gofmt]
     strategy:

--- a/scripts/docker-deep-debug.sh
+++ b/scripts/docker-deep-debug.sh
@@ -10,6 +10,7 @@
 #   bash scripts/docker-deep-debug.sh [repo-root]
 #
 # Environment:
+#   DOCKER                         Container CLI (default: docker); used for preflight + run.
 #   COLDSTEP_DOCKER_IMAGE          Override image (e.g. ubuntu:22.04 for jammy parity).
 #   COLDSTEP_DOCKER_NO_INTEGRATION Set to 1 to skip integration tests (faster).
 #   COLDSTEP_DOCKER_INTERACTIVE    Set to 1 for shell after deps + BPF build (manual bpftool/agent).
@@ -27,6 +28,12 @@
 #   - Integration tests skip some cases on WSL-like kernels; native Linux hosts match CI best.
 #
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=require-docker-daemon.sh
+source "${SCRIPT_DIR}/require-docker-daemon.sh"
+DOCKER="${DOCKER:-docker}"
+coldstep_require_docker
 
 ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 # Docker Desktop on Windows: Git Bash / MSYS passes Unix paths; convert for bind-mount reliability.
@@ -63,7 +70,7 @@ DOCKER_ARGS+=(
 	-e "COLDSTEP_DOCKER_RACE_FULL=${RACE_FULL}"
 )
 
-exec docker "${DOCKER_ARGS[@]}" "${IMAGE}" bash -s <<'EOS'
+exec "${DOCKER}" "${DOCKER_ARGS[@]}" "${IMAGE}" bash -s <<'EOS'
 set -euo pipefail
 export PATH="/usr/local/go/bin:${PATH}"
 

--- a/scripts/docker-linux-test.sh
+++ b/scripts/docker-linux-test.sh
@@ -10,17 +10,24 @@
 # - ebpf map tests need CAP_BPF inside the container (matches unprivileged restrictions).
 # - Default image: ubuntu:24.04 (matches GitHub ubuntu-latest / ubuntu-24.04 lineage). Installs golang-go + clang/llvm/libbpf-dev from apt;
 #   newer Go from go.mod is fetched via GOTOOLCHAIN=auto when needed.
+# - Override container engine: DOCKER=podman (default: docker).
 
 set -euo pipefail
 
-ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=require-docker-daemon.sh
+source "${SCRIPT_DIR}/require-docker-daemon.sh"
+DOCKER="${DOCKER:-docker}"
+coldstep_require_docker
+
+ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 if [[ "${OSTYPE:-}" == msys* ]] || [[ "${OSTYPE:-}" == cygwin* ]]; then
 	if command -v cygpath >/dev/null 2>&1; then
 		ROOT="$(cygpath -aw "${ROOT}")"
 	fi
 fi
 
-exec docker run --rm \
+exec "${DOCKER}" run --rm \
 	--cap-add BPF \
 	-v "${ROOT}:/work" \
 	-w //work \

--- a/scripts/require-docker-daemon.sh
+++ b/scripts/require-docker-daemon.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Ensure the Docker daemon is reachable before build/run (clear error vs noisy failures).
+#
+# Usage:
+#   source "$(dirname "$0")/require-docker-daemon.sh"   # from scripts/foo.sh
+#   coldstep_require_docker
+#
+#   Or run directly:
+#     bash scripts/require-docker-daemon.sh
+#
+# Override client binary:
+#   DOCKER=podman bash scripts/require-docker-daemon.sh
+
+coldstep_require_docker() {
+	local bin="${DOCKER:-docker}"
+	if ! "${bin}" info >/dev/null 2>&1; then
+		echo "error: '${bin}' daemon is not running or not reachable" >&2
+		return 1
+	fi
+	return 0
+}
+
+if [[ "${BASH_SOURCE[0]:-$0}" == "${0}" ]]; then
+	set -euo pipefail
+	coldstep_require_docker
+fi

--- a/scripts/smoke-code-review-mcp-docker.ps1
+++ b/scripts/smoke-code-review-mcp-docker.ps1
@@ -2,12 +2,19 @@
 $ErrorActionPreference = "Stop"
 $RepoRoot = Split-Path -Parent $PSScriptRoot
 $ImageTag = if ($env:IMAGE_TAG) { $env:IMAGE_TAG } else { "coldstep-code-review-mcp:smoke" }
+$DockerExe = if ($env:DOCKER) { $env:DOCKER } else { "docker" }
 
-docker build -t $ImageTag (Join-Path $RepoRoot "docker\code-review-assistant")
+& $DockerExe info 2>&1 | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "error: '${DockerExe}' daemon is not running or not reachable" -ForegroundColor Red
+    exit 1
+}
+
+& $DockerExe build -t $ImageTag (Join-Path $RepoRoot "docker\code-review-assistant")
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 $py = "import sys; sys.path.insert(0, '/app'); import server; t=server._load_expert_prompt(); assert len(t)>200; assert 'bpf' in t.lower(); cl=server._checklist_for('go',''); assert 'race' in cl.lower() or 'error' in cl.lower(); print('smoke_ok')"
-docker run --rm --entrypoint python $ImageTag -c $py
+& $DockerExe run --rm --entrypoint python $ImageTag -c $py
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 Write-Host "smoke-code-review-mcp-docker: passed"

--- a/scripts/smoke-code-review-mcp-docker.sh
+++ b/scripts/smoke-code-review-mcp-docker.sh
@@ -2,12 +2,18 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=require-docker-daemon.sh
+source "${SCRIPT_DIR}/require-docker-daemon.sh"
+DOCKER="${DOCKER:-docker}"
+coldstep_require_docker
+
 IMAGE_TAG="${IMAGE_TAG:-coldstep-code-review-mcp:smoke}"
 
-docker build -t "${IMAGE_TAG}" "${ROOT}/docker/code-review-assistant"
+"${DOCKER}" build -t "${IMAGE_TAG}" "${ROOT}/docker/code-review-assistant"
 
 # Override ENTRYPOINT so we run assertions instead of starting stdio MCP.
-docker run --rm --entrypoint python "${IMAGE_TAG}" -c "
+"${DOCKER}" run --rm --entrypoint python "${IMAGE_TAG}" -c "
 import sys
 sys.path.insert(0, '/app')
 import server

--- a/scripts/verify-mcp-code-review-docker.py
+++ b/scripts/verify-mcp-code-review-docker.py
@@ -4,12 +4,14 @@ End-to-end MCP stdio proof against the Docker image (no mocks):
 
 spawn `docker run --rm -i <image>`, run MCP initialize + tools/list + tools/call,
 using real bytes read from bpf/trace_connect.bpf.c in this repo.
-Requires: Docker, Python with `mcp` + `anyio` on the host (same stack Cursor-style clients use).
+Requires: Docker (or a `docker info`-compatible CLI), Python with `mcp` + `anyio`.
+Set environment variable `DOCKER` to use podman or another drop-in (default: docker).
 """
 
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -20,6 +22,7 @@ from mcp.client.stdio import StdioServerParameters, stdio_client
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 IMAGE_TAG = os.environ.get("IMAGE_TAG", "coldstep-code-review-mcp:smoke")
+DOCKER_BIN = os.environ.get("DOCKER", "docker")
 
 
 def _bpf_snippet() -> str:
@@ -37,9 +40,22 @@ def _tool_text(result: types.CallToolResult) -> str:
 
 
 async def _run() -> None:
+    try:
+        subprocess.run(
+            [DOCKER_BIN, "info"],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=120,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        raise SystemExit(
+            f"'{DOCKER_BIN}' daemon not reachable ({DOCKER_BIN} info failed); start the engine and retry."
+        ) from e
+
     snippet = _bpf_snippet()
     server = StdioServerParameters(
-        command="docker",
+        command=DOCKER_BIN,
         args=["run", "--rm", "-i", IMAGE_TAG],
     )
     async with stdio_client(server) as (read, write):


### PR DESCRIPTION
### Changes
- **\scripts/require-docker-daemon.sh\**: Shared \coldstep_require_docker\ (\DOCKER\ / \docker info\ gate). Sourced by local Docker harness scripts.
- **\scripts/docker-linux-test.sh\**, **\scripts/docker-deep-debug.sh\**: Preflight before \docker run\; use \\\ for the client binary.
- **\scripts/smoke-code-review-mcp-docker.sh\**, **\scripts/smoke-code-review-mcp-docker.ps1\**: Preflight before build/run; PowerShell honors \\\.
- **\scripts/verify-mcp-code-review-docker.py\**: Same check before MCP stdio; \DOCKER\ env for the spawned CLI.
- **\.github/workflows/coldstep-ci-runner.yml\**: Skip the **integration** matrix when repository variable \COLDSTEP_SKIP_INTEGRATION\ is \1\ (Actions → Variables). Unset keeps current behavior.

### Validation
CI should run the reusable **coldstep-ci runner** workflow as on any PR to \main\.