### PR TITLE
fix(bpf): call try_emit_tls_clienthello_from_tuple in udp_sendmsg iov[1] peek

### DIFF
--- a/bpf/trace_udp_sendmsg.inc
+++ b/bpf/trace_udp_sendmsg.inc
@@ -107,10 +107,18 @@ have_dest:
 
 			{
 				__u32 tls_len = iov1_len;
+				struct connect4_tuple st = {};
+				__u64 pt = use_tuple_pt ? tuple_pt
+							: bpf_get_current_pid_tgid();
 
 				if (tls_len > TLS_PAYLOAD_MAX)
 					tls_len = TLS_PAYLOAD_MAX;
-				try_emit_tls_clienthello(fd32, iov1.iov_base, tls_len);
+				st.in_use = 1;
+				st._pad = 0;
+				__builtin_memcpy(st.daddr, &sin_addr, sizeof(st.daddr));
+				__builtin_memcpy(st.dport, &sin_port, sizeof(st.dport));
+				try_emit_tls_clienthello_from_tuple(&st, iov1.iov_base,
+								    tls_len, pt);
 			}
 
 			if (sin_port == bpf_htons(80)) {


### PR DESCRIPTION
## Summary

PR #143's BG-02 iov[1] peek path in `bpf/trace_udp_sendmsg.inc` called a non-existent `try_emit_tls_clienthello(fd, buf, len)` 3-arg helper, breaking every CI job at "Prepare BPF and generated Go":

```
trace_udp_sendmsg.inc:113:5: error: call to undeclared function
'try_emit_tls_clienthello'; ISO C99 and later do not support
implicit function declarations
internal/bpf/traceconnect/gen.go:21: running "go": exit status 1
```

`trace_tls_write.inc` only defines `try_emit_tls_clienthello_from_tuple(struct connect4_tuple *, buf, len, pt)`. The fix synthesizes a `connect4_tuple` from the already-resolved `sin_addr` / `sin_port` — identical pattern to the explicit-sockaddr sendto arm in `trace_connect.bpf.c:438-445` — and picks `tuple_pt` when the cached connect tuple was used, otherwise `bpf_get_current_pid_tgid()`.

Failed runs after #143 / #146 merged:
- `26052356049` (commit `dcecbe7` — PR #143)
- `26052538912` (commit `ac2d504` — PR #146)

Every job under `coldstep-ci`: golangci-lint, unit, unit-arm64, integration, defend-mode, gosec, staticcheck, action_bundle.

## Test plan
- [ ] `coldstep-ci` workflow turns green (BPF compile passes, downstream Go vet / staticcheck / unit / integration succeed)
- [ ] `detect-mode` still passes (was passing before — sanity)
- [ ] `defend-mode` deny telemetry assertions still pass
