### PR TITLE
chore(ci): SHA-pin all actions/* refs

### DIFF
--- a/.github/workflows/coldstep-ci-nightly.yml
+++ b/.github/workflows/coldstep-ci-nightly.yml
@@ -38,8 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
       - name: Prepare BPF and generated Go (same graph as PR unit job)
@@ -60,8 +60,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
       - name: Prepare BPF and generated Go
@@ -77,8 +77,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
       - name: Prepare BPF and generated Go
@@ -94,9 +94,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
 
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload deep-debug output
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: coldstep-deep-debug-${{ github.run_id }}
           path: .coldstep-deep-debug/

--- a/.github/workflows/coldstep-ci-runner.yml
+++ b/.github/workflows/coldstep-ci-runner.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 12
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - name: AGENTS.md must not be tracked
         run: |
           set -euo pipefail
@@ -44,7 +44,7 @@ jobs:
             echo "::error::AGENTS.md is listed in the git index. It must remain gitignored and local-only; remove with git rm --cached AGENTS.md and drop any commit that adds it."
             exit 1
           fi
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
       - name: gofmt check
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
   unit:
     name: unit (${{ matrix.os }})
@@ -68,8 +68,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
       - name: Prepare BPF and generated Go
@@ -98,8 +98,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
       - name: Prepare BPF and generated Go
@@ -132,8 +132,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
       - name: Prepare BPF
@@ -155,8 +155,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
       - name: Build action binaries
@@ -180,9 +180,9 @@ jobs:
       COLDSTEP_DIFF_STRICT: ${{ inputs.coldstep_diff_strict == true && '1' || '0' }}
       NS_RUNNER_LABEL: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
 
@@ -374,7 +374,7 @@ jobs:
         run: ./bin/coldstep-report render-summary
       - name: Persist detect JSONL baseline artifact
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: coldstep-events-baseline-ubuntu-latest
           path: ${{ github.workspace }}/.coldstep-events.jsonl
@@ -396,15 +396,15 @@ jobs:
     env:
       COLDSTEP_DEFEND_DENY_JSONL_STRICT: ${{ inputs.defend_deny_jsonl_strict && '1' || '0' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
 
       # Cache skips clang+bpf rebuild when sources unchanged — composite uses release-path so startup
       # stays fast under fail-on-error (BPF verifier remains on first load inside the agent).
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         id: coldstep-bin-cache
         with:
           path: bin/coldstep

--- a/.github/workflows/coldstep-demo.yml
+++ b/.github/workflows/coldstep-demo.yml
@@ -51,9 +51,9 @@ jobs:
       COLDSTEP_DIFF_STRICT: ${{ inputs.coldstep_diff_strict == true && '1' || '0' }}
       NS_RUNNER_LABEL: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
 
@@ -280,7 +280,7 @@ jobs:
 
       - name: Persist detect JSONL baseline artifact
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: coldstep-events-baseline-${{ env.NS_RUNNER_LABEL }}
           path: ${{ github.workspace }}/.coldstep-events.jsonl
@@ -302,9 +302,9 @@ jobs:
       # Align with coldstep-ci-runner defend-mode: release-binary smoke can miss deny JSONL on some runners.
       COLDSTEP_DEFEND_DENY_JSONL_STRICT: "0"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/coldstep-pages.yml
+++ b/.github/workflows/coldstep-pages.yml
@@ -28,14 +28,14 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - name: Configure Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5
         with:
           path: website
           include-hidden-files: true
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5

--- a/.github/workflows/coldstep-redteam-ebpf.yml
+++ b/.github/workflows/coldstep-redteam-ebpf.yml
@@ -31,9 +31,9 @@ jobs:
     env:
       NS_RUNNER_LABEL: ubuntu-latest-redteam
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
 
@@ -144,7 +144,7 @@ jobs:
 
       - name: Upload Redteam Report
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: coldstep-redteam-report
           path: ${{ github.workspace }}/coldstep-redteam-report.html

--- a/.github/workflows/supply-chain-attest.yml
+++ b/.github/workflows/supply-chain-attest.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
 
@@ -70,23 +70,23 @@ jobs:
           ls -la sbom-go.cdx.json sbom-action.cdx.json
 
       - name: Attest — build provenance (Go binary)
-        uses: actions/attest@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26  # v4
         with:
           subject-path: '${{ github.workspace }}/bin/coldstep'
 
       - name: Attest — build provenance (action bundle tarball)
-        uses: actions/attest@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26  # v4
         with:
           subject-path: '${{ github.workspace }}/coldstep-action-bundle.tar.gz'
 
       - name: Attest — SBOM for Go binary subject
-        uses: actions/attest@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26  # v4
         with:
           subject-path: '${{ github.workspace }}/bin/coldstep'
           sbom-path: '${{ github.workspace }}/sbom-go.cdx.json'
 
       - name: Attest — SBOM for action bundle subject
-        uses: actions/attest@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26  # v4
         with:
           subject-path: '${{ github.workspace }}/coldstep-action-bundle.tar.gz'
           sbom-path: '${{ github.workspace }}/sbom-action.cdx.json'
@@ -126,7 +126,7 @@ jobs:
           fi
 
       - name: Upload attestable artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: supply-chain-artifacts-${{ github.run_id }}
           path: |


### PR DESCRIPTION
## Summary

- Pin every `actions/*` reference in `.github/workflows/` to the immutable commit SHA the tag currently points to (with the version preserved as a trailing comment, e.g. `actions/checkout@de0fac2…  # v6`). A moved tag can no longer silently swap the action binary out from under any workflow.
- No `.github/dependabot.yml` change needed: a `github-actions` ecosystem entry is already configured there with `interval: weekly` and `open-pull-requests-limit: 10`, so the new pins will be kept current automatically.

## Pin map (tag → SHA)

| Action | Old | New |
|---|---|---|
| `actions/checkout` | `@v6` | `@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6` |
| `actions/setup-go` | `@v6` | `@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6` |
| `actions/upload-artifact` | `@v6` | `@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6` |
| `actions/configure-pages` | `@v6` | `@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6` |
| `actions/upload-pages-artifact` | `@v5` | `@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5` |
| `actions/deploy-pages` | `@v5` | `@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5` |
| `actions/attest` | `@v4` | `@59d89421af93a897026c735860bf21b6eb4f7b26  # v4` |
| `actions/cache` | `@v5` | `@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5` |

Local third-party uses (`./` and `./.github/workflows/coldstep-ci-runner.yml`) are unchanged — those resolve from the checked-out tree, not a remote tag.

## Test plan

- [ ] CodeQL passes (no workflow regression).
- [ ] `coldstep-ci` full matrix (Go format, action_manifest, unit, integration, detect-mode, defend-mode, action_bundle) is green on this branch.
- [ ] Spot-check one job log to confirm GitHub still resolves and downloads each action by SHA (the `Download action repository '<repo>@<sha>'` line should show our pinned SHA).
- [ ] After merge, confirm Dependabot opens action-update PRs going forward (next weekly tick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)