### PR TITLE
refactor: Go Tier 1 simplifications (~160 LOC)

### DIFF
--- a/.github/pr-bodies/pr-go-simplification-tier1.md
+++ b/.github/pr-bodies/pr-go-simplification-tier1.md
@@ -1,0 +1,27 @@
+## Summary
+
+Tier-1 Go simplification pass across the agent, report, policy, config, and action layers. Pure refactor -- no behaviour change, no new tests required. Net **~219 LOC removed** across 9 files (100 insertions, 319 deletions).
+
+Each numbered item is its own GPG-signed commit:
+
+1. **`internal/agent/agent_linux_policy_maps.go` + `internal/agent/agent_linux.go`** -- drop 17 thin BPF counter-read wrappers (`readDenyReserveFailureCount`, `readUDPRingbufReserveFailureCount`, ...). They only nil-checked `*Objects` and forwarded to the existing `readUint32CounterMap` / `readUint32PerCPUArraySum` helpers; every call site already guards the nullable pointer (or passes `&stackvar`). Also factor `loadDefendMaps` and `loadLSMDefendMaps` into one `loadDefendMapsForBackend` parameterised by a `defendMapSet` -- cgroup vs LSM differ only in which `*ebpf.Map` fields they expose.
+
+2. **`internal/report/digest_aggregation.go` + `internal/report/digest.go`** -- collapse the four identical `tcpEmptyReason` / `udpEmptyReason` / `httpEmptyReason` / `tlsEmptyReason` funcs into a single `sectionEmptyReason(degraded, readerErrors)`; call sites pass the per-section bool/int directly.
+
+3. **`internal/policy/ignore.go` + `cmd/coldstep-action/allowlist_files.go`** -- dedupe comma+whitespace token splitters. `ParseIgnoredIPNets` drops the duplicate `splitIgnoredRawFields` in favour of the package-private `splitFields`; `cmd/coldstep-action` extracts a single `splitTrimNonEmpty` helper used by `splitCommaPaths`, `splitAllowInlineTokens`, and `parseAllowlistFileBody`.
+
+4. **`internal/policy/allowlist.go` + `internal/config/config.go`** -- consolidate domain normalisation into `internal/policy` (new `NormalizeDomainsFromRaw`); `internal/config` deletes its near-identical `normalizeDomains` and calls the policy helper instead.
+
+5. **`internal/config/config.go` + `cmd/coldstep-action/main.go`** -- drop the redundant explicit legacy-mode rejection branch in both `LoadFromEnv` and `normalizeCompositeMode`. The follow-up "mode not in {detect, defend}" check produces the same error message and was already covering it.
+
+## Out of scope
+
+Per the task brief, **`bpf/`**, **`internal/bpf/`**, and **`scripts/`** are untouched -- BPF work is in flight on other branches.
+
+## Verification
+
+- `bash scripts/check-gofmt.sh`
+- `bash scripts/check-encoding.sh`
+- `go build ./...`
+- `go test ./...` (Windows host: passes for all packages with build tag `!windows`; `internal/bpf/*` test failures are pre-existing on Windows because generated stubs only exist after `go generate` on Linux -- unchanged by this PR)
+- CI on hosted Linux will exercise the agent + integration matrix

--- a/cmd/coldstep-action/allowlist_files.go
+++ b/cmd/coldstep-action/allowlist_files.go
@@ -84,40 +84,32 @@ func mergeInlineAndAllowlistFiles(workspaceRoot, inline, filesCSV string) (strin
 	return strings.Join(all, ","), nil
 }
 
-func splitCommaPaths(csv string) []string {
-	s := strings.TrimSpace(csv)
-	if s == "" {
-		return nil
-	}
-	var out []string
-	for _, p := range strings.Split(s, ",") {
-		p = strings.TrimSpace(p)
-		if p != "" {
+// splitTrimNonEmpty splits s using sep, trims whitespace from each token, and
+// drops empty entries. Shared by the comma-path, inline-token, and per-line
+// token parsers below; they only differ in which separator runes they accept.
+func splitTrimNonEmpty(s string, sep func(r rune) bool) []string {
+	parts := strings.FieldsFunc(s, sep)
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
 			out = append(out, p)
 		}
 	}
 	return out
+}
+
+func splitCommaPaths(csv string) []string {
+	return splitTrimNonEmpty(csv, func(r rune) bool { return r == ',' })
 }
 
 func splitAllowInlineTokens(inline string) []string {
-	s := strings.TrimSpace(inline)
-	if s == "" {
-		return nil
-	}
-	parts := strings.FieldsFunc(s, func(r rune) bool {
+	return splitTrimNonEmpty(inline, func(r rune) bool {
 		return r == ',' || r == ' ' || r == '\n' || r == '\r' || r == '\t'
 	})
-	out := make([]string, 0, len(parts))
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			out = append(out, p)
-		}
-	}
-	return out
 }
 
 func parseAllowlistFileBody(data []byte) []string {
+	lineSep := func(r rune) bool { return r == ',' || r == ' ' || r == '\t' }
 	var out []string
 	for _, line := range strings.Split(string(data), "\n") {
 		line = strings.TrimSpace(line)
@@ -130,14 +122,7 @@ func parseAllowlistFileBody(data []byte) []string {
 		if line == "" {
 			continue
 		}
-		for _, tok := range strings.FieldsFunc(line, func(r rune) bool {
-			return r == ',' || r == ' ' || r == '\t'
-		}) {
-			tok = strings.TrimSpace(tok)
-			if tok != "" {
-				out = append(out, tok)
-			}
-		}
+		out = append(out, splitTrimNonEmpty(line, lineSep)...)
 	}
 	return out
 }

--- a/cmd/coldstep-action/main.go
+++ b/cmd/coldstep-action/main.go
@@ -161,9 +161,6 @@ func normalizeCompositeMode(raw string) (string, error) {
 	if mode == "" {
 		mode = "detect"
 	}
-	if mode == "enforce" {
-		return "", fmt.Errorf("invalid mode %q (use detect or defend)", strings.TrimSpace(raw))
-	}
 	if mode != "detect" && mode != "defend" {
 		return "", fmt.Errorf("invalid mode %q (use detect or defend)", strings.TrimSpace(raw))
 	}

--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -185,9 +185,9 @@ func Run(ctx context.Context, cfg config.Config) error {
 		}
 		hasDefend = true
 		defer func() {
-			defendState.setDenyReserveFailures(readDenyReserveFailureCount(&defendObjs))
+			defendState.setDenyReserveFailures(readUint32PerCPUArraySum(defendObjs.DenyReserveFailures, "deny_reserve_failures"))
 			if hasLSM {
-				defendState.setDenyReserveFailures(readLSMDenyReserveFailureCount(&defendObjs))
+				defendState.setDenyReserveFailures(readUint32PerCPUArraySum(defendObjs.LsmDenyReserveFailures, "lsm_deny_reserve_failures"))
 			}
 			// P0-1 Phase 1: snapshot the IPv6 observe-only counters so the
 			// digest can warn when traffic escaped the IPv4-only defend
@@ -365,7 +365,9 @@ func Run(ctx context.Context, cfg config.Config) error {
 		return fmt.Errorf("load bpf objects: %w", err)
 	}
 	defer execObjs.Close()
-	defer func() { stats.setExecRingbufReserveFailures(readExecRingbufReserveFailureCount(&execObjs)) }()
+	defer func() {
+		stats.setExecRingbufReserveFailures(readUint32PerCPUArraySum(execObjs.ExecRingbufReserveFailures, "exec_ringbuf_reserve_failures"))
+	}()
 
 	execLnk, err := link.Tracepoint("sched", "sched_process_exec", execObjs.HandleSchedProcessExec, nil)
 	if err != nil {
@@ -414,21 +416,21 @@ func Run(ctx context.Context, cfg config.Config) error {
 		defer syscallLnk.Close()
 		defer func() {
 			if syscallObjs != nil {
-				stats.setConnect4TupleUpdateFailures(readConnect4TupleUpdateFailureCount(syscallObjs))
-				stats.setUDPRingbufReserveFailures(readUDPRingbufReserveFailureCount(syscallObjs))
-				stats.setConnectRingbufReserveFailures(readConnectRingbufReserveFailureCount(syscallObjs))
-				stats.setHTTPRingbufReserveFailures(readHTTPRingbufReserveFailureCount(syscallObjs))
-				stats.setTLSRingbufReserveFailures(readTLSRingbufReserveFailureCount(syscallObjs))
-				stats.setUDPSendmsgMultiIovecObserved(readUDPSendmsgMultiIovecObservedCount(syscallObjs))
-				stats.setSendmmsgMultiMessage(readSendmmsgMultiMessageCount(syscallObjs))
-				// TODO: regenerate BPF stubs after building on Linux — readSendmmsgUnobservedExtraCount
-				// references objs.SendmmsgUnobservedExtra defined by the new
+				stats.setConnect4TupleUpdateFailures(readUint32PerCPUArraySum(syscallObjs.Connect4TupleUpdateFailures, "connect4_tuple_update_failures"))
+				stats.setUDPRingbufReserveFailures(readUint32PerCPUArraySum(syscallObjs.UdpRingbufReserveFailures, "udp_ringbuf_reserve_failures"))
+				stats.setConnectRingbufReserveFailures(readUint32PerCPUArraySum(syscallObjs.ConnectRingbufReserveFailures, "connect_ringbuf_reserve_failures"))
+				stats.setHTTPRingbufReserveFailures(readUint32PerCPUArraySum(syscallObjs.HttpRingbufReserveFailures, "http_ringbuf_reserve_failures"))
+				stats.setTLSRingbufReserveFailures(readUint32PerCPUArraySum(syscallObjs.TlsRingbufReserveFailures, "tls_ringbuf_reserve_failures"))
+				stats.setUDPSendmsgMultiIovecObserved(readUint32CounterMap(syscallObjs.UdpSendmsgMultiIovecObserved, "udp_sendmsg_multi_iovec_observed"))
+				stats.setSendmmsgMultiMessage(readUint32PerCPUArraySum(syscallObjs.SendmmsgMultiMessageObserved, "sendmmsg_multi_message_observed"))
+				// TODO: regenerate BPF stubs after building on Linux —
+				// syscallObjs.SendmmsgUnobservedExtra is defined by the new
 				// sendmmsg_unobserved_extra PERCPU_ARRAY in bpf/trace_connect.bpf.c.
-				stats.setSendmmsgUnobservedExtra(readSendmmsgUnobservedExtraCount(syscallObjs))
-				stats.setTLSWritevMultiIovecObserved(readTLSWritevMultiIovecObservedCount(syscallObjs))
-				sendfileN, spliceN, sendmmsgN := readPartialEgressCounts(syscallObjs)
+				stats.setSendmmsgUnobservedExtra(readUint32PerCPUArraySum(syscallObjs.SendmmsgUnobservedExtra, "sendmmsg_unobserved_extra"))
+				stats.setTLSWritevMultiIovecObserved(readUint32CounterMap(syscallObjs.TlsWritevMultiIovecObserved, "tls_writev_multi_iovec_observed"))
+				sendfileN, spliceN, sendmmsgN := readPartialEgressCounts(syscallObjs.PartialEgressObserved)
 				stats.setPartialEgressObserved(sendfileN, spliceN, sendmmsgN)
-				stats.setIoUringSetupObserved(readIoUringSetupObservedCount(syscallObjs))
+				stats.setIoUringSetupObserved(readUint32CounterMap(syscallObjs.IoUringSetupObserved, "io_uring_setup_observed"))
 			}
 		}()
 		// Ring readers are closed exactly once via ringReader.Close (runCtx shutdown goroutine + deferred Close).
@@ -470,9 +472,9 @@ func Run(ctx context.Context, cfg config.Config) error {
 		defer dnsLnkEnter.Close()
 		defer func() {
 			if dnsObjs != nil {
-				stats.setDNSRingbufReserveFailures(readDNSRingbufReserveFailureCount(dnsObjs))
-				stats.setTCPDNSResponsesObserved(readTCPDNSResponsesObservedCount(dnsObjs))
-				stats.setTCPDNSSkippedShortRead(readTCPDNSSkippedShortReadCount(dnsObjs))
+				stats.setDNSRingbufReserveFailures(readUint32PerCPUArraySum(dnsObjs.DnsRingbufReserveFailures, "dns_ringbuf_reserve_failures"))
+				stats.setTCPDNSResponsesObserved(readUint32CounterMap(dnsObjs.TcpDnsResponsesObserved, "tcp_dns_responses_observed"))
+				stats.setTCPDNSSkippedShortRead(readUint32CounterMap(dnsObjs.TcpDnsSkippedShortRead, "tcp_dns_skipped_short_read"))
 			}
 		}()
 	}
@@ -520,7 +522,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 					slog.Info("tracing sched_process_fork (process tree)")
 					defer func() {
 						if forkObjs != nil {
-							stats.setForkRingbufReserveFailures(readForkRingbufReserveFailureCount(forkObjs))
+							stats.setForkRingbufReserveFailures(readUint32PerCPUArraySum(forkObjs.ForkRingbufReserveFailures, "fork_ringbuf_reserve_failures"))
 						}
 						forkRd.Close()
 						if forkLnk != nil {
@@ -588,7 +590,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 					slog.Info("tracing fs events (openat+create, unlink, rename, chmod)")
 					defer func() {
 						if fsObjs != nil {
-							stats.setFSRingbufReserveFailures(readFSRingbufReserveFailureCount(fsObjs))
+							stats.setFSRingbufReserveFailures(readUint32PerCPUArraySum(fsObjs.FsRingbufReserveFailures, "fs_ringbuf_reserve_failures"))
 						}
 						fsRd.Close()
 						if fsLnk != nil {
@@ -618,7 +620,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 		defer bpfAuditLnk.Close()
 		defer func() {
 			if bpfAuditObjs != nil {
-				stats.setBPFAuditRingbufReserveFailures(readBPFAuditRingbufReserveFailureCount(bpfAuditObjs))
+				stats.setBPFAuditRingbufReserveFailures(readUint32PerCPUArraySum(bpfAuditObjs.BpfAuditReserveFailures, "bpf_audit_ringbuf_reserve_failures"))
 			}
 		}()
 	}

--- a/internal/agent/agent_linux_policy_maps.go
+++ b/internal/agent/agent_linux_policy_maps.go
@@ -20,12 +20,6 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/ringbuf"
 	"github.com/coldstep-io/coldstep/internal/bpf/defend"
-	"github.com/coldstep-io/coldstep/internal/bpf/tracebpfaudit"
-	"github.com/coldstep-io/coldstep/internal/bpf/traceconnect"
-	"github.com/coldstep-io/coldstep/internal/bpf/tracedns"
-	"github.com/coldstep-io/coldstep/internal/bpf/traceexec"
-	"github.com/coldstep-io/coldstep/internal/bpf/tracefork"
-	"github.com/coldstep-io/coldstep/internal/bpf/tracefs"
 	"github.com/coldstep-io/coldstep/internal/config"
 	"github.com/coldstep-io/coldstep/internal/policy"
 	"github.com/coldstep-io/coldstep/internal/telemetry"
@@ -150,98 +144,6 @@ func readUint32PerCPUArraySum(m *ebpf.Map, helperName string) int {
 	return n
 }
 
-func readDenyReserveFailureCount(objs *defend.DefendObjects) int {
-	if objs == nil {
-		return 0
-	}
-	return readUint32PerCPUArraySum(objs.DenyReserveFailures, "readDenyReserveFailureCount")
-}
-
-func readConnect4TupleUpdateFailureCount(objs *traceconnect.TraceconnectObjects) int {
-	if objs == nil {
-		return 0
-	}
-	return readUint32PerCPUArraySum(objs.Connect4TupleUpdateFailures, "readConnect4TupleUpdateFailureCount")
-}
-
-func readUDPRingbufReserveFailureCount(objs *traceconnect.TraceconnectObjects) int {
-	if objs == nil {
-		return 0
-	}
-	return readUint32PerCPUArraySum(objs.UdpRingbufReserveFailures, "readUDPRingbufReserveFailureCount")
-}
-
-func readDNSRingbufReserveFailureCount(objs *tracedns.TracednsObjects) int {
-	if objs == nil {
-		return 0
-	}
-	return readUint32PerCPUArraySum(objs.DnsRingbufReserveFailures, "readDNSRingbufReserveFailureCount")
-}
-
-func readConnectRingbufReserveFailureCount(objs *traceconnect.TraceconnectObjects) int {
-	if objs == nil {
-		return 0
-	}
-	return readUint32PerCPUArraySum(objs.ConnectRingbufReserveFailures, "readConnectRingbufReserveFailureCount")
-}
-
-func readBPFAuditRingbufReserveFailureCount(objs *tracebpfaudit.TracebpfauditObjects) int {
-	if objs == nil {
-		return 0
-	}
-	return readUint32PerCPUArraySum(objs.BpfAuditReserveFailures, "readBPFAuditRingbufReserveFailureCount")
-}
-
-func readHTTPRingbufReserveFailureCount(objs *traceconnect.TraceconnectObjects) int {
-	if objs == nil {
-		return 0
-	}
-	return readUint32PerCPUArraySum(objs.HttpRingbufReserveFailures, "readHTTPRingbufReserveFailureCount")
-}
-
-func readTLSRingbufReserveFailureCount(objs *traceconnect.TraceconnectObjects) int {
-	if objs == nil {
-		return 0
-	}
-	return readUint32PerCPUArraySum(objs.TlsRingbufReserveFailures, "readTLSRingbufReserveFailureCount")
-}
-
-func readUDPSendmsgMultiIovecObservedCount(objs *traceconnect.TraceconnectObjects) int {
-	if objs == nil {
-		return 0
-	}
-	return readUint32CounterMap(objs.UdpSendmsgMultiIovecObserved, "readUDPSendmsgMultiIovecObservedCount")
-}
-
-func readSendmmsgMultiMessageCount(objs *traceconnect.TraceconnectObjects) int {
-	if objs == nil {
-		return 0
-	}
-	return readUint32PerCPUArraySum(objs.SendmmsgMultiMessageObserved, "readSendmmsgMultiMessageCount")
-}
-
-// readSendmmsgUnobservedExtraCount sums BG-03 Gap 3 per-message extra-message
-// dropped counts across CPUs. Distinct from readSendmmsgMultiMessageCount,
-// which counts CALLS with vlen > 1; this counter sums individual messages
-// beyond index SENDMMSG_EXTRA_MAX (7) that the unrolled loop did not reach.
-//
-// TODO: regenerate BPF stubs after building on Linux — references
-// `objs.SendmmsgUnobservedExtra` defined by `sendmmsg_unobserved_extra` map in
-// bpf/trace_connect.bpf.c, which bpf2go will surface during CI regeneration.
-func readSendmmsgUnobservedExtraCount(objs *traceconnect.TraceconnectObjects) int {
-	if objs == nil {
-		return 0
-	}
-	return readUint32PerCPUArraySum(objs.SendmmsgUnobservedExtra, "readSendmmsgUnobservedExtraCount")
-}
-
-func readTLSWritevMultiIovecObservedCount(objs *traceconnect.TraceconnectObjects) int {
-	if objs == nil {
-		return 0
-	}
-	return readUint32CounterMap(objs.TlsWritevMultiIovecObserved, "readTLSWritevMultiIovecObservedCount")
-}
-
 // readPartialEgressCounts returns the BG-01 per-syscall partial-observe
 // counters (sendfile, splice, sendmmsg) summed across CPUs. Slots:
 //
@@ -250,13 +152,13 @@ func readTLSWritevMultiIovecObservedCount(objs *traceconnect.TraceconnectObjects
 //	2 = sendmmsg (first-message-only observed)
 //
 // Reads each slot independently because PERCPU_ARRAY Lookup is per-key.
-func readPartialEgressCounts(objs *traceconnect.TraceconnectObjects) (sendfile, splice, sendmmsg int) {
-	if objs == nil || objs.PartialEgressObserved == nil {
+func readPartialEgressCounts(m *ebpf.Map) (sendfile, splice, sendmmsg int) {
+	if m == nil {
 		return 0, 0, 0
 	}
 	read := func(key uint32, label string) int {
 		var vals []uint32
-		if err := objs.PartialEgressObserved.Lookup(&key, &vals); err != nil {
+		if err := m.Lookup(&key, &vals); err != nil {
 			if errors.Is(err, ebpf.ErrKeyNotExist) {
 				return 0
 			}
@@ -273,55 +175,6 @@ func readPartialEgressCounts(objs *traceconnect.TraceconnectObjects) (sendfile, 
 	splice = read(1, "readPartialEgressCounts(splice)")
 	sendmmsg = read(2, "readPartialEgressCounts(sendmmsg)")
 	return
-}
-
-func readIoUringSetupObservedCount(objs *traceconnect.TraceconnectObjects) int {
-	if objs == nil {
-		return 0
-	}
-	return readUint32CounterMap(objs.IoUringSetupObserved, "readIoUringSetupObservedCount")
-}
-
-func readTCPDNSResponsesObservedCount(objs *tracedns.TracednsObjects) int {
-	if objs == nil {
-		return 0
-	}
-	return readUint32CounterMap(objs.TcpDnsResponsesObserved, "readTCPDNSResponsesObservedCount")
-}
-
-func readTCPDNSSkippedShortReadCount(objs *tracedns.TracednsObjects) int {
-	if objs == nil {
-		return 0
-	}
-	return readUint32CounterMap(objs.TcpDnsSkippedShortRead, "readTCPDNSSkippedShortReadCount")
-}
-
-func readExecRingbufReserveFailureCount(objs *traceexec.TraceexecObjects) int {
-	if objs == nil {
-		return 0
-	}
-	return readUint32PerCPUArraySum(objs.ExecRingbufReserveFailures, "readExecRingbufReserveFailureCount")
-}
-
-func readForkRingbufReserveFailureCount(objs *tracefork.TraceforkObjects) int {
-	if objs == nil {
-		return 0
-	}
-	return readUint32PerCPUArraySum(objs.ForkRingbufReserveFailures, "readForkRingbufReserveFailureCount")
-}
-
-func readFSRingbufReserveFailureCount(objs *tracefs.TracefsObjects) int {
-	if objs == nil {
-		return 0
-	}
-	return readUint32PerCPUArraySum(objs.FsRingbufReserveFailures, "readFSRingbufReserveFailureCount")
-}
-
-func readLSMDenyReserveFailureCount(objs *defend.DefendObjects) int {
-	if objs == nil {
-		return 0
-	}
-	return readUint32PerCPUArraySum(objs.LsmDenyReserveFailures, "readLSMDenyReserveFailureCount")
 }
 
 // readIPv6ConnectObservedCount returns the per-CPU sum of the
@@ -402,98 +255,87 @@ func buildDefendAllowedPlan(mapName string, compiled policy.CompileResult, pol *
 	return plan, nil
 }
 
+// defendMapSet groups the four BPF maps loadDefendMapsForBackend programs,
+// plus the map-name strings used for diagnostics. cgroup and LSM backends
+// supply different *ebpf.Map field references; the load steps are identical.
+type defendMapSet struct {
+	cfgName, allowedName                        string
+	cfg, ignoredLPM, allowedLPM, allowedDomains *ebpf.Map
+}
+
+// loadDefendMapsForBackend programs BPF allowlist maps from compiled domain
+// resolutions + literal policy entries for a single defend backend.
+//
+// PR-G: allowed_ipv4 is a BPF_MAP_TYPE_LPM_TRIE (was HASH). Single-IP allowlist
+// entries (resolved domain IPs + literal /32s from --allowed-ips) are programmed
+// individually with prefixlen=32. Literal CIDR entries from --allowed-ips (e.g.
+// "10.0.0.0/8") are programmed once as a single LPM key covering the range.
+//
+// AUDIT(5h): allowlist is fixed-point at startup; runtime DNS changes are not
+// reflected. The agent resolves domains once during compileDefendAllowlist and
+// writes the resulting /32 set + literal CIDRs into the LPM trie here. If a
+// domain's A-record set changes after this point (DNS rotation, CDN edge
+// migration), the BPF allowlist still reflects the startup snapshot until the
+// next agent restart. Operators relying on DNS-backed domain rules should treat
+// the agent's lifetime as the freshness window for the allowlist and add literal
+// CIDRs / IPs for any destinations that need to survive DNS rotation. The
+// dns_cache map (populated by trace_dns.bpf.c at runtime) is consulted as a
+// fallback for reverse lookups in defend_policy.inc:dst_is_allowlisted, but the
+// primary LPM map is snapshot-only.
+func loadDefendMapsForBackend(maps defendMapSet, compiled policy.CompileResult, pol *policy.Policy) (int, int, error) {
+	keyMode := uint32(0)
+	modeDefend := uint32(1)
+	if err := maps.cfg.Update(&keyMode, &modeDefend, ebpf.UpdateAny); err != nil {
+		return 0, 0, fmt.Errorf("load %s map: %w", maps.cfgName, err)
+	}
+	ignoredCount := 0
+	if pol != nil {
+		var err error
+		ignoredCount, err = loadIgnoredLPMMap(maps.ignoredLPM, pol.IgnoredIPv4Nets())
+		if err != nil {
+			return 0, 0, err
+		}
+	}
+	plan, err := buildDefendAllowedPlan(maps.allowedName, compiled, pol)
+	if err != nil {
+		return 0, 0, err
+	}
+	if err := loadAllowedLPMMap(maps.allowedLPM, plan); err != nil {
+		return 0, 0, err
+	}
+	if err := loadAllowedDomainsMap(maps.allowedDomains, pol); err != nil {
+		return 0, 0, err
+	}
+	slog.Info("allowlist loaded into BPF map", "map", maps.allowedName, "ipv4_entries", plan.totalEntries, "ignored_cidrs", ignoredCount)
+	return plan.totalEntries, ignoredCount, nil
+}
+
 func loadLSMDefendMaps(objs *defend.DefendObjects, compiled policy.CompileResult, pol *policy.Policy) (int, int, error) {
 	if objs == nil {
 		return 0, 0, fmt.Errorf("defend objects are required for LSM defend mode")
 	}
-	keyMode := uint32(0)
-	modeDefend := uint32(1)
-	if err := objs.LsmDefendCfg.Update(&keyMode, &modeDefend, ebpf.UpdateAny); err != nil {
-		return 0, 0, fmt.Errorf("load lsm_defend_cfg map: %w", err)
-	}
-	ignoredCount := 0
-	if pol != nil {
-		var err error
-		ignoredCount, err = loadIgnoredLPMMap(objs.LsmIgnoredIpv4Lpm, pol.IgnoredIPv4Nets())
-		if err != nil {
-			return 0, 0, err
-		}
-	}
-
-	plan, err := buildDefendAllowedPlan("lsm_allowed_ipv4", compiled, pol)
-	if err != nil {
-		return 0, 0, err
-	}
-
-	if err := loadAllowedLPMMap(objs.LsmAllowedIpv4, plan); err != nil {
-		return 0, 0, err
-	}
-
-	if err := loadAllowedDomainsMap(objs.AllowedDomains, pol); err != nil {
-		return 0, 0, err
-	}
-
-	// AUDIT(5h): allowlist is fixed-point at startup; runtime DNS changes are
-	// not reflected. The agent resolves domains once during compileDefendAllowlist
-	// and writes the resulting /32 set + literal CIDRs into the LPM trie here.
-	// If a domain's A-record set changes after this point (DNS rotation, CDN
-	// edge migration), the BPF allowlist still reflects the startup snapshot
-	// until the next agent restart. Operators relying on DNS-backed domain
-	// rules should treat the agent's lifetime as the freshness window for the
-	// allowlist and add literal CIDRs / IPs for any destinations that need to
-	// survive DNS rotation. The dns_cache map (populated by trace_dns.bpf.c at
-	// runtime) is consulted as a fallback for reverse lookups in
-	// defend_policy.inc:dst_is_allowlisted, but the primary LPM map is
-	// snapshot-only.
-	slog.Info("allowlist loaded into BPF map", "map", "lsm_allowed_ipv4", "ipv4_entries", plan.totalEntries, "ignored_cidrs", ignoredCount)
-
-	return plan.totalEntries, ignoredCount, nil
+	return loadDefendMapsForBackend(defendMapSet{
+		cfgName:        "lsm_defend_cfg",
+		allowedName:    "lsm_allowed_ipv4",
+		cfg:            objs.LsmDefendCfg,
+		ignoredLPM:     objs.LsmIgnoredIpv4Lpm,
+		allowedLPM:     objs.LsmAllowedIpv4,
+		allowedDomains: objs.AllowedDomains,
+	}, compiled, pol)
 }
 
-// loadDefendMaps programs BPF allowlist maps from compiled domain resolutions + literal policy entries.
-//
-// PR-G: allowed_ipv4 is now a BPF_MAP_TYPE_LPM_TRIE (was HASH). Single-IP
-// allowlist entries (resolved domain IPs + literal /32s from --allowed-ips)
-// are still programmed individually but with prefixlen=32. Literal CIDR
-// entries from --allowed-ips (e.g. "10.0.0.0/8") are programmed once as a
-// single LPM key and cover every address inside the range.
 func loadDefendMaps(objs *defend.DefendObjects, compiled policy.CompileResult, pol *policy.Policy) (int, int, error) {
 	if objs == nil {
 		return 0, 0, fmt.Errorf("defend objects are required for cgroup defend mode")
 	}
-	keyMode := uint32(0)
-	modeDefend := uint32(1)
-	if err := objs.DefendCfg.Update(&keyMode, &modeDefend, ebpf.UpdateAny); err != nil {
-		return 0, 0, fmt.Errorf("load defend_cfg map: %w", err)
-	}
-	ignoredCount := 0
-	if pol != nil {
-		var err error
-		ignoredCount, err = loadIgnoredLPMMap(objs.IgnoredIpv4Lpm, pol.IgnoredIPv4Nets())
-		if err != nil {
-			return 0, 0, err
-		}
-	}
-
-	plan, err := buildDefendAllowedPlan("allowed_ipv4", compiled, pol)
-	if err != nil {
-		return 0, 0, err
-	}
-
-	if err := loadAllowedLPMMap(objs.AllowedIpv4, plan); err != nil {
-		return 0, 0, err
-	}
-
-	if err := loadAllowedDomainsMap(objs.AllowedDomains, pol); err != nil {
-		return 0, 0, err
-	}
-
-	// AUDIT(5h): allowlist is fixed-point at startup; runtime DNS changes are
-	// not reflected. See loadLSMDefendMaps for the full rationale — both
-	// loaders share the same compile-once / load-into-BPF lifecycle.
-	slog.Info("allowlist loaded into BPF map", "map", "allowed_ipv4", "ipv4_entries", plan.totalEntries, "ignored_cidrs", ignoredCount)
-
-	return plan.totalEntries, ignoredCount, nil
+	return loadDefendMapsForBackend(defendMapSet{
+		cfgName:        "defend_cfg",
+		allowedName:    "allowed_ipv4",
+		cfg:            objs.DefendCfg,
+		ignoredLPM:     objs.IgnoredIpv4Lpm,
+		allowedLPM:     objs.AllowedIpv4,
+		allowedDomains: objs.AllowedDomains,
+	}, compiled, pol)
 }
 
 // loadAllowedLPMMap programs the allowed_ipv4 LPM trie (PR-G).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,26 +43,6 @@ type Config struct {
 	SigningKey       string
 }
 
-func normalizeDomains(raw string) []string {
-	parts := strings.FieldsFunc(raw, func(r rune) bool {
-		return r == ',' || r == ' ' || r == '\n' || r == '\r' || r == '\t'
-	})
-	out := make([]string, 0, len(parts))
-	seen := make(map[string]struct{}, len(parts))
-	for _, part := range parts {
-		domain := strings.ToLower(strings.TrimSpace(part))
-		if domain == "" {
-			continue
-		}
-		if _, ok := seen[domain]; ok {
-			continue
-		}
-		seen[domain] = struct{}{}
-		out = append(out, domain)
-	}
-	return out
-}
-
 func defaultUnderWorkspace(rel string) string {
 	ws := strings.TrimSpace(os.Getenv("GITHUB_WORKSPACE"))
 	if ws == "" {
@@ -78,9 +58,6 @@ func LoadFromEnv() (Config, error) {
 	if rawLower == "" {
 		rawLower = string(ModeDetect)
 	}
-	if rawLower == "enforce" {
-		return Config{}, fmt.Errorf("invalid CI_GUARD_MODE %q (use detect or defend)", raw)
-	}
 	mode := Mode(rawLower)
 	if mode != ModeDetect && mode != ModeDefend {
 		return Config{}, fmt.Errorf("invalid CI_GUARD_MODE %q (use detect or defend)", raw)
@@ -93,7 +70,7 @@ func LoadFromEnv() (Config, error) {
 	if detectLog == "" {
 		detectLog = defaultUnderWorkspace(".coldstep-detect.md")
 	}
-	allowedDomains := normalizeDomains(os.Getenv("COLDSTEP_ALLOWED_DOMAINS"))
+	allowedDomains := policy.NormalizeDomainsFromRaw(os.Getenv("COLDSTEP_ALLOWED_DOMAINS"))
 	if mode == ModeDefend && len(allowedDomains) == 0 {
 		return Config{}, fmt.Errorf("CI_GUARD_MODE=defend requires non-empty allowlist (set COLDSTEP_ALLOWED_DOMAINS)")
 	}

--- a/internal/policy/allowlist.go
+++ b/internal/policy/allowlist.go
@@ -248,3 +248,10 @@ func normalizeAllowlistDomains(domains []string) []string {
 	}
 	return out
 }
+
+// NormalizeDomainsFromRaw splits raw on commas/ASCII whitespace, lowercases,
+// trims, and dedupes — the canonical entry point for COLDSTEP_ALLOWED_DOMAINS
+// and any other comma/space-separated domain list.
+func NormalizeDomainsFromRaw(raw string) []string {
+	return normalizeAllowlistDomains(splitFields(raw))
+}

--- a/internal/policy/ignore.go
+++ b/internal/policy/ignore.go
@@ -3,19 +3,13 @@ package policy
 import (
 	"fmt"
 	"net"
-	"strings"
-	"unicode"
 )
 
 // ParseIgnoredIPNets parses comma- or ASCII-whitespace-separated IPv4 CIDRs.
 // IPv6 is not supported.
 func ParseIgnoredIPNets(raw string) ([]*net.IPNet, error) {
 	var out []*net.IPNet
-	for _, tok := range splitIgnoredRawFields(raw) {
-		tok = strings.TrimSpace(tok)
-		if tok == "" {
-			continue
-		}
+	for _, tok := range splitFields(raw) {
 		_, ipnet, err := net.ParseCIDR(tok)
 		if err != nil {
 			return nil, fmt.Errorf("invalid ignored CIDR %q: %w", tok, err)
@@ -29,13 +23,6 @@ func ParseIgnoredIPNets(raw string) ([]*net.IPNet, error) {
 		})
 	}
 	return out, nil
-}
-
-// splitIgnoredRawFields matches policy.splitFields (comma or ASCII whitespace).
-func splitIgnoredRawFields(s string) []string {
-	return strings.FieldsFunc(s, func(r rune) bool {
-		return r == ',' || unicode.IsSpace(r)
-	})
 }
 
 // DefaultIgnoredIPv4Nets returns the implicit RFC1918 private-network ranges


### PR DESCRIPTION
## Summary

Tier-1 Go simplification pass across the agent, report, policy, config, and action layers. Pure refactor -- no behaviour change, no new tests required. Net **~219 LOC removed** across 9 files (100 insertions, 319 deletions).

Each numbered item is its own GPG-signed commit:

1. **`internal/agent/agent_linux_policy_maps.go` + `internal/agent/agent_linux.go`** -- drop 17 thin BPF counter-read wrappers (`readDenyReserveFailureCount`, `readUDPRingbufReserveFailureCount`, ...). They only nil-checked `*Objects` and forwarded to the existing `readUint32CounterMap` / `readUint32PerCPUArraySum` helpers; every call site already guards the nullable pointer (or passes `&stackvar`). Also factor `loadDefendMaps` and `loadLSMDefendMaps` into one `loadDefendMapsForBackend` parameterised by a `defendMapSet` -- cgroup vs LSM differ only in which `*ebpf.Map` fields they expose.

2. **`internal/report/digest_aggregation.go` + `internal/report/digest.go`** -- collapse the four identical `tcpEmptyReason` / `udpEmptyReason` / `httpEmptyReason` / `tlsEmptyReason` funcs into a single `sectionEmptyReason(degraded, readerErrors)`; call sites pass the per-section bool/int directly.

3. **`internal/policy/ignore.go` + `cmd/coldstep-action/allowlist_files.go`** -- dedupe comma+whitespace token splitters. `ParseIgnoredIPNets` drops the duplicate `splitIgnoredRawFields` in favour of the package-private `splitFields`; `cmd/coldstep-action` extracts a single `splitTrimNonEmpty` helper used by `splitCommaPaths`, `splitAllowInlineTokens`, and `parseAllowlistFileBody`.

4. **`internal/policy/allowlist.go` + `internal/config/config.go`** -- consolidate domain normalisation into `internal/policy` (new `NormalizeDomainsFromRaw`); `internal/config` deletes its near-identical `normalizeDomains` and calls the policy helper instead.

5. **`internal/config/config.go` + `cmd/coldstep-action/main.go`** -- drop the redundant explicit legacy-mode rejection branch in both `LoadFromEnv` and `normalizeCompositeMode`. The follow-up "mode not in {detect, defend}" check produces the same error message and was already covering it.

## Out of scope

Per the task brief, **`bpf/`**, **`internal/bpf/`**, and **`scripts/`** are untouched -- BPF work is in flight on other branches.

## Verification

- `bash scripts/check-gofmt.sh`
- `bash scripts/check-encoding.sh`
- `go build ./...`
- `go test ./...` (Windows host: passes for all packages with build tag `!windows`; `internal/bpf/*` test failures are pre-existing on Windows because generated stubs only exist after `go generate` on Linux -- unchanged by this PR)
- CI on hosted Linux will exercise the agent + integration matrix
