### PR TITLE
chore: add CodeQL and golangci-lint

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+# CodeQL SAST for Go and JS/TS. The Go matrix needs build-agent-linux.sh to run
+# before autobuild because the agent depends on bpf2go-generated bindings that
+# aren't checked in — same prerequisite as the unit job in coldstep-ci-runner.yml.
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 8 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [go, javascript-typescript]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
+        if: matrix.language == 'go'
+        with:
+          go-version-file: go.mod
+      - name: Prepare BPF and generated Go
+        if: matrix.language == 'go'
+        run: bash scripts/build-agent-linux.sh "$GITHUB_WORKSPACE"
+      - uses: github/codeql-action/init@ce28f5bb42b1c9b506d3b01b59e65d8f3f1a5ee6  # v3
+        with:
+          languages: ${{ matrix.language }}
+      - uses: github/codeql-action/autobuild@ce28f5bb42b1c9b506d3b01b59e65d8f3f1a5ee6  # v3
+      - uses: github/codeql-action/analyze@ce28f5bb42b1c9b506d3b01b59e65d8f3f1a5ee6  # v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,30 @@
+# golangci-lint: runs gosec, staticcheck, govet, errcheck, ineffassign, misspell.
+# BPF bindings must be generated (build-agent-linux.sh runs bpf2go) before linting,
+# otherwise the typecheck stage fails on the agent package — same pattern as the
+# unit job in coldstep-ci-runner.yml.
+
+name: lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci-lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
+        with:
+          go-version-file: go.mod
+      - name: Prepare BPF and generated Go
+        run: bash scripts/build-agent-linux.sh "$GITHUB_WORKSPACE"
+      - uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8  # v6
+        with:
+          version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,13 @@
+linters:
+  enable:
+    - gosec
+    - staticcheck
+    - govet
+    - errcheck
+    - ineffassign
+    - misspell
+
+issues:
+  exclude-rules:
+    - path: "_test\\.go"
+      linters: [gosec]

--- a/cmd/coldstep-action/main.go
+++ b/cmd/coldstep-action/main.go
@@ -167,7 +167,8 @@ func runStart(cfg startConfig) error {
 	if err := os.MkdirAll(filepath.Join(actionPath, "bin"), 0o755); err != nil {
 		return err
 	}
-	if err := os.WriteFile(detectLog, []byte{}, 0o644); err != nil {
+	// 0o644: detect log is read by the GitHub Actions runner for step summary output.
+	if err := os.WriteFile(detectLog, []byte{}, 0o644); err != nil { //nolint:gosec // G306: CI log file, must be runner-readable
 		return err
 	}
 	_ = os.Remove(agentStatus)
@@ -192,7 +193,7 @@ func runStart(cfg startConfig) error {
 		if err != nil {
 			return err
 		}
-		if err := os.WriteFile(binPath, raw, 0o755); err != nil {
+		if err := os.WriteFile(binPath, raw, 0o755); err != nil { //nolint:gosec // G306: agent binary, must be executable
 			return err
 		}
 	} else {
@@ -284,7 +285,7 @@ func runStart(cfg startConfig) error {
 			_ = p.Signal(syscall.SIGTERM)
 		}
 	}
-	if err := os.WriteFile(pidFile, []byte(strconv.Itoa(cmd.Process.Pid)), 0o644); err != nil {
+	if err := os.WriteFile(pidFile, []byte(strconv.Itoa(cmd.Process.Pid)), 0o644); err != nil { //nolint:gosec // G306: PID file, conventionally world-readable
 		stopAgent()
 		return err
 	}
@@ -300,7 +301,7 @@ func runStart(cfg startConfig) error {
 			stopAgent()
 			return fmt.Errorf("coldstep agent did not report ready (%s)", outcome)
 		}
-		if err := os.WriteFile(readyMarker, []byte("true"), 0o644); err != nil {
+		if err := os.WriteFile(readyMarker, []byte("true"), 0o644); err != nil { //nolint:gosec // G306: ready marker, conventionally world-readable
 			stopAgent()
 			return err
 		}


### PR DESCRIPTION
## Summary
- Adds CodeQL SAST for Go and JS/TS (push, PR, weekly schedule)
- Adds golangci-lint covering gosec, staticcheck, govet, errcheck, ineffassign, misspell
- Both workflows run `scripts/build-agent-linux.sh` before lint/autobuild because the agent imports bpf2go-generated bindings that aren't checked in (same prerequisite as the unit job in `coldstep-ci-runner.yml`)
- Annotates four `os.WriteFile` calls in `cmd/coldstep-action/main.go` with `//nolint:gosec` for G306 — the files (detect log, agent binary, PID file, ready marker) must be runner-readable or executable

## Test plan
- [ ] golangci-lint job passes on this PR
- [ ] CodeQL Go analysis completes
- [ ] CodeQL JS/TS analysis completes
- [ ] No new SARIF findings beyond expected