### PR TITLE
ci: add CodeQL and golangci-lint

### DIFF
--- a/.github/workflows/coldstep-ci.yml
+++ b/.github/workflows/coldstep-ci.yml
@@ -37,3 +37,24 @@ jobs:
       defend_deny_jsonl_strict: ${{ github.event_name == 'workflow_dispatch' && inputs.ci_preset == 'strict' || false }}
       skip_integration: ${{ github.event_name == 'workflow_dispatch' && inputs.ci_preset == 'fast' || false }}
     secrets: inherit
+
+  lint:
+    name: golangci-lint
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,16 @@
+version: "2"
+linters:
+  enable:
+    - govet
+    - staticcheck
+    - ineffassign
+    - unused
+    - errcheck
+    - gosec
+  exclusions:
+    rules:
+      - path: "_test\\.go"
+        linters: [gosec]
+formatters:
+  enable:
+    - gofmt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,11 @@ linters:
     - errcheck
     - gosec
   exclusions:
+    paths:
+      # bpf2go-generated companion files (LoadX, *Objects) are produced by
+      # `go generate` and not checked into git, so typecheck cannot resolve
+      # the hand-written abi_test.go references to them.
+      - "internal/bpf/"
     rules:
       - path: "_test\\.go"
         linters: [gosec]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,10 @@ linters:
     rules:
       - path: "_test\\.go"
         linters: [gosec]
+      # Belt-and-suspenders: typecheck issues bypass the paths filter for
+      # some packages under internal/bpf/ — silence them by linter too.
+      - path: "internal/bpf/"
+        linters: [typecheck]
 formatters:
   enable:
     - gofmt


### PR DESCRIPTION
Adds GitHub CodeQL analysis and golangci-lint job to CI. CodeQL runs on push/PR/weekly schedule. golangci-lint runs as a separate non-blocking job.