### PR TITLE
refactor: consolidate EmptyReason digest helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased]
+
+### Changed
+- refactor: consolidate four `*EmptyReason` digest helpers into `protocolEmptyReason`.
+
+---
+
 ## [v0.2.4] — 2025-05-16
 
 ### Fixed

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -462,7 +462,7 @@ func BuildDetectMarkdown(in DigestInput) string {
 		b.WriteString("<details>\n<summary><strong>TCP connect attempts (recent)</strong></summary>\n\n")
 		b.WriteString("| Time (UTC) | PID | Comm | Remote | Notes | Policy |\n|:--|--:|:-|:-|:-|:-|\n")
 		if len(in.TCPRows) == 0 {
-			b.WriteString(fmt.Sprintf("| — | — | — | — | — | %s |\n", sanitizeCell(tcpEmptyReason(in))))
+			b.WriteString(fmt.Sprintf("| — | — | — | — | — | %s |\n", sanitizeCell(protocolEmptyReason(in.TCPDegradedHook, in.TCPReaderErrors))))
 		} else {
 			for _, r := range in.TCPRows {
 				b.WriteString(fmt.Sprintf("| %s | `%d` | `%s` | %s | %s | %s |\n",
@@ -476,7 +476,7 @@ func BuildDetectMarkdown(in DigestInput) string {
 		b.WriteString("<details>\n<summary><strong>UDP sendto (recent)</strong></summary>\n\n")
 		b.WriteString("| Time (UTC) | PID | Comm | Remote | Len | FQDN | Policy |\n|:--|--:|:-|:-|--:|:-|:-|\n")
 		if len(in.UDPRows) == 0 {
-			b.WriteString(fmt.Sprintf("| — | — | — | — | — | — | %s |\n", sanitizeCell(udpEmptyReason(in))))
+			b.WriteString(fmt.Sprintf("| — | — | — | — | — | — | %s |\n", sanitizeCell(protocolEmptyReason(in.UDPDegradedHook, in.UDPReaderErrors))))
 		} else {
 			for _, r := range in.UDPRows {
 				fq := r.FQDN
@@ -494,7 +494,7 @@ func BuildDetectMarkdown(in DigestInput) string {
 		b.WriteString("<details>\n<summary><strong>HTTP/1 cleartext (recent)</strong></summary>\n\n")
 		b.WriteString("| Time (UTC) | PID | Comm | Method | Host | Path (summary) | Remote | Policy |\n|:--|--:|:-|:-|:-|:-|:-|:-|\n")
 		if len(in.HTTPRows) == 0 {
-			b.WriteString(fmt.Sprintf("| — | — | — | — | — | — | — | %s |\n", sanitizeCell(httpEmptyReason(in))))
+			b.WriteString(fmt.Sprintf("| — | — | — | — | — | — | — | %s |\n", sanitizeCell(protocolEmptyReason(in.HTTPDegradedHook, in.HTTPReaderErrors))))
 		} else {
 			for _, r := range in.HTTPRows {
 				b.WriteString(fmt.Sprintf("| %s | `%d` | `%s` | `%s` | `%s` | `%s` | %s | %s |\n",
@@ -512,7 +512,7 @@ func BuildDetectMarkdown(in DigestInput) string {
 		b.WriteString("<details>\n<summary><strong>TLS ClientHello / SNI (recent)</strong></summary>\n\n")
 		b.WriteString("| Time (UTC) | PID | Comm | SNI | Remote | Policy |\n|:--|--:|:-|:-|:-|:-|\n")
 		if len(in.TLSRows) == 0 {
-			b.WriteString(fmt.Sprintf("| — | — | — | — | — | %s |\n", sanitizeCell(tlsEmptyReason(in))))
+			b.WriteString(fmt.Sprintf("| — | — | — | — | — | %s |\n", sanitizeCell(protocolEmptyReason(in.TLSDegradedHook, in.TLSReaderErrors))))
 		} else {
 			for _, r := range in.TLSRows {
 				b.WriteString(fmt.Sprintf("| %s | `%d` | `%s` | `%s` | %s | %s |\n",

--- a/internal/report/digest_aggregation.go
+++ b/internal/report/digest_aggregation.go
@@ -148,42 +148,12 @@ func fsKPIVisible(in DigestInput) bool {
 	return in.FSGate
 }
 
-func tcpEmptyReason(in DigestInput) string {
-	if in.TCPDegradedHook {
+func protocolEmptyReason(degraded bool, errors int) string {
+	if degraded {
 		return "degraded hook"
 	}
-	if in.TCPReaderErrors > 0 {
-		return fmt.Sprintf("reader errors (%d)", in.TCPReaderErrors)
-	}
-	return "no events"
-}
-
-func udpEmptyReason(in DigestInput) string {
-	if in.UDPDegradedHook {
-		return "degraded hook"
-	}
-	if in.UDPReaderErrors > 0 {
-		return fmt.Sprintf("reader errors (%d)", in.UDPReaderErrors)
-	}
-	return "no events"
-}
-
-func httpEmptyReason(in DigestInput) string {
-	if in.HTTPDegradedHook {
-		return "degraded hook"
-	}
-	if in.HTTPReaderErrors > 0 {
-		return fmt.Sprintf("reader errors (%d)", in.HTTPReaderErrors)
-	}
-	return "no events"
-}
-
-func tlsEmptyReason(in DigestInput) string {
-	if in.TLSDegradedHook {
-		return "degraded hook"
-	}
-	if in.TLSReaderErrors > 0 {
-		return fmt.Sprintf("reader errors (%d)", in.TLSReaderErrors)
+	if errors > 0 {
+		return fmt.Sprintf("reader errors (%d)", errors)
 	}
 	return "no events"
 }


### PR DESCRIPTION
Collapses four near-identical `*EmptyReason` functions into a single `protocolEmptyReason(degraded bool, errors int) string` helper. ~28 LOC removed, no behavior change.