### PR TITLE
feat: BG-03 sendmmsg multi-message counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased]
+
+### Added
+- BG-03: `sendmmsg_multi_message_observed` counter tracks NR_SENDMMSG calls with vlen>1 (separate from multi-iovec counter).
+
+---
+
 ## [v0.2.4] — 2025-05-16
 
 ### Fixed

--- a/bpf/trace_connect.bpf.c
+++ b/bpf/trace_connect.bpf.c
@@ -128,6 +128,22 @@ struct {
 } tls_writev_multi_iovec_observed SEC(".maps");
 
 /*
+ * BG-03 (Phase D of 2026-05-09 BPF features plan): distinct counter for
+ * sendmmsg(2) calls with vlen > 1. The `udp_sendmsg_multi_iovec_observed`
+ * counter named-by-design tracks multi-iovec (per-message msg_iovlen > 1).
+ * Multi-message (vlen > 1) is a separate axis: one syscall, many mmsghdr
+ * entries — BPF only introspects the first one, so messages 2..N are
+ * silently invisible. PERCPU_ARRAY avoids cross-CPU contention on the
+ * increment; userspace sums the slots.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__type(value, __u32);
+} sendmmsg_multi_message_observed SEC(".maps");
+
+/*
  * PR-E (Theme C of the 2026-04-18 review): aggregate visibility counter for
  * IPv4 egress / file-descriptor write syscalls that Coldstep does NOT
  * currently sniff for HTTP/TLS payload. Real workloads (multi-message
@@ -260,6 +276,16 @@ static __always_inline void note_tls_writev_multi_iovec(void)
 {
 	__u32 k = 0;
 	__u32 *v = bpf_map_lookup_elem(&tls_writev_multi_iovec_observed, &k);
+
+	if (!v)
+		return;
+	__sync_fetch_and_add(v, 1);
+}
+
+static __always_inline void note_sendmmsg_multi_message(void)
+{
+	__u32 k = 0;
+	__u32 *v = bpf_map_lookup_elem(&sendmmsg_multi_message_observed, &k);
 
 	if (!v)
 		return;
@@ -463,7 +489,17 @@ int handle_raw_sys_enter(struct bpf_raw_tracepoint_args *ctx)
 		 */
 
 		/* struct mmsghdr starts with struct msghdr */
-		return handle_udp_obs_sendmsg((__u32)di_ul, msgvec_ptr);
+		int rc = handle_udp_obs_sendmsg((__u32)di_ul, msgvec_ptr);
+
+		/*
+		 * BG-03: count multi-message sendmmsg calls separately from
+		 * multi-iovec. `vlen_ul > 1` means messages 2..N exist but are
+		 * not introspected (BPF only walks the first mmsghdr).
+		 */
+		if (vlen_ul > 1)
+			note_sendmmsg_multi_message();
+
+		return rc;
 	}
 
 	if (id == (long)COLDSTEP_NR_SENDFILE) {

--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -331,6 +331,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 				stats.setTLSRingbufReserveFailures(readTLSRingbufReserveFailureCount(syscallObjs))
 				stats.setUDPSendmsgMultiIovecObserved(readUDPSendmsgMultiIovecObservedCount(syscallObjs))
 				stats.setTLSWritevMultiIovecObserved(readTLSWritevMultiIovecObservedCount(syscallObjs))
+				stats.setSendmmsgMultiMessageObserved(readSendmmsgMultiMessageCount(syscallObjs))
 				stats.setUnobservedEgressSyscalls(readUnobservedEgressSyscallsCount(syscallObjs))
 				stats.setIoUringSetupObserved(readIoUringSetupObservedCount(syscallObjs))
 			}

--- a/internal/agent/agent_linux_digest.go
+++ b/internal/agent/agent_linux_digest.go
@@ -136,6 +136,7 @@ func buildDigestInput(
 		FSRingbufReserveFailures:       stats.fsRingbufReserveFailures(),
 		UDPSendmsgMultiIovecObserved:   stats.udpSendmsgMultiIovecObserved(),
 		TLSWritevMultiIovecObserved:    stats.tlsWritevMultiIovecObserved(),
+		SendmmsgMultiMessage:           stats.sendmmsgMultiMessageObserved(),
 		UnobservedEgressSyscalls:       stats.unobservedEgressSyscalls(),
 		IoUringSetupObserved:           stats.ioUringSetupObserved(),
 		CanaryPipelineOK:               canarySnap.pipelineOK,

--- a/internal/agent/agent_linux_policy_maps.go
+++ b/internal/agent/agent_linux_policy_maps.go
@@ -220,6 +220,13 @@ func readTLSWritevMultiIovecObservedCount(objs *traceconnect.TraceconnectObjects
 	return readUint32CounterMap(objs.TlsWritevMultiIovecObserved, "readTLSWritevMultiIovecObservedCount")
 }
 
+func readSendmmsgMultiMessageCount(objs *traceconnect.TraceconnectObjects) int {
+	if objs == nil {
+		return 0
+	}
+	return readUint32PerCPUArraySum(objs.SendmmsgMultiMessageObserved, "sendmmsg_multi_message_observed")
+}
+
 func readUnobservedEgressSyscallsCount(objs *traceconnect.TraceconnectObjects) int {
 	if objs == nil {
 		return 0

--- a/internal/agent/agent_linux_state.go
+++ b/internal/agent/agent_linux_state.go
@@ -46,6 +46,7 @@ type runStats struct {
 	fsRingbufReserveFailuresN       int
 	udpSendmsgMultiIovecObservedN   int
 	tlsWritevMultiIovecObservedN    int
+	sendmmsgMultiMessageObservedN   int
 	unobservedEgressSyscallsN       int
 	ioUringSetupObservedN           int
 	tcpDNSResponsesObservedN        int
@@ -273,6 +274,18 @@ func (s *runStats) tlsWritevMultiIovecObserved() int {
 	return s.tlsWritevMultiIovecObservedN
 }
 
+func (s *runStats) setSendmmsgMultiMessageObserved(n int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sendmmsgMultiMessageObservedN = n
+}
+
+func (s *runStats) sendmmsgMultiMessageObserved() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sendmmsgMultiMessageObservedN
+}
+
 func (s *runStats) setUnobservedEgressSyscalls(n int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -422,6 +435,7 @@ func (s *runStats) snapshotSummary(kernel string, bpf []telemetry.BPFStatus) tel
 		RingbufReserveFailuresTotal:    rbTotal,
 		UDPSendmsgMultiIovecObserved:   s.udpSendmsgMultiIovecObservedN,
 		TLSWritevMultiIovecObserved:    s.tlsWritevMultiIovecObservedN,
+		SendmmsgMultiMessage:           s.sendmmsgMultiMessageObservedN,
 		UnobservedEgressSyscalls:       s.unobservedEgressSyscallsN,
 		IoUringSetupObserved:           s.ioUringSetupObservedN,
 		TCPDNSResponsesObserved:        s.tcpDNSResponsesObservedN,

--- a/internal/bpf/traceconnect/abi_test.go
+++ b/internal/bpf/traceconnect/abi_test.go
@@ -91,6 +91,7 @@ func TestTraceconnectMapShapes(t *testing.T) {
 			"connect_ringbuf_reserve_failures",
 			"http_ringbuf_reserve_failures",
 			"tls_ringbuf_reserve_failures",
+			"sendmmsg_multi_message_observed",
 		}
 		for _, name := range names {
 			ms, ok := spec.Maps[name]

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -96,6 +96,9 @@ func writeTriageRibbon(b *strings.Builder, in DigestInput) {
 	if in.UDPSendmsgMultiIovecObserved > 0 {
 		gapParts = append(gapParts, fmt.Sprintf("udp multi-iovec=%d", in.UDPSendmsgMultiIovecObserved))
 	}
+	if in.SendmmsgMultiMessage > 0 {
+		gapParts = append(gapParts, fmt.Sprintf("sendmmsg multi-message=%d", in.SendmmsgMultiMessage))
+	}
 	if in.TLSWritevMultiIovecObserved > 0 {
 		gapParts = append(gapParts, fmt.Sprintf("tls writev multi-iovec=%d", in.TLSWritevMultiIovecObserved))
 	}
@@ -227,6 +230,9 @@ func BuildDetectMarkdown(in DigestInput) string {
 	}
 	if in.UDPSendmsgMultiIovecObserved > 0 {
 		b.WriteString(fmt.Sprintf("| **udp_sendmsg multi-iovec calls (iov[1..n] not captured)** | %d |\n", in.UDPSendmsgMultiIovecObserved))
+	}
+	if in.SendmmsgMultiMessage > 0 {
+		b.WriteString(fmt.Sprintf("| **sendmmsg multi-message calls (msg[1..n] not introspected)** | %d |\n", in.SendmmsgMultiMessage))
 	}
 	if in.TLSWritevMultiIovecObserved > 0 {
 		b.WriteString(fmt.Sprintf("| **tls writev multi-iovec calls (iov[1..n] not captured)** | %d |\n", in.TLSWritevMultiIovecObserved))

--- a/internal/report/digest_types.go
+++ b/internal/report/digest_types.go
@@ -168,6 +168,11 @@ type DigestInput struct {
 	// to gauge how much UDP sendmsg / TLS writev traffic is partially observed.
 	UDPSendmsgMultiIovecObserved int
 	TLSWritevMultiIovecObserved  int
+	// SendmmsgMultiMessage counts sendmmsg(2) calls with vlen > 1 (BG-03).
+	// Distinct from UDPSendmsgMultiIovecObserved (which is per-message iovec
+	// fragmentation): this axis is the number of mmsghdr entries, where BPF
+	// only introspects the first so messages 2..N are silently uncaptured.
+	SendmmsgMultiMessage int
 	// UnobservedEgressSyscalls counts IPv4-egress / fd-write syscalls (sendmmsg,
 	// sendfile, sendfile64, splice, etc.) not fully covered by HTTP/TLS sniff arms (PR-E).
 	// pwrite64/pwritev/pwritev2 share the TLS ClientHello path with write/writev when tuple-correlated.

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -97,6 +97,7 @@ type Summary struct {
 	FSRingbufReserveFailures       int    `json:"fs_ringbuf_reserve_failures,omitempty"`
 	UDPSendmsgMultiIovecObserved   int    `json:"udp_sendmsg_multi_iovec_observed,omitempty"`
 	TLSWritevMultiIovecObserved    int    `json:"tls_writev_multi_iovec_observed,omitempty"`
+	SendmmsgMultiMessage           int    `json:"sendmmsg_multi_message_observed,omitempty"`
 	UnobservedEgressSyscalls       int    `json:"unobserved_egress_syscalls_observed,omitempty"`
 	IoUringSetupObserved           int    `json:"io_uring_setup_observed,omitempty"`
 	TCPDNSResponsesObserved        int    `json:"tcp_dns_responses_observed,omitempty"`


### PR DESCRIPTION
Adds sendmmsg_multi_message_observed PERCPU_ARRAY that increments when vlen_ul > 1 on NR_SENDMMSG. Separate from udp_sendmsg_multi_iovec_observed (multi-iovec on first mmsghdr). Wires counter through Go agent, telemetry, and digest.