### PR TITLE
ci: add golangci-lint and CodeQL workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+name: codeql
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '30 4 * * 1'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [go, javascript-typescript]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        if: matrix.language == 'go'
+        with:
+          go-version-file: go.mod
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # Exclude BPF generated stub packages — they don't exist in the
+          # source tree and would cause CodeQL build failures.
+          config: |
+            paths-ignore:
+              - internal/bpf
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,31 @@
+name: lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci-lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64.8
+          # internal/bpf/ packages require generated files that are only
+          # produced by `go generate` on Linux with clang installed.
+          # The .golangci.yml exclusions handle typecheck errors, but skip
+          # the whole subtree from being linted at the package level too.
+          args: --timeout=5m $(go list ./... | grep -v 'internal/bpf' | tr '\n' ' ')


### PR DESCRIPTION
﻿Adds two CI gates:
- golangci-lint (v1.64.8) on all PRs — excludes internal/bpf which requires go generate output
- CodeQL (Go + TypeScript) weekly + on PRs

.golangci.yml is already on main with the correct internal/bpf exclusions.
