### PR TITLE
docs(website): bump pin to v0.2.4, rename enforce-mode to defend, note IPv4-only scope

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -58,7 +58,7 @@
               <div class="pipeline-row">
                 <span class="pill">BPF load</span>
                 <span class="bar" aria-hidden="true"></span>
-                <strong>observe / enforce</strong>
+                <strong>observe / defend</strong>
               </div>
               <div class="pipeline-row">
                 <span class="pill">your job</span>
@@ -87,7 +87,7 @@
             <article class="feature" data-reveal>
               <h3>Progressive hardening</h3>
               <p>
-                Start in detect mode to learn normal egress. When policy is clear, switch to enforce mode with explicit
+                Start in detect mode to learn normal egress. When policy is clear, switch to defend mode with explicit
                 allowlists so unexpected destinations fail the job early instead of silently leaking.
               </p>
             </article>
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: coldstep-io/coldstep@v0.2.1
+      - uses: coldstep-io/coldstep@v0.2.4
 </code></pre>
           </div>
         </section>
@@ -129,7 +129,7 @@ jobs:
         <section class="section section--tight-top" aria-labelledby="modes-heading">
           <h2 id="modes-heading">Two modes, one agent</h2>
           <p class="section-intro">
-            Pin a release tag in workflows (for example <code>coldstep-io/coldstep@v0.2.1</code>) instead of tracking
+            Pin a release tag in workflows (for example <code>coldstep-io/coldstep@v0.2.4</code>) instead of tracking
             <code>@main</code> unless you intentionally want churn.
           </p>
           <div class="modes">
@@ -139,10 +139,11 @@ jobs:
               <span class="mode-tag">Default</span>
             </div>
             <div class="mode">
-              <h3>Enforce</h3>
+              <h3>Defend</h3>
               <p>
-                Block TCP and UDP egress outside your allowlist. Requires explicit configuration—this is a guardrail,
-                not a surprise.
+                Block IPv4 egress outside your allowlist (cgroup <code>connect4</code> / <code>sendmsg4</code>, BPF
+                LSM where available). Requires a non-empty allowlist—this is a guardrail, not a surprise. IPv6 is
+                out of scope.
               </p>
               <span class="mode-tag">Opt-in</span>
             </div>


### PR DESCRIPTION
Follow-up to the v0.2.4 release train. Per `RELEASE_PROCESS.md`, `website/` bumps land in a separate PR after the tag exists on Releases — and v0.2.4 was tagged + asset published earlier today (asset digest `672a4de1140eb5b6777d00192eb5cb99861b43adcc511d46fdb2d21d1ef04104`).

The site had drifted further than just one release: it was still pinned at `v0.2.1` (it missed the v0.2.2 and v0.2.3 follow-ups too) and still used `enforce` for the literal mode name, which has been rejected at input parsing for a while.

## Changes (`website/index.html`)

- **Version pin → v0.2.4** (two places — the YAML snippet on L124 and the modes-section example on L132).
- **Mode-name `enforce` → `defend`** in the three spots where the wording refers to the actual `mode:` input value:
  - Hero panel pipeline row: `observe / enforce` → `observe / defend`.
  - "Progressive hardening" feature: "switch to enforce mode" → "switch to defend mode".
  - Modes section: `<h3>Enforce</h3>` → `<h3>Defend</h3>`.
- **IPv4-only scope callout** in the defend-mode description, matching CLAUDE.md's "Both are IPv4-only — do not promise IPv6 anywhere":

  > Block IPv4 egress outside your allowlist (cgroup `connect4` / `sendmsg4`, BPF LSM where available). Requires a non-empty allowlist—this is a guardrail, not a surprise. IPv6 is out of scope.

Pure-English uses of the verb "enforce" / noun "enforcement" (meta description, hero lede) are left as-is since they read as ordinary English, not as references to the deprecated mode name.

## Deploy

`coldstep-pages.yml` triggers on `push: main, paths: website/**`, so merging this PR will publish the changes to GitHub Pages without a manual `workflow_dispatch`.

## Verification

```
$ grep -E "v0\.2\.[0-3]|>Enforce<|observe / enforce|enforce mode" website/
(no matches)
```
