### PR TITLE
feat(bpf): bounded iov[1] peek for TLS/HTTP sniff (BG-02)

### DIFF
--- a/.github/pr-bodies/pr-bg02-multi-iov-peek.md
+++ b/.github/pr-bodies/pr-bg02-multi-iov-peek.md
@@ -1,0 +1,36 @@
+## Summary
+
+Implements **BG-02** (`documentation/2026-05-09-bpf-features-implementation-plan.md` Phase C, design choice **C1**): a single bounded `iov[1]` peek for TLS / HTTP fingerprint when `writev`/`pwritev`/`pwritev2` is called with `vlen >= 2`, or `sendmsg`/`sendmmsg` is called with `msg_iovlen >= 2`.
+
+Previously only `iov[0]` was passed to the sniff helpers. The dedicated counters `tls_writev_multi_iovec_observed` and `udp_sendmsg_multi_iovec_observed` fired when fragmentation was observed, but any TLS ClientHello or HTTP request line that landed in `iov[1]` (e.g. length-prefixed framing with a header in `iov[0]`) was silently dropped from `tls_events` / `http_events`.
+
+## What changed
+
+- **`bpf/trace_tls_write.inc`** — in `handle_tls_obs_sys_enter` for `NR_WRITEV` / `NR_PWRITEV` / `NR_PWRITEV2`, after the existing `iov[0]` call to `try_emit_tls_clienthello`, when `dx_ul >= 2` perform one more bounded `bpf_probe_read_user` of `iov[1]` (16 bytes — constant size) and re-invoke `try_emit_tls_clienthello`. The internal TLS prefix fingerprint (`0x16 0x03 0x0? ... 0x01`) gates emission, so a non-matching `iov[1]` is a no-op.
+
+- **`bpf/trace_udp_sendmsg.inc`** — in `handle_udp_obs_sendmsg`, after the existing destination + length extraction from `iov[0]`, when `msg_iovlen >= 2` peek `iov[1]` and feed its buffer through both `try_emit_tls_clienthello` and the cleartext HTTP request fingerprint (`http_prefix_looks_like_request` gated on `dport == 80`). Both helpers gate on their own prefix tests.
+
+- **`bpf/trace_connect.bpf.c`** — reorder includes so `trace_udp_sendmsg.inc` comes after `trace_http_obs.inc` and `trace_tls_write.inc` (the new iov[1] sniff calls helpers defined there). `handle_udp_obs_sendmsg` is only referenced from the .bpf.c dispatcher below the includes, so reordering is safe.
+
+- **`CHANGELOG.md`** — `[Unreleased]` entry describing the change.
+
+## Constraints honored
+
+- **Bounded only** — strictly capped at index 1, no `iov` walk loop.
+- **Constant-size reads** — `sizeof(struct coldstep_iovec)` is a compile-time constant, keeping the verifier's scalar range tight.
+- **Counters preserved** — `tls_writev_multi_iovec_observed` and `udp_sendmsg_multi_iovec_observed` still increment on `vlen > 1` / `msg_iovlen > 1` so the historical fragmentation-rate metric stays comparable; comments updated to note iov[1] is no longer dropped.
+- **No Go / agent / wire changes** — emit goes through existing `tls_events` / `http_events` paths.
+- **No `enforce` references** introduced.
+
+## Validation
+
+- `bash scripts/check-gofmt.sh` — pass.
+- `bash scripts/check-encoding.sh` — pass.
+- `go vet $(go list ./... | grep -v internal/bpf/)` — pass (BPF stub packages require Linux + clang + libbpf to generate `*_bpfel.go`; verified in CI).
+- `go test $(go list ./... | grep -v internal/bpf/) -count=1` — pass.
+- BPF compile + verifier load are validated by CI's `coldstep-ci-runner.yml` (`unit`, `unit-arm64`, `integration`, `detect-mode`, `defend-mode`).
+
+## Follow-ups (out of scope)
+
+- **BG-03** `sendmmsg` multi-message counter (separate PR per implementation plan Phase D).
+- Synthetic `writev` / `sendmsg` 2-iov integration fixture (Phase C step 4 — fixture lives in the demo / red-team workflows; not required for the BPF change itself to merge).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - refactor: consolidate four `*EmptyReason` digest helpers into `protocolEmptyReason`.
 - **BPF telemetry — per-syscall partial-observe counters (BG-01).** Replaced the dead aggregate `unobserved_egress_syscalls_observed` ARRAY (no increment sites since the pwrite* sniff arms were added; always read 0) with a 4-slot `partial_egress_observed` PERCPU_ARRAY. Slots: `sendfile`/`sendfile64`, `splice`, and `sendmmsg` (first-message-only). The digest, triage ribbon, and telemetry JSON now surface each path independently (`sendfile_observed`, `splice_observed`, `sendmmsg_first_only`) so operators can see *which* syscall drove the visibility gap instead of a single total. Existing sniff paths are unchanged.
+- **BG-02: bounded multi-iovec sniff** — When `writev`/`pwritev`/`pwritev2` is called with `vlen >= 2`, or `sendmsg`/`sendmmsg` is called with `msg_iovlen >= 2`, the BPF agent now performs a single additional bounded `bpf_probe_read_user` of `iov[1]` and feeds it through the existing TLS ClientHello and HTTP request fingerprint helpers. Previously only `iov[0]` was inspected, and any TLS/HTTP content fragmented into `iov[1]` (e.g. header-then-body framing) was silently dropped from `tls_events` / `http_events`. Strictly capped at index 1 — no unlimited iov walk. The `tls_writev_multi_iovec_observed` and `udp_sendmsg_multi_iovec_observed` counters continue to fire so the historical fragmentation-rate metric stays comparable.
 
 ---
 

--- a/bpf/trace_connect.bpf.c
+++ b/bpf/trace_connect.bpf.c
@@ -303,9 +303,14 @@ static __always_inline void note_partial_egress(int slot)
 
 #include "trace_tcp_obs.inc"
 #include "trace_udp_obs.inc"
-#include "trace_udp_sendmsg.inc"
 #include "trace_http_obs.inc"
 #include "trace_tls_write.inc"
+/*
+ * trace_udp_sendmsg.inc must come last among these — its BG-02 iov[1] peek
+ * path calls try_emit_tls_clienthello (defined in trace_tls_write.inc) and
+ * handle_http_obs_emit{,_pt} (defined in trace_http_obs.inc).
+ */
+#include "trace_udp_sendmsg.inc"
 
 /*
  * Canary emit helper: reads canary_trigger[0]; if non-zero, reserves a

--- a/bpf/trace_tls_write.inc
+++ b/bpf/trace_tls_write.inc
@@ -144,9 +144,11 @@ static __always_inline int handle_write_obs_sys_enter(long id, unsigned long di_
 		if (dx_ul > 0 && si_ul) {
 			/*
 			 * Multi-iovec visibility: writev's `vlen` arg (dx_ul) > 1
-			 * means scatter/gather payload that we will only observe
-			 * for iov[0]. Counter wired to tlsWritevMultiIovecObservedN
-			 * in agent_linux.go.
+			 * means scatter/gather payload. The counter still fires to
+			 * surface the rate of fragmented writes; BG-02 added a
+			 * bounded peek at iov[1] below so the second segment is no
+			 * longer silently dropped from sniff. Counter wired to
+			 * tlsWritevMultiIovecObservedN in agent_linux.go.
 			 */
 			if (dx_ul > 1)
 				note_tls_writev_multi_iovec();
@@ -163,6 +165,29 @@ static __always_inline int handle_write_obs_sys_enter(long id, unsigned long di_
 					iov_len = TLS_PAYLOAD_MAX;
 				try_emit_buffer_sniff_from_tuple(&tup, iov0.iov_base, iov_len,
 								 pt);
+
+				/*
+				 * BG-02 (C1, bounded): some writev callers split the
+				 * record so iov[0] holds a small header (length prefix
+				 * or framing byte) and iov[1] holds the TLS
+				 * ClientHello body. The dispatch helper rejects
+				 * non-TLS / non-HTTP prefixes internally, so doing a
+				 * second bounded peek at iov[1] is safe — at worst the
+				 * fingerprint also fails on iov[1] and nothing is
+				 * emitted. Strictly capped at index 1; no iov walk.
+				 */
+				if (dx_ul >= 2) {
+					struct coldstep_iovec iov1 = {};
+					if (bpf_probe_read_user(&iov1, sizeof(iov1),
+						(void *)(si_ul + sizeof(struct coldstep_iovec))) == 0) {
+						__u32 iov1_len = coldstep_syscall_len_u32(iov1.iov_len);
+						if (iov1_len > TLS_PAYLOAD_MAX)
+							iov1_len = TLS_PAYLOAD_MAX;
+						try_emit_buffer_sniff_from_tuple(&tup,
+										 iov1.iov_base,
+										 iov1_len, pt);
+					}
+				}
 			}
 		}
 		return 0;

--- a/bpf/trace_udp_sendmsg.inc
+++ b/bpf/trace_udp_sendmsg.inc
@@ -67,8 +67,11 @@ have_dest:
 	} else {
 		/*
 		 * Multi-iovec visibility: surface scatter/gather sendmsg calls so
-		 * operators see the rate of payload-fragmentation we don't observe past
-		 * iov[0]. Counter wired to udpSendmsgMultiIovecObservedN in agent_linux.go.
+		 * operators see the rate of payload-fragmentation. Counter still fires
+		 * so the historical metric stays comparable; BG-02 added the bounded
+		 * iov[1] peek below so iov[1] is no longer silently dropped from
+		 * TLS/HTTP sniff. Counter wired to udpSendmsgMultiIovecObservedN in
+		 * agent_linux.go.
 		 */
 		if (msg_iovlen > 1)
 			note_udp_sendmsg_multi_iovec();
@@ -84,6 +87,51 @@ have_dest:
 		handle_udp_obs_emit_pt(tuple_pt, sin_port, sin_addr, len);
 	else
 		handle_udp_obs_emit(sin_port, sin_addr, len);
+
+	/*
+	 * BG-02 (C1, bounded): historically only iov[0] length was extracted
+	 * for the udp_send_event; iov[1+] payloads were silently dropped from
+	 * TLS/HTTP sniff. When the sendmsg buffer is split (e.g. header in
+	 * iov[0], TLS ClientHello / HTTP request line in iov[1]) the protocol
+	 * fingerprint lives in iov[1]. Do one bounded peek at iov[1] and feed
+	 * it through the existing sniff helpers — both gate on their own
+	 * prefix tests, so non-matching payloads emit nothing. Strictly capped
+	 * at index 1: no unlimited iov walk.
+	 */
+	if (msg_iov && msg_iovlen >= 2) {
+		struct coldstep_iovec iov1 = {};
+
+		if (bpf_probe_read_user(&iov1, sizeof(iov1),
+					(void *)(msg_iov + sizeof(struct coldstep_iovec))) == 0) {
+			__u32 iov1_len = coldstep_syscall_len_u32(iov1.iov_len);
+
+			{
+				__u32 tls_len = iov1_len;
+
+				if (tls_len > TLS_PAYLOAD_MAX)
+					tls_len = TLS_PAYLOAD_MAX;
+				try_emit_tls_clienthello(fd32, iov1.iov_base, tls_len);
+			}
+
+			if (sin_port == bpf_htons(80)) {
+				__u32 http_len = iov1_len;
+
+				if (http_len > 0x00100000)
+					http_len = 0x00100000;
+				if (http_len >= 4 &&
+				    http_prefix_looks_like_request(iov1.iov_base, http_len)) {
+					if (use_tuple_pt)
+						handle_http_obs_emit_pt(tuple_pt, iov1.iov_base,
+									http_len, sin_port,
+									sin_addr);
+					else
+						handle_http_obs_emit(iov1.iov_base, http_len,
+								     sin_port, sin_addr);
+				}
+			}
+		}
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
## Summary

Implements **BG-02** (`documentation/2026-05-09-bpf-features-implementation-plan.md` Phase C, design choice **C1**): a single bounded `iov[1]` peek for TLS / HTTP fingerprint when `writev`/`pwritev`/`pwritev2` is called with `vlen >= 2`, or `sendmsg`/`sendmmsg` is called with `msg_iovlen >= 2`.

Previously only `iov[0]` was passed to the sniff helpers. The dedicated counters `tls_writev_multi_iovec_observed` and `udp_sendmsg_multi_iovec_observed` fired when fragmentation was observed, but any TLS ClientHello or HTTP request line that landed in `iov[1]` (e.g. length-prefixed framing with a header in `iov[0]`) was silently dropped from `tls_events` / `http_events`.

## What changed

- **`bpf/trace_tls_write.inc`** — in `handle_tls_obs_sys_enter` for `NR_WRITEV` / `NR_PWRITEV` / `NR_PWRITEV2`, after the existing `iov[0]` call to `try_emit_tls_clienthello`, when `dx_ul >= 2` perform one more bounded `bpf_probe_read_user` of `iov[1]` (16 bytes — constant size) and re-invoke `try_emit_tls_clienthello`. The internal TLS prefix fingerprint (`0x16 0x03 0x0? ... 0x01`) gates emission, so a non-matching `iov[1]` is a no-op.

- **`bpf/trace_udp_sendmsg.inc`** — in `handle_udp_obs_sendmsg`, after the existing destination + length extraction from `iov[0]`, when `msg_iovlen >= 2` peek `iov[1]` and feed its buffer through both `try_emit_tls_clienthello` and the cleartext HTTP request fingerprint (`http_prefix_looks_like_request` gated on `dport == 80`). Both helpers gate on their own prefix tests.

- **`bpf/trace_connect.bpf.c`** — reorder includes so `trace_udp_sendmsg.inc` comes after `trace_http_obs.inc` and `trace_tls_write.inc` (the new iov[1] sniff calls helpers defined there). `handle_udp_obs_sendmsg` is only referenced from the .bpf.c dispatcher below the includes, so reordering is safe.

- **`CHANGELOG.md`** — `[Unreleased]` entry describing the change.

## Constraints honored

- **Bounded only** — strictly capped at index 1, no `iov` walk loop.
- **Constant-size reads** — `sizeof(struct coldstep_iovec)` is a compile-time constant, keeping the verifier's scalar range tight.
- **Counters preserved** — `tls_writev_multi_iovec_observed` and `udp_sendmsg_multi_iovec_observed` still increment on `vlen > 1` / `msg_iovlen > 1` so the historical fragmentation-rate metric stays comparable; comments updated to note iov[1] is no longer dropped.
- **No Go / agent / wire changes** — emit goes through existing `tls_events` / `http_events` paths.
- **No `enforce` references** introduced.

## Validation

- `bash scripts/check-gofmt.sh` — pass.
- `bash scripts/check-encoding.sh` — pass.
- `go vet $(go list ./... | grep -v internal/bpf/)` — pass (BPF stub packages require Linux + clang + libbpf to generate `*_bpfel.go`; verified in CI).
- `go test $(go list ./... | grep -v internal/bpf/) -count=1` — pass.
- BPF compile + verifier load are validated by CI's `coldstep-ci-runner.yml` (`unit`, `unit-arm64`, `integration`, `detect-mode`, `defend-mode`).

## Follow-ups (out of scope)

- **BG-03** `sendmmsg` multi-message counter (separate PR per implementation plan Phase D).
- Synthetic `writev` / `sendmsg` 2-iov integration fixture (Phase C step 4 — fixture lives in the demo / red-team workflows; not required for the BPF change itself to merge).
