### PR TITLE
fix(cgroup): attach defend BPF to cgroup v2 root, not agent sub-cgroup

### DIFF
--- a/internal/cgroup/path_linux.go
+++ b/internal/cgroup/path_linux.go
@@ -3,7 +3,6 @@
 package cgroup
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,20 +10,19 @@ import (
 )
 
 // AttachPath returns the cgroup directory used for BPF cgroup attach (e.g. link.AttachCgroup).
-// If override is non-empty (COLDSTEP_CGROUP_PATH), it must exist and be a directory.
-// Otherwise cgroup v2 unified hierarchy is read from /proc/self/cgroup (first "0::" line);
-// if missing or unusable, "/sys/fs/cgroup" is returned.
 //
-// Scope assumption — cgroup v2 ONLY. The "0::" prefix in /proc/self/cgroup is
-// the unified-hierarchy marker. cgroup v1 hosts emit per-controller lines like
-// `12:cpu:/user.slice/...` which have no "0::" entry, so this function falls
-// back to "/sys/fs/cgroup" (which on a v1 host is the tmpfs root containing
-// per-controller subdirs, not a cgroup directory) and the BPF
-// cgroup/connect4 + cgroup/sendmsg4 attach in trace_defend.bpf.c will fail
-// with EINVAL. Coldstep currently targets GitHub-hosted `ubuntu-latest`
-// runners which have used cgroup v2 unified hierarchy since the
-// `ubuntu-22.04` image (Linux 5.15+). v1 runner support is out of scope.
-// See knowledge/reports/2026-04-18-deep-ebpf-code-review-synthesis.md F-U2-02.
+// If override is non-empty (COLDSTEP_CGROUP_PATH), it must exist and be a directory; that
+// path is used as-is (useful for self-hosted runners that want to scope to a job cgroup).
+//
+// Otherwise the cgroup v2 unified-hierarchy root "/sys/fs/cgroup" is returned. Using the
+// root is intentional: coldstep runs as root (sudo -E) and must cover ALL job-step
+// processes, which on GitHub-hosted ubuntu-latest runners may be placed in sibling or
+// parent cgroups relative to the coldstep agent process. Attaching to a sub-cgroup (derived
+// from /proc/self/cgroup) would leave those steps unprotected.
+//
+// cgroup v1 note: "/sys/fs/cgroup" on a v1 host is the tmpfs root, not a cgroup directory,
+// so link.AttachCgroup will fail with EINVAL. v1 runners are out of scope; coldstep targets
+// GitHub-hosted ubuntu-latest which uses cgroup v2 unified hierarchy (kernel 5.15+).
 func AttachPath(override string) (string, error) {
 	o := strings.TrimSpace(override)
 	if o != "" {
@@ -38,28 +36,5 @@ func AttachPath(override string) (string, error) {
 		return filepath.Abs(o)
 	}
 
-	data, err := os.ReadFile("/proc/self/cgroup")
-	if err != nil {
-		return "/sys/fs/cgroup", nil
-	}
-	sc := bufio.NewScanner(strings.NewReader(string(data)))
-	for sc.Scan() {
-		line := sc.Text()
-		if !strings.HasPrefix(line, "0::") {
-			continue
-		}
-		rel := strings.TrimPrefix(line, "0::")
-		rel = strings.TrimSpace(rel)
-		base := "/sys/fs/cgroup"
-		if rel == "" || rel == "/" {
-			return base, nil
-		}
-		rel = strings.TrimPrefix(rel, "/")
-		full := filepath.Join(base, rel)
-		if st, err := os.Stat(full); err == nil && st.IsDir() {
-			return full, nil
-		}
-		return base, nil
-	}
 	return "/sys/fs/cgroup", nil
 }

--- a/internal/cgroup/path_linux_test.go
+++ b/internal/cgroup/path_linux_test.go
@@ -20,6 +20,20 @@ func TestAttachPath_linux_default(t *testing.T) {
 	}
 }
 
+// TestAttachPath_linux_root verifies that the default attach path is the cgroup v2
+// root (/sys/fs/cgroup), not a sub-cgroup derived from /proc/self/cgroup.
+// This ensures the BPF program covers ALL job-step processes on GitHub-hosted runners,
+// which may run in different cgroups than the coldstep agent (root via sudo).
+func TestAttachPath_linux_root(t *testing.T) {
+	got, err := AttachPath("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/sys/fs/cgroup" {
+		t.Fatalf("default attach path = %q, want /sys/fs/cgroup (root cgroup)", got)
+	}
+}
+
 func TestAttachPath_linux_override(t *testing.T) {
 	dir := t.TempDir()
 	got, err := AttachPath(dir)


### PR DESCRIPTION
Root cause of defend mode blocking zero connections: the agent attached the BPF cgroup program to its own sub-cgroup (read from /proc/self/cgroup). On GitHub-hosted runners, sudo-spawned processes land in a different cgroup than regular job steps, so npm install and other step processes were never covered.

Fix: always default to /sys/fs/cgroup (the cgroup v2 root). Running as root gives permission, and the isolated VM means this covers exactly the right scope.