### PR TITLE
fix(agent,ci): harden eBPF allowlist loading and simplify CI dispatch…

### DIFF
--- a/.github/workflows/coldstep-ci-runner.yml
+++ b/.github/workflows/coldstep-ci-runner.yml
@@ -14,6 +14,10 @@ on:
         description: When true, defend-mode fails if no deny JSONL rows appear after defend smoke (stricter than default variance-tolerant path)
         type: boolean
         default: false
+      skip_integration:
+        description: When true, skip the integration matrix (faster manual runs)
+        type: boolean
+        default: false
 
 # Default to least-privilege for every job in this reusable workflow.
 # Jobs that legitimately need more (e.g. `actions: read` to download a
@@ -114,10 +118,11 @@ jobs:
       - name: Race detector (Go agent)
         run: go test -race -count=1 ./internal/agent/... -timeout 15m
 
-  # Skip on locked-down runners: set repository variable COLDSTEP_SKIP_INTEGRATION=1
-  # (Settings → Secrets and variables → Actions → Variables).
+  # Integration can be skipped in two ways:
+  # 1) workflow input skip_integration=true (used by coldstep-ci.yml fast preset)
+  # 2) repository variable COLDSTEP_SKIP_INTEGRATION=1 (global override)
   integration:
-    if: ${{ vars.COLDSTEP_SKIP_INTEGRATION != '1' }}
+    if: ${{ !inputs.skip_integration && vars.COLDSTEP_SKIP_INTEGRATION != '1' }}
     name: integration (${{ matrix.os }})
     needs: [gofmt]
     strategy:

--- a/.github/workflows/coldstep-ci.yml
+++ b/.github/workflows/coldstep-ci.yml
@@ -10,14 +10,14 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
-      coldstep_diff_strict:
-        description: Fail detect-mode if previous-run JSONL diff baseline is unavailable (hosted-linux job)
-        type: boolean
-        default: true
-      defend_deny_jsonl_strict:
-        description: Fail defend-mode if defend smoke produces no deny JSONL rows (optional strict gate)
-        type: boolean
-        default: false
+      ci_preset:
+        description: CI preset (default = normal, fast = skip integration, strict = extra defend/diff gates)
+        type: choice
+        options:
+          - default
+          - fast
+          - strict
+        default: default
 
 permissions:
   contents: read
@@ -33,6 +33,7 @@ jobs:
   hosted-linux:
     uses: ./.github/workflows/coldstep-ci-runner.yml
     with:
-      coldstep_diff_strict: ${{ github.event_name != 'workflow_dispatch' || inputs.coldstep_diff_strict }}
-      defend_deny_jsonl_strict: ${{ github.event_name == 'workflow_dispatch' && inputs.defend_deny_jsonl_strict || false }}
+      coldstep_diff_strict: ${{ github.event_name != 'workflow_dispatch' || inputs.ci_preset == 'strict' }}
+      defend_deny_jsonl_strict: ${{ github.event_name == 'workflow_dispatch' && inputs.ci_preset == 'strict' || false }}
+      skip_integration: ${{ github.event_name == 'workflow_dispatch' && inputs.ci_preset == 'fast' || false }}
     secrets: inherit

--- a/internal/agent/agent_linux_policy_maps.go
+++ b/internal/agent/agent_linux_policy_maps.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -303,7 +304,12 @@ func loadLSMEnforceMaps(objs *tracelsmenforce.TracelsmenforceObjects, compiled p
 	if pol != nil {
 		literalNets = pol.AllowedIPv4Nets()
 	}
-	totalEntries := len(v4keys) + len(literalNets)
+
+	plan, err := buildAllowedLPMPlan("lsm_allowed_ipv4", v4keys, literalNets)
+	if err != nil {
+		return 0, 0, err
+	}
+	totalEntries := plan.totalEntries
 	if totalEntries > policy.MaxAllowedEnforceIPv4Keys {
 		return 0, 0, fmt.Errorf("lsm_allowed_ipv4: %d entries exceeds BPF max %d", totalEntries, policy.MaxAllowedEnforceIPv4Keys)
 	}
@@ -312,7 +318,7 @@ func loadLSMEnforceMaps(objs *tracelsmenforce.TracelsmenforceObjects, compiled p
 		return 0, 0, fmt.Errorf("enforce allowlist effective allowlist is empty (no map entries)")
 	}
 
-	if err := loadAllowedLPMMap(objs.LsmAllowedIpv4, v4keys, literalNets); err != nil {
+	if err := loadAllowedLPMMap(objs.LsmAllowedIpv4, plan); err != nil {
 		return 0, 0, err
 	}
 
@@ -357,7 +363,12 @@ func loadEnforceMaps(objs *traceenforce.TraceenforceObjects, compiled policy.Com
 	if pol != nil {
 		literalNets = pol.AllowedIPv4Nets()
 	}
-	totalEntries := len(v4keys) + len(literalNets)
+
+	plan, err := buildAllowedLPMPlan("allowed_ipv4", v4keys, literalNets)
+	if err != nil {
+		return 0, 0, err
+	}
+	totalEntries := plan.totalEntries
 	if totalEntries > policy.MaxAllowedEnforceIPv4Keys {
 		return 0, 0, fmt.Errorf("allowed_ipv4: %d entries exceeds BPF max %d", totalEntries, policy.MaxAllowedEnforceIPv4Keys)
 	}
@@ -366,7 +377,7 @@ func loadEnforceMaps(objs *traceenforce.TraceenforceObjects, compiled policy.Com
 		return 0, 0, fmt.Errorf("enforce allowlist effective allowlist is empty (no map entries)")
 	}
 
-	if err := loadAllowedLPMMap(objs.AllowedIpv4, v4keys, literalNets); err != nil {
+	if err := loadAllowedLPMMap(objs.AllowedIpv4, plan); err != nil {
 		return 0, 0, err
 	}
 
@@ -388,48 +399,84 @@ func loadEnforceMaps(objs *traceenforce.TraceenforceObjects, compiled policy.Com
 // reads it as a u32) and bytes [4:8] are the network address in network byte
 // order. Don't reorder fields without also updating the BPF `struct ns_lpm4_key`
 // definition in bpf/trace_enforce.bpf.c — they share wire format.
-func loadAllowedLPMMap(m *ebpf.Map, ipKeys map[[4]byte]struct{}, nets []*net.IPNet) error {
-	if m == nil {
-		if len(ipKeys) > 0 || len(nets) > 0 {
-			return fmt.Errorf("allowed_ipv4 map is nil with %d entries", len(ipKeys)+len(nets))
+type allowedLPMPlan struct {
+	singleIPKeys [][8]byte
+	cidrKeys     [][8]byte
+	totalEntries int
+}
+
+func buildAllowedLPMPlan(mapName string, ipKeys map[[4]byte]struct{}, nets []*net.IPNet) (allowedLPMPlan, error) {
+	plan := allowedLPMPlan{}
+	seen := make(map[[8]byte]struct{}, len(ipKeys)+len(nets))
+
+	addKey := func(key [8]byte, dst *[][8]byte) {
+		if _, ok := seen[key]; ok {
+			return
 		}
-		return nil
+		seen[key] = struct{}{}
+		*dst = append(*dst, key)
 	}
-	val := uint8(1)
+
+	// Build deterministic ordering for /32 entries.
+	ipAddrs := make([][4]byte, 0, len(ipKeys))
 	for addr := range ipKeys {
+		ipAddrs = append(ipAddrs, addr)
+	}
+	sort.Slice(ipAddrs, func(i, j int) bool {
+		return bytes.Compare(ipAddrs[i][:], ipAddrs[j][:]) < 0
+	})
+	for _, addr := range ipAddrs {
 		var key [8]byte
 		binary.LittleEndian.PutUint32(key[0:4], 32)
 		copy(key[4:8], addr[:])
-		if err := m.Update(key, val, ebpf.UpdateAny); err != nil {
-			return fmt.Errorf("load allowed_ipv4 map (/32 %d.%d.%d.%d): %w",
-				addr[0], addr[1], addr[2], addr[3], err)
-		}
+		addKey(key, &plan.singleIPKeys)
 	}
+
 	for _, n := range nets {
 		if n == nil {
-			slog.Warn("allowed_ipv4: skipping nil CIDR entry in allowed_ipv4 LPM load")
-			continue
+			return allowedLPMPlan{}, fmt.Errorf("%s: nil CIDR entry in policy", mapName)
 		}
 		ones, bits := n.Mask.Size()
 		if bits != 32 || ones < 0 || ones > 32 {
-			slog.Warn("allowed_ipv4: skipping CIDR with non-IPv4 mask (unexpected from policy parse)", "cidr", n.String(), "bits", bits, "ones", ones)
-			continue
+			return allowedLPMPlan{}, fmt.Errorf("%s: non-IPv4 CIDR mask %q (bits=%d ones=%d)", mapName, n.String(), bits, ones)
 		}
 		ip4 := n.IP.To4()
 		if ip4 == nil {
-			slog.Warn("allowed_ipv4: skipping non-IPv4 CIDR (unexpected from policy parse)", "cidr", n.String())
-			continue
+			return allowedLPMPlan{}, fmt.Errorf("%s: non-IPv4 CIDR %q", mapName, n.String())
 		}
 		network := ip4.Mask(n.Mask)
 		if network == nil {
-			slog.Warn("allowed_ipv4: skipping CIDR with nil masked network (unexpected)", "cidr", n.String())
-			continue
+			return allowedLPMPlan{}, fmt.Errorf("%s: invalid masked network for CIDR %q", mapName, n.String())
 		}
 		var key [8]byte
 		binary.LittleEndian.PutUint32(key[0:4], uint32(ones))
 		binary.BigEndian.PutUint32(key[4:8], binary.BigEndian.Uint32(network))
+		addKey(key, &plan.cidrKeys)
+	}
+
+	plan.totalEntries = len(seen)
+	return plan, nil
+}
+
+func loadAllowedLPMMap(m *ebpf.Map, plan allowedLPMPlan) error {
+	if m == nil {
+		if plan.totalEntries > 0 {
+			return fmt.Errorf("allowed_ipv4 map is nil with %d entries", plan.totalEntries)
+		}
+		return nil
+	}
+	val := uint8(1)
+	for _, key := range plan.singleIPKeys {
 		if err := m.Update(key, val, ebpf.UpdateAny); err != nil {
-			return fmt.Errorf("load allowed_ipv4 map (cidr %s): %w", n.String(), err)
+			addr := key[4:8]
+			return fmt.Errorf("load allowed_ipv4 map (/32 %d.%d.%d.%d): %w",
+				addr[0], addr[1], addr[2], addr[3], err)
+		}
+	}
+	for _, key := range plan.cidrKeys {
+		if err := m.Update(key, val, ebpf.UpdateAny); err != nil {
+			prefix := binary.LittleEndian.Uint32(key[0:4])
+			return fmt.Errorf("load allowed_ipv4 map (cidr %d.%d.%d.%d/%d): %w", key[4], key[5], key[6], key[7], prefix, err)
 		}
 	}
 	return nil

--- a/internal/agent/agent_linux_test.go
+++ b/internal/agent/agent_linux_test.go
@@ -728,6 +728,47 @@ func TestLoadIgnoredLPMMap_NoProgrammableIPv4ReturnsError(t *testing.T) {
 	}
 }
 
+func TestBuildAllowedLPMPlan_DeduplicatesAcrossIPAndCIDR(t *testing.T) {
+	ipKeys := map[[4]byte]struct{}{
+		{1, 1, 1, 1}: {},
+		{1, 1, 1, 2}: {},
+	}
+	_, cidr32a, err := net.ParseCIDR("1.1.1.1/32")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, cidr24, err := net.ParseCIDR("1.1.1.0/24")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	plan, err := buildAllowedLPMPlan("allowed_ipv4", ipKeys, []*net.IPNet{cidr32a, cidr24})
+	if err != nil {
+		t.Fatalf("buildAllowedLPMPlan: %v", err)
+	}
+	// 1.1.1.1/32 exists in both ipKeys and literal nets; should be counted once.
+	if plan.totalEntries != 3 {
+		t.Fatalf("totalEntries=%d want 3", plan.totalEntries)
+	}
+}
+
+func TestBuildAllowedLPMPlan_RejectsMalformedCIDRInput(t *testing.T) {
+	ipKeys := map[[4]byte]struct{}{
+		{1, 1, 1, 1}: {},
+	}
+	invalid := &net.IPNet{
+		IP:   net.ParseIP("2001:db8::"),
+		Mask: net.CIDRMask(64, 128),
+	}
+	_, err := buildAllowedLPMPlan("allowed_ipv4", ipKeys, []*net.IPNet{invalid})
+	if err == nil {
+		t.Fatal("expected malformed CIDR error")
+	}
+	if !strings.Contains(err.Error(), "non-IPv4 CIDR") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 // B-SR-04: Map.Update failures must stay identifiable (prefix + CIDR + %w) for callers like loadEnforceMaps.
 func TestLoadIgnoredLPMMap_MapUpdateFailureIsWrapped(t *testing.T) {
 	spec := &ebpf.MapSpec{

--- a/internal/agent/dns_cache.go
+++ b/internal/agent/dns_cache.go
@@ -20,6 +20,9 @@ const (
 	dnsMaxTTLSec  = 3600
 	dnsDefaultTTL = 300
 	dnsMinTTLSec  = 1
+	// dnsBPFNameMax is the maximum DNS name payload we write into the
+	// 256-byte BPF value buffer while preserving trailing NUL.
+	dnsBPFNameMax = 255
 )
 
 type dnsEntry struct {
@@ -60,6 +63,13 @@ func (c *DNSCache) SetBPFFailureCallback(cb func()) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.onBPFFailure = cb
+}
+
+func dnsNameForBPF(name string) (string, bool) {
+	if len(name) <= dnsBPFNameMax {
+		return name, false
+	}
+	return name[:dnsBPFNameMax], true
 }
 
 func ttlToExpiry(ttl uint32, now time.Time) int64 {
@@ -158,7 +168,13 @@ func (c *DNSCache) AddFromPacket(packet []byte) {
 			var bpfKey [4]byte
 			copy(bpfKey[:], ip[:])
 			var bpfVal [256]byte
-			copy(bpfVal[:], ans.name)
+			bpfName, truncated := dnsNameForBPF(ans.name)
+			if truncated {
+				ipString := net.IP(ip[:]).String()
+				slog.Warn("dns cache owner truncated for BPF map value",
+					"ip", ipString, "name_len", len(ans.name), "max_len", dnsBPFNameMax)
+			}
+			copy(bpfVal[:], bpfName)
 			for i, bpfMap := range c.bpfMaps {
 				if bpfMap == nil {
 					continue

--- a/internal/agent/dns_cache_test.go
+++ b/internal/agent/dns_cache_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"net"
 	"testing"
 	"time"
@@ -194,6 +195,17 @@ func TestDNSCache_failureCallbackRegistration(t *testing.T) {
 	c.AddFromPacket(minimalResponseWWWExample())
 	if called != 0 {
 		t.Fatalf("no BPF map registered, callback should not fire; got %d", called)
+	}
+}
+
+func TestDNSNameForBPF_TruncatesLongNames(t *testing.T) {
+	name := string(bytes.Repeat([]byte{'a'}, dnsBPFNameMax+10))
+	got, truncated := dnsNameForBPF(name)
+	if !truncated {
+		t.Fatal("expected truncation flag for oversized DNS name")
+	}
+	if len(got) != dnsBPFNameMax {
+		t.Fatalf("truncated length=%d want %d", len(got), dnsBPFNameMax)
 	}
 }
 


### PR DESCRIPTION
… options

Align enforce expected map counts with canonical deduplicated LPM programming and fail fast on malformed CIDRs to avoid false tamper churn.

Simplify workflow_dispatch to one ci_preset input (default/fast/strict) so users can run CI without juggling advanced toggles.