### PR TITLE
fix(bpf): use tuple-form TLS sniff helper in udp_sendmsg iov[1] peek

### DIFF
--- a/bpf/trace_udp_sendmsg.inc
+++ b/bpf/trace_udp_sendmsg.inc
@@ -107,10 +107,18 @@ have_dest:
 
 			{
 				__u32 tls_len = iov1_len;
+				struct connect4_tuple st = {};
+				__u64 pt_sniff = use_tuple_pt ? tuple_pt
+							      : bpf_get_current_pid_tgid();
 
 				if (tls_len > TLS_PAYLOAD_MAX)
 					tls_len = TLS_PAYLOAD_MAX;
-				try_emit_tls_clienthello(fd32, iov1.iov_base, tls_len);
+				st.in_use = 1;
+				st._pad = 0;
+				__builtin_memcpy(st.daddr, &sin_addr, sizeof(st.daddr));
+				__builtin_memcpy(st.dport, &sin_port, sizeof(st.dport));
+				try_emit_tls_clienthello_from_tuple(&st, iov1.iov_base,
+								    tls_len, pt_sniff);
 			}
 
 			if (sin_port == bpf_htons(80)) {


### PR DESCRIPTION
## Summary

Hotfix for the BPF compile break on `main` introduced by the BG-02 merge (#143).

BG-04 (#140) removed the `try_emit_tls_clienthello(fd32, buf, len)` helper and replaced its call sites with the tuple-form `try_emit_tls_clienthello_from_tuple` / `try_emit_buffer_sniff_from_tuple`. The BG-02 PR added a bounded `iov[1]` peek to **two** sites:

- `bpf/trace_tls_write.inc` — conflicted with BG-04 during rebase, was resolved manually to use the new helper.
- `bpf/trace_udp_sendmsg.inc` — auto-merged cleanly because BG-04 didn't touch it, but the inserted `try_emit_tls_clienthello(fd32, …)` call now references a deleted symbol. CI on `dcecbe7` (BG-02 merge commit) failed every `unit`/`integration`/`defend-mode`/`staticcheck`/`golangci-lint`/`action_bundle` job with:

```
bpf/trace_udp_sendmsg.inc:113:5: error: call to undeclared function 'try_emit_tls_clienthello'
```

This PR routes the iov[1] peek through `try_emit_tls_clienthello_from_tuple` by synthesizing a stack `connect4_tuple` from the already-resolved `sin_addr`/`sin_port`, matching the explicit-sockaddr pattern at `bpf/trace_connect.bpf.c:438`. When the destination was resolved via `coldstep_tuple_dst_for_fd` we reuse the cached `tuple_pt`; for the explicit-sockaddr path we synthesize via `bpf_get_current_pid_tgid()`.

## Test plan

- [ ] CI `unit` and `integration` jobs pass (BPF object compiles).
- [ ] CI `defend-mode` lab still emits TLS sniff events for iov[1] payloads.
