### PR TITLE
docs: add CLAUDE.md guide for AI assistants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,135 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo ships
+
+**coldstep** is a GitHub Action (`coldstep-io/coldstep@<tag>`) plus a Linux eBPF agent for GitHub-hosted `ubuntu-latest` runners. It records process / network egress activity to JSONL and optional Markdown digests, and can optionally block IPv4 egress not on an allowlist.
+
+Two runtime modes (the only `mode:` values; `enforce` is rejected at input parsing and in `CI_GUARD_MODE`):
+
+- **`detect`** (default) — observe-only telemetry.
+- **`defend`** — block non-allowlisted IPv4 egress via cgroup `connect4`/`sendmsg4` (+ BPF LSM where available). Requires a non-empty effective allowlist.
+
+Internally the config enum still uses `ModeEnforce` (`internal/config/config.go`) as the value `defend` maps to — do not let that mislead you into accepting `enforce` as a public input. Older JSONL artifacts may show `"mode":"enforce"`; that is legacy data only.
+
+## Build and dev commands
+
+**Build the agent + action + reporter (Linux only).** `scripts/build-agent-linux.sh` is the single source of truth — it installs clang/llvm/libbpf-dev, dumps BTF to `bpf/vmlinux.h` if missing, runs `go generate` for every `internal/bpf/<probe>` package, and `go build`s three binaries into `bin/`:
+
+```bash
+bash scripts/build-agent-linux.sh "$PWD"    # bin/coldstep, bin/coldstep-action, bin/coldstep-report
+```
+
+`bpf/vmlinux.h` and `internal/bpf/**/*_bpfel.go` / `*_bpfeb.go` are **gitignored generated artifacts** — never commit them.
+
+**Go checks (run on hosted Linux; mirror CI):**
+
+```bash
+bash scripts/check-gofmt.sh           # fail when gofmt -l prints anything
+bash scripts/check-encoding.sh        # mojibake + U+FFFD scan across tracked text
+go vet ./...
+staticcheck ./...                     # honnef.co/go/tools/cmd/staticcheck@v0.7.0
+go test ./... -count=1                # unit tests
+go test -race -count=1 ./internal/agent/... -timeout 15m
+sudo env "PATH=$PATH" go test -tags=integration ./internal/agent/... -count=1 -parallel 1   # needs BPF + root
+```
+
+Run a single test: `go test ./internal/agent -run TestRun_BuildsDigestInputWithUDPHTTPSectionState -count=1`.
+
+Integration tests are gated by `//go:build integration && linux && !windows` and require root for BPF load. The `traceconnect` program enables verbose verifier logging only when `COLDSTEP_BPF_VERBOSE_VERIFY` is set — leave it unset on hosted runners.
+
+BPF host-side C unit tests (portable helpers in `bpf/host_test/`) run as part of `build-agent-linux.sh` via `scripts/run-bpf-c-unit-tests.sh`.
+
+**TypeScript composite bundles (`src/` → `dist/`, legacy entrypoint):**
+
+```bash
+npm ci
+npm run typecheck                     # tsc --noEmit
+npm run build                         # esbuild pre/main/post → dist/{pre,main,post}/index.js
+```
+
+`action.yml` declares `using: node24` with `pre: dist/pre/index.js`, `main: dist/main/index.js`, `post: dist/post/index.js`. The TS layer is **legacy** — it largely shells out to the Go `coldstep-action` binary. If you edit `src/*.ts`, commit a matching `dist/` rebuild in the same PR (CI/CodeQL verifies it).
+
+**Local Linux oracle when not on Linux:**
+
+```bash
+bash scripts/docker-linux-test.sh     # ubuntu:24.04 container; mirrors build-agent-linux + go test ./...
+bash scripts/docker-deep-debug.sh     # closer to CI: vet, staticcheck, race, govulncheck, coverage, integration
+bash scripts/agent-linux-verify.sh    # wraps both, writes .coldstep-verify-last.log + COLDSTEP_AGENT_VERIFY_BUNDLE_* markers
+```
+
+Set `COLDSTEP_VERIFY_MODE=quick|deep|fast` to switch the wrapper (default `deep`). On Windows: `scripts\agent-linux-verify.cmd` or the `.ps1` / `.py` siblings.
+
+## Architecture
+
+### Three Go binaries, one composite action
+
+- **`cmd/coldstep`** (`bin/coldstep run`) — privileged BPF agent. `main` is one line: dispatch to `internal/agent.Main`. Linux-only build (`agent_linux.go`); a non-Linux stub returns an error so the binary still compiles cross-platform.
+- **`cmd/coldstep-action`** (`bin/coldstep-action start|stop`) — the action's runtime helper. `start` parses inputs from flags / `INPUT_*` env, sanitizes allowlists, computes effective config, and spawns `bin/coldstep run` as a `sudo` child. `stop` flushes the digest, optionally merges it into `$GITHUB_STEP_SUMMARY`, and optionally posts a PR comment via the GitHub REST API (bounded by `httpNotifyClient`'s 60s timeout — do not remove).
+- **`cmd/coldstep-report`** — post-run report pipeline invoked by demo workflows: `build-model`, `assert-integrity`, `render-summary`, `render-html`, `diff`, `rdns-enrich`, `otx-enrich`, `render-ip-summary`. Reads `.coldstep-events.jsonl`, produces a normalized model under `internal/report/model`, then renders / enriches.
+
+### Composite lifecycle (`action.yml`)
+
+`runs.using: node24` with `pre` / `main` / `post` JS entrypoints in `dist/`. The TS layer (`src/pre.ts`, `src/main.ts`, `src/post.ts`, `src/start.ts`, `src/stop.ts`, `src/shared.ts`) is a thin orchestrator — `pre.ts` starts the agent, `post.ts` stops it. `main.ts` keeps backward compat with the older `phase: start` / `phase: stop` flow where consumers had two `uses:` blocks; `phase` is now marked deprecated in `action.yml`.
+
+`action.yml` exposes a small set of current inputs (`mode`, `allow`, `allow-file`, `detect-profile`, `report`, `fail-on-error`, `signing-key`, `log-level`, `ignored-nets[-file]`, `bootstrap-allowlist`, `no-default-ignored-nets`, `ready-timeout-seconds`, `github-token`) plus a larger block of **deprecated** inputs kept for backward compatibility (`allowed-domains`, `allowed-hosts`, `allowed-ips`, `feature-gates`, `report-job-summary`, `report-pr-summary`, `phase`, `smoke-test-egress`, `io-uring-disable`, `release-path`). When adding inputs, follow that split — document current inputs in README/QUICK_START and leave the deprecated ones untouched unless removing.
+
+**Composite manifest rule:** GitHub only loads a repo-root composite from `action.yml` or `action.yaml`. Do not rename it.
+
+### Agent ↔ BPF wiring (`internal/agent/`, `internal/bpf/`, `bpf/`)
+
+Eight BPF probe packages under `internal/bpf/`, each compiled by `go generate`:
+
+| Package | Compiler driver | Why |
+| :------ | :------------- | :-- |
+| `traceexec`, `tracefork`, `traceenforce` | direct `//go:generate go run github.com/cilium/ebpf/cmd/bpf2go@v0.21.0 …` | No syscall-NR dispatch in the C source. |
+| `traceconnect`, `tracedns`, `tracefs`, `tracebpfaudit`, `tracelsmenforce` | indirect `//go:generate go run ./run_bpf2go.go` | C sources branch on syscall numbers per arch (`#if defined(bpf_target_arm64)` vs `bpf_target_x86`) so bpf2go must be invoked with `-D__TARGET_ARCH_<runtime.GOARCH>`; the wrapper builds the flags string. |
+
+Shared C headers live in `bpf/` (notably `coldstep_pure.h`, `deny_event.h`, `enforce_policy.inc`, `enforce_lpm_key.h`, `trace_connect_obs.h`, `trace_*_obs.inc`, `trace_tls_write.inc`). Defend hooks come from two .bpf.c files: `trace_enforce.bpf.c` (cgroup `connect4`/`sendmsg4`) and `trace_lsm_enforce.bpf.c` (BPF LSM `socket_connect`/`socket_sendmsg`). Both are IPv4-only — do not promise IPv6 anywhere.
+
+The agent's Linux entry (`internal/agent/agent_linux.go`) loads each program in a fixed order, captures BPF status into `telemetry.BPFStatus` rows used by the digest, and drains ringbufs through `agent_linux_ring_read.go`. Feature gates `proc_tree`, `tls_sni`, `fs_events` (parsed in `internal/config/featuregates.go`) toggle optional event streams; `COLDSTEP_DETECT_PROFILE=enhanced` flips defaults on if a key is unset. Set the same profile env on the post-run `coldstep-report build-model` step so integrity scoring matches.
+
+### Config + policy compilation
+
+`internal/config.LoadFromEnv` reads `CI_GUARD_MODE` and `COLDSTEP_*` env (set by `coldstep-action` from action inputs):
+
+- `CI_GUARD_MODE=enforce` is **rejected** (returns an error). `defend` maps internally to `ModeEnforce`. Detect is default.
+- `defend` mode also requires `COLDSTEP_ALLOWED_DOMAINS` to be non-empty.
+- Output paths default under `$GITHUB_WORKSPACE` and are overrideable: `COLDSTEP_EVENTS_LOG`, `COLDSTEP_DETECT_LOG`, `COLDSTEP_TELEMETRY_JSON`, `COLDSTEP_AGENT_STATUS`, `COLDSTEP_CGROUP_PATH`, `COLDSTEP_SIGNING_KEY`.
+
+`internal/policy/allowlist.go` resolves the effective IPv4 set. DNS lookups are bounded (`coldstepDomainLookupConcurrencyLimit = 32`, 25s per lookup) and warn when a single domain resolves to >10 IPv4s — warn-only, do not change effective allowlist on that path without updating the comments.
+
+### Report model + integrity gates
+
+`internal/report/model/` defines the on-disk JSON model that `coldstep-report build-model` produces from JSONL. `internal/report/integrity/` scores it: `RequiredTypesForDetectProfile("enhanced")` expands required event types from `{meta, exec, tcp}` to `{meta, exec, tcp, udp, http, tls, proc_fork, fs_event}`. Detect workflows in CI run `assert-integrity` as an anti-blindness gate.
+
+### Artifacts written to `$GITHUB_WORKSPACE`
+
+- `.coldstep-events.jsonl` — append-only event stream (source of truth).
+- `.coldstep-detect.md` — Markdown shutdown digest (post-step merges into Job Summary unless `report: none`/`pr-comment`).
+- `.coldstep-telemetry.json` — totals + BPF health.
+- `.coldstep-ready.json` — readiness probe; `fail-on-error: true` waits for `ok:true` (clamp 60–2700s, default 1500).
+- `.coldstep-agent.stderr.log`, `.coldstep-verify-last.log`, `.coldstep-deep-debug/` — local-only, gitignored.
+
+Note GitHub freezes per-step summary files when a step ends, so the agent writes to `.coldstep-detect.md` during the job; the **stop** step merges into `$GITHUB_STEP_SUMMARY`.
+
+## CI gates (what merges depend on)
+
+- **`coldstep-ci.yml`** (PR / push to main / dispatch) calls reusable **`coldstep-ci-runner.yml`**, which runs: `gofmt`, encoding scan, `unit` (ubuntu-latest + ubuntu-22.04 amd64), `unit-arm64` (ubuntu-24.04-arm + ubuntu-22.04-arm), `integration` (matrix, root, BPF), `action_bundle`, `detect-mode`, `defend-mode`. Concurrency does **not** cancel in-progress runs — defend mode can sit 20+ min in the BPF verifier and a new push must not cancel it.
+- **`coldstep-ci-nightly.yml`** — `go test -shuffle`, `govulncheck`, full-module race detector.
+- **`coldstep-demo.yml`**, **`coldstep-redteam-ebpf.yml`**, **`coldstep-pages.yml`**, **`supply-chain-attest.yml`** (tag `v*`, attestations + Linux agent upload to the Release).
+
+When CI fails on BPF verifier or generated-stub drift, run `bash scripts/agent-linux-verify.sh` locally (or via Docker) — its emitted `COLDSTEP_AGENT_VERIFY_BUNDLE_*` block is the recommended fix-loop format.
+
+## Conventions
+
+- **Go version:** `go 1.25.10` pinned in `go.mod`; CI uses `setup-go` with `go-version-file: go.mod`. Don't bump the minor in code without updating workflows.
+- **`gofmt` is enforced** on every tracked `.go` file in the working tree.
+- **Encoding:** repo is UTF-8 / LF. `.editorconfig` enforces tabs for Go, 2-space spaces for YAML/TS/JSON. `scripts/check-encoding.sh` blocks U+FFFD bytes (`EF BF BD`) and a specific mojibake sequence — common cause is shell quoting damage from PowerShell `gh pr edit --body "…"`; use `--body-file` and templates under `.github/pr-bodies/` instead.
+- **No vendored guard code.** Implementation is clean-room.
+- **Cross-platform builds:** every Linux-specific file uses `//go:build linux` and has a sibling stub for other GOOSes when needed (see `internal/agent/agent_stub.go`, `internal/cgroup/path_other.go`). Integration tests use `//go:build integration && linux && !windows`.
+- **Local-only / gitignored trees:** `plans/`, `docs/`, `design/`, `knowledge/`, `skills/`, `.cursor/`, `.vscode/`, `specs/`, `AGENTS.md`, `ARCHITECTURE.md`, `KNOWLEDGE_DIRECTOR.md`. `coldstep-ci-runner.yml` actively fails CI if `AGENTS.md` is committed. **Never** `git add -f` any of these paths.
+- **Docs alignment:** changes to `action.yml` inputs or workflow pins require updating `README.md`, `QUICK_START.md`, and the input descriptions in lockstep. Release pins (`MARKETPLACE_COLDSTEP_TAG`, `COLDSTEP_AGENT_VERSION`, `website/`) follow the two-train flow in `RELEASE_PROCESS.md` — repo docs + CI pins land in the release PR before `git tag`; `website/` bumps land in a **separate follow-up PR after** the tag exists on Releases.
+- **PR descriptions:** prefer the templates under `.github/pr-bodies/` (`gh pr create --body-file`); see `scripts/gh-pr-body.ps1` for the Windows wrapper.
+- **Optional pre-commit:** `.pre-commit-config.yaml` runs `scripts/check-encoding.sh` if the user installs pre-commit.


### PR DESCRIPTION
## Summary

Adds a repo-root `CLAUDE.md` so future Claude Code (and other AI assistant) sessions can come up to speed on coldstep without re-deriving the layout from scratch. Content is sourced from `README.md`, `QUICK_START.md`, `CONTRIBUTING.md`, `SECURITY.md`, `RELEASE_PROCESS.md`, `action.yml`, the CI workflows, and the actual Go / BPF source layout — not invented.

Covers:

- **Build / test commands** — `scripts/build-agent-linux.sh` as the single source of truth; how to run gofmt, encoding scan, `go vet`, `staticcheck`, unit, race, and the `integration`-tagged BPF tests; how to run a single test; the TypeScript composite bundle path (`npm run typecheck` / `build`); and the Docker / `agent-linux-verify` fallbacks for non-Linux hosts.
- **Architecture** — the three Go binaries (`cmd/coldstep`, `cmd/coldstep-action`, `cmd/coldstep-report`), the node24 `pre`/`main`/`post` composite lifecycle in `action.yml`, the eight `internal/bpf/*` probe packages split between direct and indirect `bpf2go` drivers (the indirect set needs `-D__TARGET_ARCH_<runtime.GOARCH>` because the C sources dispatch by syscall NR per arch), the IPv4-only defend hooks (`trace_enforce.bpf.c` cgroup + `trace_lsm_enforce.bpf.c` LSM), the env-driven config in `internal/config`, and the integrity-gated report model.
- **Mode contract** — `detect` vs `defend` only; `enforce` rejected at input parsing and in `CI_GUARD_MODE`; note that internally `defend` maps to `ModeEnforce` so reviewers don't try to "fix" that.
- **CI layout** — what `coldstep-ci.yml` → `coldstep-ci-runner.yml` runs, why the workflow does **not** cancel in-progress runs (defend mode can sit 20+ min in the BPF verifier), and the nightly / demo / supply-chain entry points.
- **Conventions** — Go 1.25.10 pin via `go.mod`, gofmt enforcement, the encoding guard's U+FFFD / mojibake rules, generated artifacts that are gitignored (`bpf/vmlinux.h`, `internal/bpf/**/*_bpfel.go`), the local-only gitignored trees (`plans/`, `docs/`, `design/`, `knowledge/`, `AGENTS.md`, `ARCHITECTURE.md`) that must never be `git add -f`'d (CI actively fails if `AGENTS.md` is committed), and the two-train release flow.

## Test plan

- [ ] Skim `CLAUDE.md` for accuracy against `README.md`, `action.yml`, and `coldstep-ci-runner.yml`.
- [ ] Confirm no commands or invariants contradict `CONTRIBUTING.md` / `RELEASE_PROCESS.md`.
- [ ] `coldstep-ci` runs against this branch (docs-only change; gofmt + encoding checks should pass).


---
_Generated by [Claude Code](https://claude.ai/code/session_018iEgnbyd5FoQn23ieM5kh3)_