### PR TITLE
refactor: consolidate allowlist compile path (phase 2.2)

### DIFF
--- a/internal/agent/agent_linux_policy_maps.go
+++ b/internal/agent/agent_linux_policy_maps.go
@@ -276,6 +276,29 @@ func readLSMDenyReserveFailureCount(objs *tracelsmdefend.TracelsmdefendObjects) 
 	return readUint32PerCPUArraySum(objs.LsmDenyReserveFailures, "readLSMDenyReserveFailureCount")
 }
 
+// buildDefendAllowedPlan unifies the compile-and-merge sequence shared by the
+// cgroup and LSM defend loaders: take compiled domain resolutions, fold in the
+// literal IPv4 entries from the policy, and produce an LPM plan ready to write
+// into the BPF allowlist map identified by mapName. The two callers differ only
+// in which BPF map (allowed_ipv4 vs lsm_allowed_ipv4) receives the result.
+func buildDefendAllowedPlan(mapName string, compiled policy.CompileResult, pol *policy.Policy) (allowedLPMPlan, error) {
+	v4keys := make(map[[4]byte]struct{}, compiled.AllowedIPv4.Len())
+	compiled.AllowedIPv4.ForEach(func(k [4]byte) { v4keys[k] = struct{}{} })
+	pol.MergeLiteralAllowedIPv4Keys(v4keys)
+
+	plan, err := buildAllowedLPMPlan(mapName, v4keys, pol.AllowedIPv4Nets())
+	if err != nil {
+		return allowedLPMPlan{}, err
+	}
+	if plan.totalEntries > policy.MaxAllowedDefendIPv4Keys {
+		return allowedLPMPlan{}, fmt.Errorf("%s: %d entries exceeds BPF max %d", mapName, plan.totalEntries, policy.MaxAllowedDefendIPv4Keys)
+	}
+	if plan.totalEntries == 0 {
+		return allowedLPMPlan{}, fmt.Errorf("defend allowlist effective allowlist is empty (no map entries)")
+	}
+	return plan, nil
+}
+
 func loadLSMDefendMaps(objs *tracelsmdefend.TracelsmdefendObjects, compiled policy.CompileResult, pol *policy.Policy) (int, int, error) {
 	if objs == nil {
 		return 0, 0, fmt.Errorf("tracelsmdefend objects are required for defend mode")
@@ -294,27 +317,9 @@ func loadLSMDefendMaps(objs *tracelsmdefend.TracelsmdefendObjects, compiled poli
 		}
 	}
 
-	v4keys := make(map[[4]byte]struct{}, compiled.AllowedIPv4.Len())
-	compiled.AllowedIPv4.ForEach(func(k [4]byte) { v4keys[k] = struct{}{} })
-	if pol != nil {
-		pol.MergeLiteralAllowedIPv4Keys(v4keys)
-	}
-	var literalNets []*net.IPNet
-	if pol != nil {
-		literalNets = pol.AllowedIPv4Nets()
-	}
-
-	plan, err := buildAllowedLPMPlan("lsm_allowed_ipv4", v4keys, literalNets)
+	plan, err := buildDefendAllowedPlan("lsm_allowed_ipv4", compiled, pol)
 	if err != nil {
 		return 0, 0, err
-	}
-	totalEntries := plan.totalEntries
-	if totalEntries > policy.MaxAllowedDefendIPv4Keys {
-		return 0, 0, fmt.Errorf("lsm_allowed_ipv4: %d entries exceeds BPF max %d", totalEntries, policy.MaxAllowedDefendIPv4Keys)
-	}
-
-	if totalEntries == 0 {
-		return 0, 0, fmt.Errorf("defend allowlist effective allowlist is empty (no map entries)")
 	}
 
 	if err := loadAllowedLPMMap(objs.LsmAllowedIpv4, plan); err != nil {
@@ -325,7 +330,7 @@ func loadLSMDefendMaps(objs *tracelsmdefend.TracelsmdefendObjects, compiled poli
 		return 0, 0, err
 	}
 
-	return totalEntries, ignoredCount, nil
+	return plan.totalEntries, ignoredCount, nil
 }
 
 // loadDefendMaps programs BPF allowlist maps from compiled domain resolutions + literal policy entries.
@@ -353,27 +358,9 @@ func loadDefendMaps(objs *tracedefend.TracedefendObjects, compiled policy.Compil
 		}
 	}
 
-	v4keys := make(map[[4]byte]struct{}, compiled.AllowedIPv4.Len())
-	compiled.AllowedIPv4.ForEach(func(k [4]byte) { v4keys[k] = struct{}{} })
-	if pol != nil {
-		pol.MergeLiteralAllowedIPv4Keys(v4keys)
-	}
-	var literalNets []*net.IPNet
-	if pol != nil {
-		literalNets = pol.AllowedIPv4Nets()
-	}
-
-	plan, err := buildAllowedLPMPlan("allowed_ipv4", v4keys, literalNets)
+	plan, err := buildDefendAllowedPlan("allowed_ipv4", compiled, pol)
 	if err != nil {
 		return 0, 0, err
-	}
-	totalEntries := plan.totalEntries
-	if totalEntries > policy.MaxAllowedDefendIPv4Keys {
-		return 0, 0, fmt.Errorf("allowed_ipv4: %d entries exceeds BPF max %d", totalEntries, policy.MaxAllowedDefendIPv4Keys)
-	}
-
-	if totalEntries == 0 {
-		return 0, 0, fmt.Errorf("defend allowlist effective allowlist is empty (no map entries)")
 	}
 
 	if err := loadAllowedLPMMap(objs.AllowedIpv4, plan); err != nil {
@@ -384,7 +371,7 @@ func loadDefendMaps(objs *tracedefend.TracedefendObjects, compiled policy.Compil
 		return 0, 0, err
 	}
 
-	return totalEntries, ignoredCount, nil
+	return plan.totalEntries, ignoredCount, nil
 }
 
 // loadAllowedLPMMap programs the allowed_ipv4 LPM trie (PR-G).


### PR DESCRIPTION
﻿## Summary

- Phase 2.2 of `SIMPLIFICATION_PLAN.md`: extract the duplicated compile-and-merge sequence shared by `loadDefendMaps` (cgroup) and `loadLSMDefendMaps` (LSM) into a single helper, `buildDefendAllowedPlan`, in `internal/agent/agent_linux_policy_maps.go`.
- Both callers now build the `allowedLPMPlan` through the same path; they differ only in which BPF map (`allowed_ipv4` vs `lsm_allowed_ipv4`) receives the result.
- Net -13 LOC in `internal/agent/agent_linux_policy_maps.go`.

## Behavior

Pure Go refactor with zero observable change:
- Same IPv4 keys merged in the same order (compiled domain resolutions + `pol.MergeLiteralAllowedIPv4Keys` + `pol.AllowedIPv4Nets()`).
- Same `MaxAllowedDefendIPv4Keys` cap and same `defend allowlist effective allowlist is empty (no map entries)` error.
- Same `mapName`-prefixed `%s: %d entries exceeds BPF max %d` error string (`allowed_ipv4:` for cgroup, `lsm_allowed_ipv4:` for LSM).
- The `cfg.BuildPolicy()` seam is untouched; `compileDefendAllowlist` (which calls `policy.CompileDomainAllowlist`) is unchanged.
- Both `*policy.Policy` methods used in the helper (`MergeLiteralAllowedIPv4Keys`, `AllowedIPv4Nets`) are nil-safe on receiver, preserving the previous `if pol != nil` behavior.

## Test plan

- [x] `gofmt -l internal/agent/agent_linux_policy_maps.go` — clean
- [x] `go vet ./internal/policy/...` — clean
- [x] `go vet ./internal/agent/...` — clean (Windows; Linux-only files require generated BPF stubs only present on the Linux builder)
- [ ] CI: `coldstep-ci.yml` unit + integration + defend-mode + detect-mode (verifies the BPF map load paths on a Linux runner with bpf2go stubs generated)

Refs: `SIMPLIFICATION_PLAN.md` phase 2.2.

Generated with [Claude Code](https://claude.com/claude-code)
