### PR TITLE
fix(agent): probe cgroup BPF enforcement before reporting ready

### DIFF
--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -259,6 +259,15 @@ func Run(ctx context.Context, cfg config.Config) error {
 			return fmt.Errorf("attach defend_sendmsg4: %w", err)
 		}
 		defer defendSendmsgLnk.Close()
+
+		// AttachCgroup returns once the program is bound, but on hosted runners the
+		// kernel has been observed to not yet enforce for newly-created sockets for
+		// ~1-3s afterward — so the first connect after .coldstep-ready.json was
+		// written could slip through. Block until a live probe deny is observed.
+		if err := probeDefendEnforcement(denyRd.R, defaultProbeTimeout); err != nil {
+			_ = writeAgentStatus(cfg.AgentStatusPath, false)
+			return fmt.Errorf("defend mode requires confirmed cgroup BPF enforcement: %w", err)
+		}
 	}
 
 	var execObjs traceexec.TraceexecObjects

--- a/internal/agent/agent_linux_probe.go
+++ b/internal/agent/agent_linux_probe.go
@@ -1,0 +1,120 @@
+//go:build linux
+
+package agent
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	"github.com/cilium/ebpf/ringbuf"
+)
+
+// probeDefendDst is a TEST-NET-3 (RFC 5737) IPv4 address used as the destination of
+// the post-attach self-test connect. TEST-NET-3 is documented as never routable on
+// the public internet, so a probe to it has no side effects beyond invoking the
+// cgroup connect4 BPF program.
+var probeDefendDst = net.IPv4(203, 0, 113, 1)
+
+const (
+	probeDefendDport    uint16        = 1
+	defaultProbeTimeout time.Duration = 5 * time.Second
+	probeDialTimeout    time.Duration = 50 * time.Millisecond
+	probeDialRetryEvery time.Duration = 50 * time.Millisecond
+)
+
+// probeDefendEnforcement verifies that the cgroup defend BPF program is actively
+// enforcing — not merely attached — before the caller declares the agent ready.
+//
+// AttachCgroup returns success once the program is bound to the cgroup, but on
+// GitHub-hosted ubuntu-latest runners the program is observed to not yet block
+// connects from newly-created sockets for ~1-3s afterward. This caused the first
+// connect after .coldstep-ready.json was written to slip through.
+//
+// The probe drives a TCP connect to a non-allowlisted destination (TEST-NET-3
+// 203.0.113.1:1) and waits for the corresponding deny ringbuf event. Receiving the
+// event proves: cgroup hook fires → deny ringbuf reserve succeeds → readable by
+// userspace. The connect attempt is retried at ~50ms intervals so a slow initial
+// subscribe does not miss the only event.
+//
+// Probe-originated deny events are drained inside this function. Other deny events
+// (background egress) arriving during the probe window are also drained — at agent
+// startup, before .coldstep-ready.json is written, no caller is yet reading the
+// ringbuf, and the probe completes before any meaningful workload begins.
+func probeDefendEnforcement(rd *ringbuf.Reader, timeout time.Duration) error {
+	if rd == nil {
+		return errors.New("probe: nil ringbuf reader")
+	}
+	if timeout <= 0 {
+		timeout = defaultProbeTimeout
+	}
+	deadline := time.Now().Add(timeout)
+
+	stop := make(chan struct{})
+	defer close(stop)
+	go runProbeDialLoop(stop, deadline)
+
+	rd.SetDeadline(deadline)
+	defer rd.SetDeadline(time.Time{})
+
+	for {
+		rec, err := rd.Read()
+		if err != nil {
+			if errors.Is(err, os.ErrDeadlineExceeded) {
+				return fmt.Errorf("probe: no matching deny event within %s — cgroup BPF not enforcing for newly-created sockets", timeout)
+			}
+			return fmt.Errorf("probe: ringbuf read: %w", err)
+		}
+		if matchProbeDenyEvent(rec.RawSample) {
+			return nil
+		}
+		// Non-probe deny event during startup — drain and keep waiting.
+	}
+}
+
+// runProbeDialLoop fires repeated TCP connects to the probe destination until the
+// deadline elapses or stop is closed. Each connect attempt is the BPF trigger; the
+// first one to be denied causes probeDefendEnforcement to return.
+func runProbeDialLoop(stop <-chan struct{}, deadline time.Time) {
+	dialer := net.Dialer{Timeout: probeDialTimeout}
+	addr := net.JoinHostPort(probeDefendDst.String(), fmt.Sprintf("%d", probeDefendDport))
+	for {
+		select {
+		case <-stop:
+			return
+		default:
+		}
+		if time.Now().After(deadline) {
+			return
+		}
+		conn, _ := dialer.Dial("tcp4", addr)
+		if conn != nil {
+			_ = conn.Close()
+		}
+		select {
+		case <-stop:
+			return
+		case <-time.After(probeDialRetryEvery):
+		}
+	}
+}
+
+// matchProbeDenyEvent reports whether a deny ringbuf payload corresponds to a
+// probeDefendEnforcement probe (TCP, AF_INET, daddr=probeDefendDst, dport=probeDefendDport).
+// Split out as a pure function so the matcher can be unit-tested without ringbuf infra.
+func matchProbeDenyEvent(raw []byte) bool {
+	if len(raw) < denyEventWireSize {
+		return false
+	}
+	protocol := raw[24]
+	af := raw[26]
+	dport := binary.BigEndian.Uint16(raw[44:46])
+	if protocol != denyProtoTCP || af != uint8(linuxAFInet) || dport != probeDefendDport {
+		return false
+	}
+	ip4 := probeDefendDst.To4()
+	return raw[28] == ip4[0] && raw[29] == ip4[1] && raw[30] == ip4[2] && raw[31] == ip4[3]
+}

--- a/internal/agent/agent_linux_probe_test.go
+++ b/internal/agent/agent_linux_probe_test.go
@@ -1,0 +1,47 @@
+//go:build linux
+
+package agent
+
+import (
+	"net"
+	"testing"
+)
+
+func TestMatchProbeDenyEvent_Match(t *testing.T) {
+	t.Parallel()
+	raw := fillTestDenyRawV4(0, 0, "probe", denyProtoTCP, denyReasonDstNotAllowlisted, probeDefendDst, probeDefendDport)
+	if !matchProbeDenyEvent(raw) {
+		t.Fatalf("expected match for canonical probe deny event")
+	}
+}
+
+func TestMatchProbeDenyEvent_WrongDstIP(t *testing.T) {
+	t.Parallel()
+	raw := fillTestDenyRawV4(0, 0, "probe", denyProtoTCP, denyReasonDstNotAllowlisted, net.ParseIP("1.2.3.4"), probeDefendDport)
+	if matchProbeDenyEvent(raw) {
+		t.Fatalf("expected no match: different destination IP must not be confused with probe")
+	}
+}
+
+func TestMatchProbeDenyEvent_WrongDport(t *testing.T) {
+	t.Parallel()
+	raw := fillTestDenyRawV4(0, 0, "probe", denyProtoTCP, denyReasonDstNotAllowlisted, probeDefendDst, 443)
+	if matchProbeDenyEvent(raw) {
+		t.Fatalf("expected no match: different destination port must not be confused with probe")
+	}
+}
+
+func TestMatchProbeDenyEvent_WrongProto(t *testing.T) {
+	t.Parallel()
+	raw := fillTestDenyRawV4(0, 0, "probe", denyProtoUDP, denyReasonDstNotAllowlisted, probeDefendDst, probeDefendDport)
+	if matchProbeDenyEvent(raw) {
+		t.Fatalf("expected no match: UDP deny must not be confused with TCP probe")
+	}
+}
+
+func TestMatchProbeDenyEvent_ShortBuffer(t *testing.T) {
+	t.Parallel()
+	if matchProbeDenyEvent(make([]byte, denyEventWireSize-1)) {
+		t.Fatalf("expected no match: truncated payload must be rejected")
+	}
+}


### PR DESCRIPTION
## Summary

`AttachCgroup` returns success once the program is bound, but on GitHub-hosted ubuntu-latest runners the kernel does not yet enforce the program for newly-created sockets for **~1-3 seconds afterward**. As a result, the first connect after `.coldstep-ready.json` flipped to \`ok:true\` could slip through, defeating defend mode for any workload that begins immediately after the agent declares ready.

The CLAUDE.md / action.yml comments already acknowledge that ok:true is written only after the deny reader goroutine is alive (avoiding a userspace race), but the same comments assume \`AttachCgroup\` returning success means the program is enforcing. Empirical testing in coldstep-labs shows that assumption does not hold on first connect.

## Fix

After both \`AttachCgroup\` calls (\`connect4\`, \`sendmsg4\`) succeed in defend mode, drive an active self-test:

1. Open a TCP socket to a non-allowlisted TEST-NET-3 destination (\`203.0.113.1:1\`) via \`net.Dialer\`.
2. Subscribe to the deny ringbuf and wait for the matching deny event (matched by protocol=TCP, AF_INET, daddr=203.0.113.1, dport=1).
3. Retry the dial at ~50ms intervals so a slow initial subscribe does not miss the only event.
4. **Block agent startup** (and therefore the readiness signal) until the matching event arrives — only then can we be sure the cgroup hook fires → ringbuf reserve → userspace read all works end-to-end.

On timeout (default 5s), write \`ok:false\` and return the same error shape used when syscall trace attach fails. Defend mode should fail loudly if it cannot guarantee enforcement.

## Why TEST-NET-3 (203.0.113.0/24)?

RFC 5737 reserves it for documentation and testing. It is never routable on the public internet, so the probe has no side effects beyond invoking the cgroup connect4 program. Port 1 is unassigned.

## Event handling

- **Probe-originated deny events**: drained inside the probe function — they do not reach \`readDenyRing\`.
- **Non-probe deny events** during the ~5s probe window: also drained. This is acceptable because (a) the probe runs *before* any deny reader goroutine is launched and *before* \`.coldstep-ready.json\` flips, and (b) no downstream consumer is expecting events yet.

## Tests

\`agent_linux_probe_test.go\` covers the matcher (\`matchProbeDenyEvent\`) directly using the existing \`fillTestDenyRawV4\` helper:

- canonical probe event → match
- different destination IP → no match
- different destination port → no match
- wrong protocol (UDP) → no match
- truncated payload → no match

The end-to-end probe (live ringbuf + cgroup BPF) is exercised by the existing \`TestRun_DefendModeBlockedConnectEmitsDenyJSONL\` integration test: the probe runs as part of normal defend startup; if it fails, the integration test fails. No new integration test is required.

## Follow-ups (deliberately out of scope)

- LSM backend has the same theoretical race; add a sibling LSM probe once we have empirical data showing the lag also affects LSM hooks.
- The lab repo workflow (\`coldstep-io/coldstep-labs/.github/workflows/defend-mode.yml\`) has a \`sleep 3\` workaround that can be removed once this lands and a new release is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)