### PR TITLE
ci: restore golangci-lint signal -- generate BPF stubs before lint

### DIFF
--- a/.github/workflows/coldstep-ci.yml
+++ b/.github/workflows/coldstep-ci.yml
@@ -42,7 +42,6 @@ jobs:
     name: golangci-lint
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    continue-on-error: true
     permissions:
       contents: read
     steps:
@@ -53,6 +52,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+
+      - name: Prepare BPF and generated Go
+        run: bash scripts/build-agent-linux.sh "$GITHUB_WORKSPACE"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8

--- a/SIMPLIFICATION_PLAN.md
+++ b/SIMPLIFICATION_PLAN.md
@@ -1,12 +1,12 @@
 # Coldstep Simplification Plan
 
-> **Status:** Phase 2.4 (this document) complete. Phases 2.2 and 2.3 planned.
+> **Status:** Phases 2.2 and 2.4 complete. Phase 2.3 planned.
 >
 > This file lives at the repo root and is tracked in git (unlike `/docs/`).
 
 ---
 
-## Phase 2.2 — Unified policy loader
+## Phase 2.2 — Unified policy loader ✓ done (PR #136, net -13 LOC)
 
 ### Current state
 
@@ -99,5 +99,5 @@ None.
 ## Completion checklist
 
 - [x] 2.4 — SIMPLIFICATION_PLAN.md written and tracked
-- [ ] 2.2 — Unified policy loader implemented and merged
+- [x] 2.2 — Unified policy loader implemented and merged (PR #136, net -13 LOC)
 - [ ] 2.3 — Shared BPF skeleton implemented and merged


### PR DESCRIPTION
The golangci-lint job ran with continue-on-error: true because the BPF-generated stubs were missing, causing typecheck to fail. This adds the same Prepare BPF and generated Go step that every other Linux CI job already has, and removes the continue-on-error swallow. Also marks Phase 2.2 complete in SIMPLIFICATION_PLAN.md (merged as PR 136, net -13 LOC).