### PR TITLE
feat(bpf): HTTP/80 sniff parity for write/writev/pwrite* (BG-04)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- **HTTP/1 sniff parity for write(2) family** — plaintext HTTP/1 requests on dport 80 are now captured when emitted via `write(2)`, `writev(2)`, `pwrite64(2)`, `pwritev(2)`, or `pwritev2(2)` on a connected TCP socket. Previously only the `sendto(2)` arm produced `http_events`; Go `net/http`, libcurl over plain HTTP, and most stdlib HTTP clients use `write(2)` and were silently missing from the HTTP JSONL stream. The new dispatch helper fetches the (tgid,fd) tuple once and runs both the TLS-ClientHello sniff and the HTTP/80 sniff from a single LRU lookup, keeping the verifier budget flat. (BG-04)
+
 ### Changed
 - refactor: consolidate four `*EmptyReason` digest helpers into `protocolEmptyReason`.
 

--- a/bpf/trace_connect.bpf.c
+++ b/bpf/trace_connect.bpf.c
@@ -4,7 +4,8 @@
  *   - IPv4-only TCP connect + (tgid,fd)->dst map for optional TLS ClientHello correlation
  *   - IPv4 egress via sendto(2) and sendmsg(2) → `udp_events` ringbuf (name legacy; includes TCP sendto;
  *     not complete for all UDP egress paths)
- *   - Optional cleartext HTTP/1 on destination port 80 and TLS ClientHello sniff on write/writev/pwrite(2)/pwritev/pwritev2/sendto
+ *   - Optional cleartext HTTP/1 on destination port 80 and TLS ClientHello sniff on
+ *     write/writev/pwrite64/pwritev/pwritev2/sendto (single tuple lookup shared by both sniffs)
  *   - LRU map eviction handles stale (tgid,fd) entries (close(2) cleanup removed)
  *
  * Logic is split across bpf/trace_tcp_obs.inc, trace_udp_obs.inc, and trace_http_obs.inc
@@ -426,7 +427,7 @@ int handle_raw_sys_enter(struct bpf_raw_tracepoint_args *ctx)
 		if (ns_read_syscall_arg(regs, 2, &dx_ul))
 			return 0;
 
-		return handle_tls_obs_sys_enter(id, di_ul, si_ul, dx_ul);
+		return handle_write_obs_sys_enter(id, di_ul, si_ul, dx_ul);
 	}
 
 	if (id == (long)COLDSTEP_NR_SENDMMSG) {

--- a/bpf/trace_tls_write.inc
+++ b/bpf/trace_tls_write.inc
@@ -1,9 +1,10 @@
 /*
- * TLS ClientHello sniff on IPv4 TCP buffers.
+ * TLS ClientHello + plaintext HTTP/1 sniff on IPv4 TCP buffers.
  *
  * Dispatch:
- *   - write(2) / writev(2) / pwrite(2) / pwritev(2) / pwritev2(2): handled here via
- *     handle_tls_obs_sys_enter (tuple from fd map; first three syscall args match write/writev ABI).
+ *   - write(2) / writev(2) / pwrite64(2) / pwritev(2) / pwritev2(2): handled here via
+ *     handle_write_obs_sys_enter (tuple from fd map; first three syscall args match write/writev ABI).
+ *     One LRU lookup feeds both TLS and HTTP/80 sniff (mirrors the sendto arm in trace_connect.bpf.c).
  *   - sendto(2): handled in trace_connect.bpf.c NR_SENDTO — builds connect4_tuple from
  *     cached connect tuple OR explicit sockaddr-in (parity with HTTP sendto path).
  */
@@ -86,23 +87,53 @@ static __always_inline void try_emit_tls_clienthello_from_tuple(struct connect4_
 	}
 }
 
-/* NR_write/NR_writev: fd lookup then try_emit_tls_clienthello_from_tuple. NR_sendto paths call try_emit_tls_clienthello_from_tuple from trace_connect.bpf.c (including explicit sockaddr TCP sendto). */
-static __always_inline void try_emit_tls_clienthello(__u32 fd32, unsigned long buf_ptr, __u32 len_in)
+/*
+ * Run both TLS-ClientHello and HTTP/80 sniff against a single buffer using a
+ * pre-fetched (tgid,fd) tuple. Used by handle_write_obs_sys_enter so each
+ * write/writev/pwrite* dispatch does at most one connect4_by_tgid_fd lookup.
+ * Mirrors the sendto arm in trace_connect.bpf.c (TLS + HTTP from one tuple).
+ */
+static __always_inline void try_emit_buffer_sniff_from_tuple(struct connect4_tuple *tup,
+							     unsigned long buf_ptr, __u32 len,
+							     __u64 pt)
+{
+	try_emit_tls_clienthello_from_tuple(tup, buf_ptr, len, pt);
+
+	if (!tup || !tup->in_use)
+		return;
+
+	{
+		__be16 sin_port;
+		__be32 sin_addr;
+
+		__builtin_memcpy(&sin_port, tup->dport, sizeof(sin_port));
+		__builtin_memcpy(&sin_addr, tup->daddr, sizeof(sin_addr));
+
+		if (sin_port == bpf_htons(80) && len >= 4 &&
+		    http_prefix_looks_like_request(buf_ptr, len))
+			handle_http_obs_emit_pt(pt, buf_ptr, len, sin_port, sin_addr);
+	}
+}
+
+/*
+ * write/writev/pwrite64/pwritev/pwritev2 dispatch: fetch (tgid,fd) tuple once,
+ * run TLS ClientHello sniff (any port) and HTTP/1 plaintext sniff (dport 80).
+ * di/si/dx are syscall arg registers as read in handle_raw_sys_enter.
+ */
+static __always_inline int handle_write_obs_sys_enter(long id, unsigned long di_ul,
+						      unsigned long si_ul, unsigned long dx_ul)
 {
 	struct connect4_tuple tup;
 	__u64 pt;
 
-	if (coldstep_connect_tuple_fetch(fd32, &tup, &pt))
-		return;
-	try_emit_tls_clienthello_from_tuple(&tup, buf_ptr, len_in, pt);
-}
+	if (coldstep_connect_tuple_fetch((__u32)di_ul, &tup, &pt))
+		return 0;
 
-/* id + syscall arg registers; di/si/dx read only in handle_raw_sys_enter. */
-static __always_inline int handle_tls_obs_sys_enter(long id, unsigned long di_ul,
-						   unsigned long si_ul, unsigned long dx_ul)
-{
-	if (id == (long)COLDSTEP_NR_WRITE) {
-		try_emit_tls_clienthello((__u32)di_ul, si_ul, coldstep_syscall_len_u32(dx_ul));
+	if (id == (long)COLDSTEP_NR_WRITE || id == (long)COLDSTEP_NR_PWRITE64) {
+		/* fd, buf, count — same first-three-arg layout for write and pwrite64
+		 * (pwrite64 offset is arg3, ignored for sniff). */
+		try_emit_buffer_sniff_from_tuple(&tup, si_ul, coldstep_syscall_len_u32(dx_ul),
+						 pt);
 		return 0;
 	}
 
@@ -130,15 +161,10 @@ static __always_inline int handle_tls_obs_sys_enter(long id, unsigned long di_ul
 				__u32 iov_len = coldstep_syscall_len_u32(iov0.iov_len);
 				if (iov_len > TLS_PAYLOAD_MAX)
 					iov_len = TLS_PAYLOAD_MAX;
-				try_emit_tls_clienthello((__u32)di_ul, iov0.iov_base, iov_len);
+				try_emit_buffer_sniff_from_tuple(&tup, iov0.iov_base, iov_len,
+								 pt);
 			}
 		}
-		return 0;
-	}
-
-	if (id == (long)COLDSTEP_NR_PWRITE64) {
-		/* fd, buf, count — same layout as NR_WRITE; offset is arg3 (ignored for sniff). */
-		try_emit_tls_clienthello((__u32)di_ul, si_ul, coldstep_syscall_len_u32(dx_ul));
 		return 0;
 	}
 

--- a/internal/agent/agent_integration_test.go
+++ b/internal/agent/agent_integration_test.go
@@ -496,6 +496,90 @@ s.close()
 	}
 }
 
+// TestRun_HTTPWritePort80JSONL covers BG-04: HTTP/1 plaintext on dport 80 emitted via
+// write(2)/pwrite64(2) after a TCP connect must produce a "type":"http" JSONL row, same as
+// the sendto(2) arm. Mirrors TestRun_HTTPSendtoPort80JSONL but uses write/os.write and
+// pwrite to exercise the write/pwrite* dispatch arm in trace_connect.bpf.c.
+func TestRun_HTTPWritePort80JSONL(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root for BPF load")
+	}
+	skipIfUnsupportedSyscallBPFKernel(t)
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not installed:", err)
+	}
+	dir := t.TempDir()
+	detect := filepath.Join(dir, "detect.md")
+	events := filepath.Join(dir, ".coldstep-events.jsonl")
+	probe := filepath.Join(dir, "http_write_probe.py")
+	if err := os.WriteFile(detect, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GITHUB_WORKSPACE", dir)
+	t.Setenv("COLDSTEP_ALLOWED_HOSTS", "")
+	t.Setenv("COLDSTEP_ALLOWED_IPS", "")
+	t.Setenv("CI_GUARD_MODE", "detect")
+	t.Setenv("GITHUB_STEP_SUMMARY", "")
+	t.Setenv("COLDSTEP_DETECT_LOG", detect)
+	t.Setenv("COLDSTEP_EVENTS_LOG", events)
+
+	cfg, err := config.LoadFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- Run(ctx, cfg) }()
+
+	time.Sleep(450 * time.Millisecond)
+
+	// Issue both write() and pwrite() so the test asserts the new write/pwrite* sniff arm.
+	// socket.send() invokes sendto(2) under the hood; os.write(fd, ...) is plain write(2),
+	// and os.pwrite(fd, ...) is pwrite64(2) — both hit handle_write_obs_sys_enter.
+	py := `import os
+import socket
+addr = ("example.com", 80)
+req1 = b"GET /a HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n"
+req2 = b"GET /b HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n"
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.connect(addr)
+os.write(s.fileno(), req1)
+s.close()
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.connect(addr)
+os.pwrite(s.fileno(), req2, 0)
+s.close()
+`
+	if err := os.WriteFile(probe, []byte(py), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("python3", probe)
+	if err := cmd.Run(); err != nil {
+		t.Logf("http write probe (non-fatal): %v", err)
+	}
+
+	cancel()
+	err = <-errCh
+	if err != nil && err != context.Canceled {
+		t.Fatalf("Run: %v", err)
+	}
+
+	b, err := os.ReadFile(events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(b, []byte(`"type":"http"`)) {
+		t.Fatalf("expected at least one http JSONL line, got:\n%s", b)
+	}
+	if !bytes.Contains(b, []byte(`"dport":80`)) {
+		t.Fatalf("expected http JSONL with dport 80, got:\n%s", b)
+	}
+}
+
 func TestRun_TLSClientHelloSNIJSONL(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip("requires root for BPF load")


### PR DESCRIPTION
## Summary

Closes the BG-04 parity gap from the BPF gaps backlog: cleartext HTTP/80 sniff now fires on the `write(2)` family in addition to `sendto`. Previously, `sendto` ran both TLS ClientHello and HTTP/80 sniff after a `connect` tuple lookup, but `write`/`writev`/`pwrite64`/`pwritev`/`pwritev2` ran only the TLS path — so HTTP requests issued via `write` over a connected socket were invisible to the agent.

## What changed

- **`bpf/trace_tls_write.inc`** — renamed `handle_tls_obs_sys_enter` → `handle_write_obs_sys_enter` to reflect that it now drives both sniff paths. Introduced `try_emit_buffer_sniff_from_tuple`, which does a single `coldstep_connect_tuple_fetch` and then runs both:
  - TLS ClientHello sniff from the connected tuple (existing behavior).
  - HTTP/80 cleartext sniff from the connected tuple (new; mirrors `sendto`).
- **`bpf/trace_connect.bpf.c`** — dispatch arm updated to call the renamed helper.

The single shared tuple-fetch keeps verifier complexity bounded and avoids duplicating the lookup across two sniff helpers.

## Why

`sendto` already handled both sniff types; the `write(2)` family was the asymmetric one. This is BG-04 from the BPF gaps backlog — closing it gives consistent visibility regardless of which syscall a workload chooses to push bytes onto a connected socket.

## Test

- New integration test `TestRun_HTTPWritePort80JSONL` in `internal/agent/agent_integration_test.go`, gated `//go:build integration && linux && !windows`. It writes a synthetic HTTP request over a connected port-80 socket via `write` / `pwrite` and asserts a `type:http` event lands in the JSONL stream.
- Existing TLS sendto/write integration tests continue to pass — the rename preserves behavior on that path.

## Notes for reviewers

- BPF C compilation and integration tests require Linux CI (root + BPF). The PR's `integration` matrix job is the authoritative gate.
- No changes to generated bpf2go artifacts in this PR — they remain gitignored; CI regenerates via `scripts/build-agent-linux.sh`.
- IPv4-only, in line with the rest of the BPF surface.
