### PR TITLE
report: GFM-compliant compact Step Summary (remove <font>/<sub>/<p align>, cut length ~80%)

### DIFF
--- a/internal/agent/agent_integration_test.go
+++ b/internal/agent/agent_integration_test.go
@@ -101,8 +101,8 @@ func TestRun_DetectWritesSummary(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Contains(b, []byte("## Coldstep")) || !bytes.Contains(b, []byte("| **exec** |")) {
-		t.Fatalf("expected Coldstep table with exec row, got:\n%s", string(b))
+	if !bytes.Contains(b, []byte("coldstep — detect")) || !bytes.Contains(b, []byte("| **exec** |")) {
+		t.Fatalf("expected coldstep detect heading with exec row, got:\n%s", string(b))
 	}
 }
 

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -11,6 +11,11 @@
 //     ringbuf summing, KPI visibility predicates, empty-state reasons).
 //   - digest.go (this file): the markdown writers and the top-level
 //     BuildDetectMarkdown / WriteDetectDigest entry points.
+//
+// Output is GitHub Flavored Markdown (GFM) only — standard Markdown plus the
+// GFM HTML subset (<details>, <summary>, <br>, <hr>, <table>). No <font>,
+// <p align>, <sub>, or <center>; those are not in the GFM allowlist and render
+// as literal text in Job Summaries.
 package report
 
 import (
@@ -22,22 +27,22 @@ import (
 )
 
 // partialEgressTotal sums the BG-01 per-syscall partial-observe counters so the
-// headline-badge "Review" threshold can flip on any non-zero partial-observe
-// without the user having to scroll into the KPI table.
+// headline-verdict "Review" threshold flips on any non-zero partial-observe.
 func partialEgressTotal(in DigestInput) int {
 	return in.SendfileObserved + in.SpliceObserved + in.SendmmsgFirstOnly
 }
 
-// writeHeadlineBadge renders a one-line summary verdict immediately under the
-// `## Coldstep · …` header. Levels: 🚨 Alert, ⚠️ Review, ✅ Clean run. The badge
-// is a blockquote so it survives GitHub Job Summary's tight vertical budget
-// even when the rest of the digest is collapsed.
-func writeHeadlineBadge(b *strings.Builder, in DigestInput) {
-	mode := "detect"
-	if isBlockingDigestMode(in.DefendMode) {
-		mode = "defend"
+func droppedTotal(in DigestInput) int {
+	t := 0
+	for _, v := range in.DroppedCounts {
+		t += v
 	}
+	return t
+}
 
+// verdictEmoji returns ✅ / ⚠️ / 🚨 for the headline. Mirrors the prior
+// blockquote badge logic but is now embedded directly in the `##` heading.
+func verdictEmoji(in DigestInput) string {
 	bpfOK := true
 	for _, row := range in.BPF {
 		if !row.OK {
@@ -45,65 +50,92 @@ func writeHeadlineBadge(b *strings.Builder, in DigestInput) {
 			break
 		}
 	}
-
 	alert := (!in.CanaryPipelineOK && in.CanaryFailCount > 0) ||
 		in.BPFHeartbeatFailures > 0 ||
 		in.BPFMapIntegrityFailures > 0 ||
 		(len(in.BPF) > 0 && !bpfOK)
-
-	rbTotal := totalDetectRingbufReserveFailures(in)
-	review := rbTotal > 0 ||
+	if alert {
+		return "🚨"
+	}
+	review := totalDetectRingbufReserveFailures(in) > 0 ||
 		in.UDPSendmsgMultiIovecObserved > 0 ||
 		in.TLSWritevMultiIovecObserved > 0 ||
 		in.SendmmsgMultiMessage > 0 ||
-		partialEgressTotal(in) > 0
-
-	var emoji, label string
-	switch {
-	case alert:
-		emoji, label = "🚨", "Alert"
-	case review:
-		emoji, label = "⚠️", "Review"
-	default:
-		emoji, label = "✅", "Clean run"
+		partialEgressTotal(in) > 0 ||
+		in.Connect4TupleUpdateFailures > 0 ||
+		in.DefendDenyReserveFailures > 0 ||
+		droppedTotal(in) > 0 ||
+		in.IoUringSetupObserved > 0
+	if review {
+		return "⚠️"
 	}
-
-	bpfNote := "BPF OK"
-	if !bpfOK {
-		bpfNote = "BPF degraded"
-	}
-	if len(in.BPF) == 0 {
-		bpfNote = "BPF status n/a"
-	}
-
-	parts := []string{
-		fmt.Sprintf("%s **%s**", emoji, label),
-		mode,
-		bpfNote,
-		fmt.Sprintf("%d exec", in.ExecTotal),
-		fmt.Sprintf("%d tcp", in.TCPTotal),
-	}
-	b.WriteString("> ")
-	b.WriteString(strings.Join(parts, " · "))
-	b.WriteString("\n\n")
+	return "✅"
 }
 
-func writeTriageRibbon(b *strings.Builder, in DigestInput) {
-	b.WriteString("### Triage\n\n")
-	b.WriteString("| Question | Answer |\n|:--|:--|\n")
+// writeHeader renders the single-line `## <emoji> coldstep — <mode>` heading.
+func writeHeader(b *strings.Builder, in DigestInput) {
+	mode := "detect"
+	if isBlockingDigestMode(in.DefendMode) {
+		mode = "defend"
+	}
+	fmt.Fprintf(b, "## %s coldstep — %s\n\n", verdictEmoji(in), mode)
+}
+
+// writeCompactKPI emits a single-row 5-column KPI table. The full per-channel
+// KPI breakdown (ringbuf reserves, partial-observe counters, health rows) sits
+// inside the Technical details fold instead.
+func writeCompactKPI(b *strings.Builder, in DigestInput) {
+	tlsCell := "—"
+	if tlsKPIVisible(in) {
+		tlsCell = fmt.Sprintf("%d", in.TLSTotal)
+	}
+	b.WriteString("| exec | tcp | udp | http | tls |\n")
+	b.WriteString("|--:|--:|--:|--:|--:|\n")
+	fmt.Fprintf(b, "| %d | %d | %d | %d | %s |\n\n",
+		in.ExecTotal, in.TCPTotal, in.UDPTotal, in.HTTPTotal, tlsCell)
+}
+
+// writeTopDestinations emits the top-10 hot egress destinations. Hidden when
+// no egress was observed.
+func writeTopDestinations(b *strings.Builder, in DigestInput) {
+	hot := buildHotEgressList(in)
+	if len(hot) == 0 {
+		return
+	}
+	if len(hot) > 10 {
+		hot = hot[:10]
+	}
+	b.WriteString("### Top destinations\n\n")
+	b.WriteString("| Rank | Entity | Rows | Channels |\n")
+	b.WriteString("|--:|:--|--:|:--|\n")
+	for i, e := range hot {
+		tags := hotKindTags(e.kinds)
+		if tags == "" {
+			tags = "—"
+		}
+		fmt.Fprintf(b, "| %d | %s | %d | %s |\n",
+			i+1, sanitizeCell(e.key), e.count, sanitizeCell(tags))
+	}
+	b.WriteString("\n")
+}
+
+// buildTriageRows returns (label, value) pairs for the compact Triage table.
+// Empty rows are skipped — only signals that actually matter surface.
+func buildTriageRows(in DigestInput) [][2]string {
+	var rows [][2]string
 
 	mode := "detect"
 	if isBlockingDigestMode(in.DefendMode) {
 		mode = "defend"
 	}
-	b.WriteString(fmt.Sprintf("| **Mode** | `%s`", sanitizeCell(mode)))
+	modeCell := fmt.Sprintf("`%s`", mode)
 	if isBlockingDigestMode(in.DefendMode) {
-		b.WriteString(fmt.Sprintf(" — **deny events:** %d", in.DefendDenyCount))
+		modeCell += fmt.Sprintf(" — **deny events:** %d", in.DefendDenyCount)
 		if in.DefendDenyReserveFailures > 0 {
-			b.WriteString(fmt.Sprintf(" (**+%d** deny reserve failures)", in.DefendDenyReserveFailures))
+			modeCell += fmt.Sprintf(" (**+%d** deny reserve failures)", in.DefendDenyReserveFailures)
 		}
 	}
-	b.WriteString(" |\n")
+	rows = append(rows, [2]string{"**Mode**", modeCell})
 
 	bpfOK := true
 	var badBPF []string
@@ -113,115 +145,185 @@ func writeTriageRibbon(b *strings.Builder, in DigestInput) {
 			badBPF = append(badBPF, row.Name)
 		}
 	}
-	if len(in.BPF) == 0 {
-		b.WriteString("| **BPF hooks** | *(no status rows)* |\n")
-	} else if bpfOK {
-		b.WriteString("| **BPF hooks** | ✅ All probes OK |\n")
-	} else {
+	switch {
+	case len(in.BPF) == 0:
+		rows = append(rows, [2]string{"**BPF hooks**", "*(no status rows)*"})
+	case bpfOK:
+		rows = append(rows, [2]string{"**BPF hooks**", "✅ All probes OK"})
+	default:
 		sort.Strings(badBPF)
-		b.WriteString(fmt.Sprintf("| **BPF hooks** | 🚨 **Review** — degraded: %s |\n", sanitizeCell(strings.Join(badBPF, ", "))))
+		rows = append(rows, [2]string{"**BPF hooks**", fmt.Sprintf("🚨 **Review** — degraded: %s", sanitizeCell(strings.Join(badBPF, ", ")))})
 	}
 
-	droppedTotal := 0
-	for _, v := range in.DroppedCounts {
-		droppedTotal += v
-	}
-	if droppedTotal == 0 {
-		b.WriteString("| **JSONL decode drops** | ✅ None |\n")
-	} else {
-		b.WriteString(fmt.Sprintf("| **JSONL decode drops** | ⚠️ **%d** total — see rollups below |\n", droppedTotal))
+	if dt := droppedTotal(in); dt > 0 {
+		rows = append(rows, [2]string{"**JSONL decode drops**", fmt.Sprintf("⚠️ **%d** total — see Technical details", dt)})
 	}
 
 	var gapParts []string
-	if in.Connect4TupleUpdateFailures > 0 {
-		gapParts = append(gapParts, fmt.Sprintf("connect4 map failures=%d", in.Connect4TupleUpdateFailures))
+	gapAdd := func(label string, n int) {
+		if n > 0 {
+			gapParts = append(gapParts, fmt.Sprintf("%s=%d", label, n))
+		}
 	}
-	if in.UDPRingbufReserveFailures > 0 {
-		gapParts = append(gapParts, fmt.Sprintf("udp ringbuf reserve=%d", in.UDPRingbufReserveFailures))
-	}
-	if in.DNSRingbufReserveFailures > 0 {
-		gapParts = append(gapParts, fmt.Sprintf("dns ringbuf reserve=%d", in.DNSRingbufReserveFailures))
-	}
-	if in.ConnectRingbufReserveFailures > 0 {
-		gapParts = append(gapParts, fmt.Sprintf("connect ringbuf reserve=%d", in.ConnectRingbufReserveFailures))
-	}
-	if in.HTTPRingbufReserveFailures > 0 {
-		gapParts = append(gapParts, fmt.Sprintf("http ringbuf reserve=%d", in.HTTPRingbufReserveFailures))
-	}
-	if in.TLSRingbufReserveFailures > 0 {
-		gapParts = append(gapParts, fmt.Sprintf("tls ringbuf reserve=%d", in.TLSRingbufReserveFailures))
-	}
-	if in.ExecRingbufReserveFailures > 0 {
-		gapParts = append(gapParts, fmt.Sprintf("exec ringbuf reserve=%d", in.ExecRingbufReserveFailures))
-	}
-	if in.ForkRingbufReserveFailures > 0 {
-		gapParts = append(gapParts, fmt.Sprintf("fork ringbuf reserve=%d", in.ForkRingbufReserveFailures))
-	}
-	if in.FSRingbufReserveFailures > 0 {
-		gapParts = append(gapParts, fmt.Sprintf("fs ringbuf reserve=%d", in.FSRingbufReserveFailures))
-	}
-	if in.UDPSendmsgMultiIovecObserved > 0 {
-		gapParts = append(gapParts, fmt.Sprintf("udp multi-iovec=%d", in.UDPSendmsgMultiIovecObserved))
-	}
-	if in.SendmmsgMultiMessage > 0 {
-		gapParts = append(gapParts, fmt.Sprintf("sendmmsg multi-message=%d", in.SendmmsgMultiMessage))
-	}
-	if in.TLSWritevMultiIovecObserved > 0 {
-		gapParts = append(gapParts, fmt.Sprintf("tls writev multi-iovec=%d", in.TLSWritevMultiIovecObserved))
-	}
-	if in.SendfileObserved > 0 {
-		gapParts = append(gapParts, fmt.Sprintf("sendfile partial-observe=%d", in.SendfileObserved))
-	}
-	if in.SpliceObserved > 0 {
-		gapParts = append(gapParts, fmt.Sprintf("splice partial-observe=%d", in.SpliceObserved))
-	}
-	if in.SendmmsgFirstOnly > 0 {
-		gapParts = append(gapParts, fmt.Sprintf("sendmmsg first-message-only=%d", in.SendmmsgFirstOnly))
-	}
-	if in.TCPDNSSkippedShortRead > 0 {
-		gapParts = append(gapParts, fmt.Sprintf("tcp dns short read=%d", in.TCPDNSSkippedShortRead))
-	}
+	gapAdd("connect4 map failures", in.Connect4TupleUpdateFailures)
+	gapAdd("udp ringbuf reserve", in.UDPRingbufReserveFailures)
+	gapAdd("dns ringbuf reserve", in.DNSRingbufReserveFailures)
+	gapAdd("connect ringbuf reserve", in.ConnectRingbufReserveFailures)
+	gapAdd("http ringbuf reserve", in.HTTPRingbufReserveFailures)
+	gapAdd("tls ringbuf reserve", in.TLSRingbufReserveFailures)
+	gapAdd("exec ringbuf reserve", in.ExecRingbufReserveFailures)
+	gapAdd("fork ringbuf reserve", in.ForkRingbufReserveFailures)
+	gapAdd("fs ringbuf reserve", in.FSRingbufReserveFailures)
+	gapAdd("udp multi-iovec", in.UDPSendmsgMultiIovecObserved)
+	gapAdd("sendmmsg multi-message", in.SendmmsgMultiMessage)
+	gapAdd("tls writev multi-iovec", in.TLSWritevMultiIovecObserved)
+	gapAdd("sendfile partial-observe", in.SendfileObserved)
+	gapAdd("splice partial-observe", in.SpliceObserved)
+	gapAdd("sendmmsg first-message-only", in.SendmmsgFirstOnly)
+	gapAdd("tcp dns short read", in.TCPDNSSkippedShortRead)
+	gapAdd("bpf audit ringbuf reserve", in.BPFAuditRingbufReserveFailures)
 	if in.IoUringSetupObserved > 0 {
 		gapParts = append(gapParts, fmt.Sprintf("⚠️ io_uring_setup (syscall-hook bypass class)=%d", in.IoUringSetupObserved))
-	}
-	if in.BPFAuditRingbufReserveFailures > 0 {
-		gapParts = append(gapParts, fmt.Sprintf("bpf audit ringbuf reserve=%d", in.BPFAuditRingbufReserveFailures))
 	}
 	if !in.CanaryPipelineOK && in.CanaryFailCount > 0 {
 		gapParts = append(gapParts, fmt.Sprintf("🚨 telemetry canary FAILED (failures=%d)", in.CanaryFailCount))
 	}
 	if len(gapParts) > 0 {
-		b.WriteString(fmt.Sprintf("| **Capture gaps** | ⚠️ **Review** — %s |\n", sanitizeCell(strings.Join(gapParts, "; "))))
+		rows = append(rows, [2]string{"**Capture gaps**", fmt.Sprintf("⚠️ %s", sanitizeCell(strings.Join(gapParts, "; ")))})
 	}
 
 	if interp := truthfulnessInterpretation(in); interp != "" {
-		b.WriteString(fmt.Sprintf("| **Observability (partial / bypass-class)** | %s |\n", sanitizeCell(interp)))
+		rows = append(rows, [2]string{"**Observability (partial / bypass-class)**", sanitizeCell(interp)})
 	}
 
-	if rbTotal := totalDetectRingbufReserveFailures(in); rbTotal > 0 {
-		b.WriteString(fmt.Sprintf("| **Ringbuf reserve pressure (total)** | **%d** across detect-path channels (per-channel KPI rows below) |\n", rbTotal))
+	if rb := totalDetectRingbufReserveFailures(in); rb > 0 {
+		rows = append(rows, [2]string{"**Ringbuf reserve pressure (total)**", fmt.Sprintf("**%d** across detect-path channels", rb)})
 	}
 
+	return rows
+}
+
+func writeTriageTable(b *strings.Builder, in DigestInput) {
+	rows := buildTriageRows(in)
+	b.WriteString("### Triage\n\n")
+	b.WriteString("| Signal | Detail |\n|:--|:--|\n")
+	for _, r := range rows {
+		fmt.Fprintf(b, "| %s | %s |\n", r[0], r[1])
+	}
 	b.WriteString("\n")
 }
 
-func writeHotEgressTable(b *strings.Builder, in DigestInput) {
-	hot := buildHotEgressList(in)
-	if len(hot) == 0 {
-		return
+// writeFullKPITable emits the long-form per-channel KPI table that used to be
+// in the main body. Now sits inside Technical details.
+func writeFullKPITable(b *strings.Builder, in DigestInput) {
+	b.WriteString("#### Full KPI\n\n")
+	b.WriteString("| Signal | Count |\n|:--|--:|\n")
+	writeDetectProfileKPI(b, in)
+
+	// --- network ---
+	fmt.Fprintf(b, "| **tcp** | %d |\n", in.TCPTotal)
+	if in.Connect4TupleUpdateFailures > 0 {
+		fmt.Fprintf(b, "| **connect4 (tgid,fd)→tuple map update failures** | %d |\n", in.Connect4TupleUpdateFailures)
 	}
-	b.WriteString("### Hot egress destinations\n\n")
-	b.WriteString("Ranked by **event rows in this digest window** (not global uniqueness across the full JSONL). ")
-	b.WriteString("Prefer **Host** / **SNI** / **FQDN** columns when present.\n\n")
-	b.WriteString("| Rank | Entity | Rows | Channels |\n")
-	b.WriteString("|--:|:-|--:|:-|\n")
-	for i, e := range hot {
-		tags := hotKindTags(e.kinds)
-		if tags == "" {
-			tags = "—"
+	if in.ConnectRingbufReserveFailures > 0 {
+		fmt.Fprintf(b, "| **connect_events ringbuf reserve failures** | %d |\n", in.ConnectRingbufReserveFailures)
+	}
+	if in.DNSRingbufReserveFailures > 0 {
+		fmt.Fprintf(b, "| **dns_events ringbuf reserve failures** | %d |\n", in.DNSRingbufReserveFailures)
+	}
+	if in.TCPDNSResponsesObserved > 0 {
+		fmt.Fprintf(b, "| **TCP DNS responses observed** | %d |\n", in.TCPDNSResponsesObserved)
+	}
+	if in.TCPDNSSkippedShortRead > 0 {
+		fmt.Fprintf(b, "| **TCP DNS short reads (<6 B)** | %d |\n", in.TCPDNSSkippedShortRead)
+	}
+
+	fmt.Fprintf(b, "| **udp** | %d |\n", in.UDPTotal)
+	if in.UDPRingbufReserveFailures > 0 {
+		fmt.Fprintf(b, "| **udp_events ringbuf reserve failures** | %d |\n", in.UDPRingbufReserveFailures)
+	}
+	if in.UDPSendmsgMultiIovecObserved > 0 {
+		fmt.Fprintf(b, "| **udp_sendmsg multi-iovec calls (iov[1..n] not captured)** | %d |\n", in.UDPSendmsgMultiIovecObserved)
+	}
+	if in.SendmmsgMultiMessage > 0 {
+		fmt.Fprintf(b, "| **sendmmsg multi-message calls (msg[1..n] not introspected)** | %d |\n", in.SendmmsgMultiMessage)
+	}
+
+	fmt.Fprintf(b, "| **http** | %d |\n", in.HTTPTotal)
+	if in.HTTPRingbufReserveFailures > 0 {
+		fmt.Fprintf(b, "| **http_events ringbuf reserve failures** | %d |\n", in.HTTPRingbufReserveFailures)
+	}
+
+	if tlsKPIVisible(in) {
+		fmt.Fprintf(b, "| **tls** | %d |\n", in.TLSTotal)
+		if in.TLSRingbufReserveFailures > 0 {
+			fmt.Fprintf(b, "| **tls_events ringbuf reserve failures** | %d |\n", in.TLSRingbufReserveFailures)
 		}
-		b.WriteString(fmt.Sprintf("| %d | %s | %d | %s |\n",
-			i+1, sanitizeCell(e.key), e.count, sanitizeCell(tags)))
+		if in.TLSWritevMultiIovecObserved > 0 {
+			fmt.Fprintf(b, "| **tls writev multi-iovec calls (iov[1..n] not captured)** | %d |\n", in.TLSWritevMultiIovecObserved)
+		}
+	}
+
+	if in.SendfileObserved > 0 {
+		fmt.Fprintf(b, "| **sendfile partial-observe (dest+len, no payload sniff)** | %d |\n", in.SendfileObserved)
+	}
+	if in.SpliceObserved > 0 {
+		fmt.Fprintf(b, "| **splice partial-observe (dest+len, no payload sniff)** | %d |\n", in.SpliceObserved)
+	}
+	if in.SendmmsgFirstOnly > 0 {
+		fmt.Fprintf(b, "| **sendmmsg first-message-only (msgs 2..N not introspected)** | %d |\n", in.SendmmsgFirstOnly)
+	}
+	if in.IoUringSetupObserved > 0 {
+		fmt.Fprintf(b, "| **⚠️ io_uring_setup (syscall-hook bypass class)** | %d |\n", in.IoUringSetupObserved)
+	}
+
+	// --- processes ---
+	fmt.Fprintf(b, "| **exec** | %d |\n", in.ExecTotal)
+	if in.ExecRingbufReserveFailures > 0 {
+		fmt.Fprintf(b, "| **exec_events ringbuf reserve failures** | %d |\n", in.ExecRingbufReserveFailures)
+	}
+	if procForkKPIVisible(in) {
+		fmt.Fprintf(b, "| **proc_fork** | %d |\n", in.ProcForkTotal)
+		if in.ForkRingbufReserveFailures > 0 {
+			fmt.Fprintf(b, "| **proc_fork_events ringbuf reserve failures** | %d |\n", in.ForkRingbufReserveFailures)
+		}
+	}
+	if in.BPFAuditTotal > 0 {
+		fmt.Fprintf(b, "| **bpf_audit** | %d |\n", in.BPFAuditTotal)
+	}
+	if in.BPFAuditRingbufReserveFailures > 0 {
+		fmt.Fprintf(b, "| **bpf_audit_events ringbuf reserve failures** | %d |\n", in.BPFAuditRingbufReserveFailures)
+	}
+
+	// --- filesystem ---
+	if fsKPIVisible(in) {
+		fmt.Fprintf(b, "| **fs_event** | %d |\n", in.FSTotal)
+		if in.FSRingbufReserveFailures > 0 {
+			fmt.Fprintf(b, "| **fs_events ringbuf reserve failures** | %d |\n", in.FSRingbufReserveFailures)
+		}
+	}
+
+	if dt := droppedTotal(in); dt > 0 {
+		fmt.Fprintf(b, "| **dropped events (decode/jsonl)** | %d |\n", dt)
+	}
+
+	// --- health (last) ---
+	if in.BPFMapIntegrityFailures > 0 {
+		fmt.Fprintf(b, "| **bpf_map_integrity_failures** | **%d** |\n", in.BPFMapIntegrityFailures)
+	}
+	if in.CanaryFailCount > 0 {
+		status := "✅ OK"
+		if !in.CanaryPipelineOK {
+			status = "🚨 FAILED"
+		}
+		fmt.Fprintf(b, "| **Telemetry integrity canary** | %s (failures=%d) |\n", status, in.CanaryFailCount)
+	} else {
+		b.WriteString("| **Telemetry integrity canary** | ✅ OK |\n")
+	}
+	if in.BPFHeartbeatFailures > 0 {
+		fmt.Fprintf(b, "| **🚨 BPF Self-protection Heartbeat Failures** | %d |\n", in.BPFHeartbeatFailures)
+	} else {
+		b.WriteString("| **BPF Self-protection Heartbeat** | ✅ OK |\n")
 	}
 	b.WriteString("\n")
 }
@@ -238,130 +340,7 @@ func writeDetectProfileKPI(b *strings.Builder, in DigestInput) {
 	b.WriteString("| **detect profile** | standard |\n")
 }
 
-// writeKPITable emits the KPI rows ordered network → process → fs → health.
-// Ringbuf reserve / multi-iovec / partial-egress counters sit directly under
-// the metric they relate to instead of being scattered across the table.
-func writeKPITable(b *strings.Builder, in DigestInput) {
-	b.WriteString("### KPI\n\n")
-	b.WriteString("| Signal | Count |\n|:--|--:|\n")
-	writeDetectProfileKPI(b, in)
-
-	// --- network ---
-	b.WriteString(fmt.Sprintf("| **tcp** | %d |\n", in.TCPTotal))
-	if in.Connect4TupleUpdateFailures > 0 {
-		b.WriteString(fmt.Sprintf("| **connect4 (tgid,fd)→tuple map update failures** | %d |\n", in.Connect4TupleUpdateFailures))
-	}
-	if in.ConnectRingbufReserveFailures > 0 {
-		b.WriteString(fmt.Sprintf("| **connect_events ringbuf reserve failures** | %d |\n", in.ConnectRingbufReserveFailures))
-	}
-	if in.DNSRingbufReserveFailures > 0 {
-		b.WriteString(fmt.Sprintf("| **dns_events ringbuf reserve failures** | %d |\n", in.DNSRingbufReserveFailures))
-	}
-	if in.TCPDNSResponsesObserved > 0 {
-		b.WriteString(fmt.Sprintf("| **TCP DNS responses observed** | %d |\n", in.TCPDNSResponsesObserved))
-	}
-	if in.TCPDNSSkippedShortRead > 0 {
-		b.WriteString(fmt.Sprintf("| **TCP DNS short reads (<6 B)** | %d |\n", in.TCPDNSSkippedShortRead))
-	}
-
-	b.WriteString(fmt.Sprintf("| **udp** | %d |\n", in.UDPTotal))
-	if in.UDPRingbufReserveFailures > 0 {
-		b.WriteString(fmt.Sprintf("| **udp_events ringbuf reserve failures** | %d |\n", in.UDPRingbufReserveFailures))
-	}
-	if in.UDPSendmsgMultiIovecObserved > 0 {
-		b.WriteString(fmt.Sprintf("| **udp_sendmsg multi-iovec calls (iov[1..n] not captured)** | %d |\n", in.UDPSendmsgMultiIovecObserved))
-	}
-	if in.SendmmsgMultiMessage > 0 {
-		b.WriteString(fmt.Sprintf("| **sendmmsg multi-message calls (msg[1..n] not introspected)** | %d |\n", in.SendmmsgMultiMessage))
-	}
-
-	b.WriteString(fmt.Sprintf("| **http** | %d |\n", in.HTTPTotal))
-	if in.HTTPRingbufReserveFailures > 0 {
-		b.WriteString(fmt.Sprintf("| **http_events ringbuf reserve failures** | %d |\n", in.HTTPRingbufReserveFailures))
-	}
-
-	if tlsKPIVisible(in) {
-		b.WriteString(fmt.Sprintf("| **tls** | %d |\n", in.TLSTotal))
-		if in.TLSRingbufReserveFailures > 0 {
-			b.WriteString(fmt.Sprintf("| **tls_events ringbuf reserve failures** | %d |\n", in.TLSRingbufReserveFailures))
-		}
-		if in.TLSWritevMultiIovecObserved > 0 {
-			b.WriteString(fmt.Sprintf("| **tls writev multi-iovec calls (iov[1..n] not captured)** | %d |\n", in.TLSWritevMultiIovecObserved))
-		}
-	}
-
-	// BG-01 per-syscall partial-observe.
-	if in.SendfileObserved > 0 {
-		b.WriteString(fmt.Sprintf("| **sendfile partial-observe (dest+len, no payload sniff)** | %d |\n", in.SendfileObserved))
-	}
-	if in.SpliceObserved > 0 {
-		b.WriteString(fmt.Sprintf("| **splice partial-observe (dest+len, no payload sniff)** | %d |\n", in.SpliceObserved))
-	}
-	if in.SendmmsgFirstOnly > 0 {
-		b.WriteString(fmt.Sprintf("| **sendmmsg first-message-only (msgs 2..N not introspected)** | %d |\n", in.SendmmsgFirstOnly))
-	}
-	if in.IoUringSetupObserved > 0 {
-		b.WriteString(fmt.Sprintf("| **⚠️ io_uring_setup (syscall-hook bypass class)** | %d |\n", in.IoUringSetupObserved))
-	}
-
-	// --- processes ---
-	b.WriteString(fmt.Sprintf("| **exec** | %d |\n", in.ExecTotal))
-	if in.ExecRingbufReserveFailures > 0 {
-		b.WriteString(fmt.Sprintf("| **exec_events ringbuf reserve failures** | %d |\n", in.ExecRingbufReserveFailures))
-	}
-	if procForkKPIVisible(in) {
-		b.WriteString(fmt.Sprintf("| **proc_fork** | %d |\n", in.ProcForkTotal))
-		if in.ForkRingbufReserveFailures > 0 {
-			b.WriteString(fmt.Sprintf("| **proc_fork_events ringbuf reserve failures** | %d |\n", in.ForkRingbufReserveFailures))
-		}
-	}
-	if in.BPFAuditTotal > 0 {
-		b.WriteString(fmt.Sprintf("| **bpf_audit** | %d |\n", in.BPFAuditTotal))
-	}
-	if in.BPFAuditRingbufReserveFailures > 0 {
-		b.WriteString(fmt.Sprintf("| **bpf_audit_events ringbuf reserve failures** | %d |\n", in.BPFAuditRingbufReserveFailures))
-	}
-
-	// --- filesystem ---
-	if fsKPIVisible(in) {
-		b.WriteString(fmt.Sprintf("| **fs_event** | %d |\n", in.FSTotal))
-		if in.FSRingbufReserveFailures > 0 {
-			b.WriteString(fmt.Sprintf("| **fs_events ringbuf reserve failures** | %d |\n", in.FSRingbufReserveFailures))
-		}
-	}
-
-	// --- decode/jsonl drops near the dropped-counter rollup ---
-	droppedTotal := 0
-	for _, v := range in.DroppedCounts {
-		droppedTotal += v
-	}
-	if droppedTotal > 0 {
-		b.WriteString(fmt.Sprintf("| **dropped events (decode/jsonl)** | %d |\n", droppedTotal))
-	}
-
-	// --- health (last) ---
-	if in.BPFMapIntegrityFailures > 0 {
-		b.WriteString(fmt.Sprintf("| **bpf_map_integrity_failures** | <font color=\"red\">%d</font> |\n", in.BPFMapIntegrityFailures))
-	}
-	if in.CanaryFailCount > 0 {
-		status := "✅ OK"
-		if !in.CanaryPipelineOK {
-			status = "🚨 FAILED"
-		}
-		b.WriteString(fmt.Sprintf("| **Telemetry integrity canary** | %s (failures=%d) |\n", status, in.CanaryFailCount))
-	} else {
-		b.WriteString("| **Telemetry integrity canary** | ✅ OK |\n")
-	}
-	if in.BPFHeartbeatFailures > 0 {
-		b.WriteString(fmt.Sprintf("| **🚨 BPF Self-protection Heartbeat Failures** | %d |\n", in.BPFHeartbeatFailures))
-	} else {
-		b.WriteString("| **BPF Self-protection Heartbeat** | ✅ OK |\n")
-	}
-	b.WriteString("\n")
-}
-
 // writeRollups emits the policy-classification and dropped-event rollup lines.
-// Kept separate from writeKPITable so KPI stays one Markdown table.
 func writeRollups(b *strings.Builder, in DigestInput) {
 	if len(in.PolicyCounts) > 0 {
 		rollupLabel := "TCP / UDP / HTTP classification"
@@ -391,11 +370,7 @@ func writeRollups(b *strings.Builder, in DigestInput) {
 		b.WriteString("\n\n")
 	}
 
-	droppedTotal := 0
-	for _, v := range in.DroppedCounts {
-		droppedTotal += v
-	}
-	if droppedTotal > 0 {
+	if dt := droppedTotal(in); dt > 0 {
 		b.WriteString("**Dropped event counters**: ")
 		type kv struct {
 			k string
@@ -423,29 +398,242 @@ func writeRollups(b *strings.Builder, in DigestInput) {
 	}
 }
 
-// writeRunInfo emits a compact 2-row table with the JSONL canonical-log path and
-// the userspace event-sequence range. Sits above the Technical details fold.
+// writeDefendDetails emits the defend section (allowlist size, deny count,
+// first deny row) inside Technical details when defend was active.
+func writeDefendDetails(b *strings.Builder, in DigestInput) {
+	if in.DefendMode == "" && in.DefendAllowlistSize == 0 && in.DefendDenyCount == 0 &&
+		in.DefendDenyReserveFailures == 0 && in.DefendFirstDeny == nil {
+		return
+	}
+	b.WriteString("#### Defend\n\n")
+	b.WriteString("| Field | Value |\n|:--|:--|\n")
+	mode := digestModeCell(in.DefendMode)
+	fmt.Fprintf(b, "| Mode | `%s` |\n", sanitizeCell(mode))
+	fmt.Fprintf(b, "| Allowlist size | %d |\n", in.DefendAllowlistSize)
+	fmt.Fprintf(b, "| Deny count | %d |\n", in.DefendDenyCount)
+	if in.DefendDenyReserveFailures > 0 {
+		fmt.Fprintf(b, "| Deny ringbuf reserve failures (blocked, no JSONL) | %d |\n", in.DefendDenyReserveFailures)
+	}
+	b.WriteString("\n")
+
+	if in.DefendFirstDeny != nil {
+		row := in.DefendFirstDeny
+		b.WriteString("**First deny**\n\n")
+		b.WriteString("| Time (UTC) | PID | Comm | Protocol | Remote | Reason |\n|:--|--:|:-|:-|:-|:-|\n")
+		fmt.Fprintf(b, "| %s | `%d` | `%s` | `%s` | `%s:%d` | `%s` |\n\n",
+			sanitizeCell(row.TS),
+			row.PID,
+			sanitizeCell(row.Comm),
+			sanitizeCell(row.Protocol),
+			sanitizeCell(row.Dst),
+			row.Dport,
+			sanitizeCell(row.Reason),
+		)
+	}
+}
+
 func writeRunInfo(b *strings.Builder, in DigestInput) {
 	if in.JSONLPath == "" && (in.SeqFirst == 0 || in.SeqLast < in.SeqFirst) {
 		return
 	}
-	b.WriteString("### Run info\n\n")
+	b.WriteString("#### Run info\n\n")
 	b.WriteString("| Field | Value |\n|:--|:--|\n")
 	if in.JSONLPath != "" {
-		b.WriteString(fmt.Sprintf("| **Canonical log (JSONL)** | `%s` |\n", sanitizeCell(in.JSONLPath)))
+		fmt.Fprintf(b, "| **Canonical log (JSONL)** | `%s` |\n", sanitizeCell(in.JSONLPath))
 	}
 	if in.SeqFirst > 0 && in.SeqLast >= in.SeqFirst {
-		b.WriteString(fmt.Sprintf("| **Event sequence range (userspace)** | %d–%d |\n", in.SeqFirst, in.SeqLast))
+		fmt.Fprintf(b, "| **Event sequence range (userspace)** | %d–%d |\n", in.SeqFirst, in.SeqLast)
 	}
 	b.WriteString("\n")
 }
 
-// writeTechnicalDetails folds the long-form KPI semantics, truncation note,
-// per-protocol caveats, and the BPF hook status table into a single `<details>`
-// block at the bottom of the digest.
-func writeTechnicalDetails(b *strings.Builder, in DigestInput, max int) {
-	b.WriteString("<details>\n<summary>Technical details — KPI semantics and capture notes</summary>\n\n")
+// writeEventTables emits per-protocol row tables inside Technical details.
+// Each protocol gets its own nested <details> so operators can drill in without
+// scrolling past every event type when only one is interesting.
+func writeEventTables(b *strings.Builder, in DigestInput, max int) {
+	writeExecSection(b, in)
+	writeBPFAuditSection(b, in)
+	writeProcessTreeSection(b, in)
+	writeTCPSection(b, in)
+	writeUDPSection(b, in)
+	writeHTTPSection(b, in)
+	writeTLSSection(b, in)
+	writeFSSection(b, in, max)
+}
 
+func writeExecSection(b *strings.Builder, in DigestInput) {
+	b.WriteString("<details>\n<summary><strong>Exec (recent)</strong></summary>\n\n")
+	b.WriteString("| Time (UTC) | PID (TGID) | TID | Comm | Executable (BPF-capped) |\n|:--|--:|--:|:-|:-|\n")
+	for _, r := range in.ExecRows {
+		fmt.Fprintf(b, "| %s | `%d` | `%d` | `%s` | `%s` |\n",
+			sanitizeCell(r.TS), r.PID, r.ThreadID, sanitizeCell(r.Comm), sanitizeCell(r.Exe))
+	}
+	b.WriteString("\n</details>\n\n")
+}
+
+func writeProcessTreeSection(b *strings.Builder, in DigestInput) {
+	if !procForkKPIVisible(in) {
+		return
+	}
+	b.WriteString("<details>\n<summary><strong>Process tree (recent)</strong></summary>\n\n")
+	b.WriteString("| Outline |\n|:-|\n")
+	if len(in.ProcessTreeLines) == 0 {
+		fmt.Fprintf(b, "| %s |\n", sanitizeCell(protocolEmptyReason(in.ProcForkDegraded, in.ProcForkReaderErrors)))
+	} else {
+		for _, line := range in.ProcessTreeLines {
+			fmt.Fprintf(b, "| %s |\n", sanitizeCell(line))
+		}
+	}
+	b.WriteString("\n</details>\n\n")
+}
+
+func writeTCPSection(b *strings.Builder, in DigestInput) {
+	b.WriteString("<details>\n<summary><strong>TCP connect attempts (recent)</strong></summary>\n\n")
+	b.WriteString("| Time (UTC) | PID | Comm | Remote | Notes | Policy |\n|:--|--:|:-|:-|:-|:-|\n")
+	if len(in.TCPRows) == 0 {
+		fmt.Fprintf(b, "| — | — | — | — | — | %s |\n", sanitizeCell(protocolEmptyReason(in.TCPDegradedHook, in.TCPReaderErrors)))
+	} else {
+		for _, r := range in.TCPRows {
+			fmt.Fprintf(b, "| %s | `%d` | `%s` | %s | %s | %s |\n",
+				sanitizeCell(r.TS), r.PID, sanitizeCell(r.Comm),
+				sanitizeCell(r.Remote), sanitizeCell(r.Notes), sanitizeCell(r.Policy))
+		}
+	}
+	b.WriteString("\n</details>\n\n")
+}
+
+func writeUDPSection(b *strings.Builder, in DigestInput) {
+	b.WriteString("<details>\n<summary><strong>UDP sendto (recent)</strong></summary>\n\n")
+	b.WriteString("| Time (UTC) | PID | Comm | Remote | Len | FQDN | Policy |\n|:--|--:|:-|:-|--:|:-|:-|\n")
+	if len(in.UDPRows) == 0 {
+		fmt.Fprintf(b, "| — | — | — | — | — | — | %s |\n", sanitizeCell(protocolEmptyReason(in.UDPDegradedHook, in.UDPReaderErrors)))
+	} else {
+		for _, r := range in.UDPRows {
+			fq := r.FQDN
+			if fq == "" {
+				fq = "—"
+			}
+			fmt.Fprintf(b, "| %s | `%d` | `%s` | %s | %d | %s | %s |\n",
+				sanitizeCell(r.TS), r.PID, sanitizeCell(r.Comm),
+				sanitizeCell(r.Remote), r.DgramLen, sanitizeCell(fq), sanitizeCell(r.Policy))
+		}
+	}
+	b.WriteString("\n</details>\n\n")
+}
+
+func writeHTTPSection(b *strings.Builder, in DigestInput) {
+	b.WriteString("<details>\n<summary><strong>HTTP/1 cleartext (recent)</strong></summary>\n\n")
+	b.WriteString("| Time (UTC) | PID | Comm | Method | Host | Path (summary) | Remote | Policy |\n|:--|--:|:-|:-|:-|:-|:-|:-|\n")
+	if len(in.HTTPRows) == 0 {
+		fmt.Fprintf(b, "| — | — | — | — | — | — | — | %s |\n", sanitizeCell(protocolEmptyReason(in.HTTPDegradedHook, in.HTTPReaderErrors)))
+	} else {
+		for _, r := range in.HTTPRows {
+			fmt.Fprintf(b, "| %s | `%d` | `%s` | `%s` | `%s` | `%s` | %s | %s |\n",
+				sanitizeCell(r.TS), r.PID, sanitizeCell(r.Comm),
+				sanitizeCell(r.Method), sanitizeCell(r.Host), sanitizeCell(r.Path),
+				sanitizeCell(r.Remote), sanitizeCell(r.Policy))
+		}
+	}
+	b.WriteString("\n</details>\n\n")
+}
+
+func writeTLSSection(b *strings.Builder, in DigestInput) {
+	if !tlsKPIVisible(in) {
+		return
+	}
+	b.WriteString("<details>\n<summary><strong>TLS ClientHello / SNI (recent)</strong></summary>\n\n")
+	b.WriteString("| Time (UTC) | PID | Comm | SNI | Remote | Policy |\n|:--|--:|:-|:-|:-|:-|\n")
+	if len(in.TLSRows) == 0 {
+		fmt.Fprintf(b, "| — | — | — | — | — | %s |\n", sanitizeCell(protocolEmptyReason(in.TLSDegradedHook, in.TLSReaderErrors)))
+	} else {
+		for _, r := range in.TLSRows {
+			fmt.Fprintf(b, "| %s | `%d` | `%s` | `%s` | %s | %s |\n",
+				sanitizeCell(r.TS), r.PID, sanitizeCell(r.Comm),
+				sanitizeCell(r.SNI), sanitizeCell(r.Remote), sanitizeCell(r.Policy))
+		}
+	}
+	b.WriteString("\n</details>\n\n")
+}
+
+func writeFSSection(b *strings.Builder, in DigestInput, _ int) {
+	if !in.FSGate {
+		return
+	}
+	b.WriteString("<details>\n<summary><strong>Filesystem (recent)</strong></summary>\n\n")
+	b.WriteString("| Time | PID | Comm | Op | Path |\n|:--|--:|:--|:--|:--|\n")
+	if len(in.FSRows) == 0 {
+		reason := "no events"
+		if in.FSDegradedHook {
+			reason = "degraded hook"
+		} else if in.FSReaderErrors > 0 {
+			reason = fmt.Sprintf("reader errors (%d)", in.FSReaderErrors)
+		}
+		fmt.Fprintf(b, "| — | — | — | — | %s |\n", reason)
+	} else {
+		for _, r := range in.FSRows {
+			fmt.Fprintf(b, "| `%s` | %d | `%s` | `%s` | `%s` |\n",
+				sanitizeCell(r.TS), r.PID, sanitizeCell(r.Comm), sanitizeCell(r.Op), sanitizeCell(r.Path))
+		}
+		if in.TruncatedFS {
+			fmt.Fprintf(b, "\n*Showing last %d of %d — full stream in JSONL.*\n",
+				len(in.FSRows), in.FSTotal)
+		}
+	}
+	b.WriteString("\n</details>\n\n")
+}
+
+func writeBPFAuditSection(b *strings.Builder, in DigestInput) {
+	if in.BPFAuditTotal == 0 && !in.BPFAuditDegradedHook && in.BPFAuditReaderErrors == 0 {
+		return
+	}
+	b.WriteString("<details>\n<summary><strong>BPF audit (recent)</strong></summary>\n\n")
+	b.WriteString("| Time (UTC) | PID | Comm | Command |\n|:--|--:|:-|:-|\n")
+	if len(in.BPFAuditRows) == 0 {
+		reason := "no events"
+		if in.BPFAuditDegradedHook {
+			reason = "degraded hook"
+		} else if in.BPFAuditReaderErrors > 0 {
+			reason = fmt.Sprintf("reader errors (%d)", in.BPFAuditReaderErrors)
+		}
+		fmt.Fprintf(b, "| — | — | — | %s |\n", reason)
+	} else {
+		for _, r := range in.BPFAuditRows {
+			fmt.Fprintf(b, "| %s | `%d` | `%s` | `%s` (%d) |\n",
+				sanitizeCell(r.TS), r.PID, sanitizeCell(r.Comm), sanitizeCell(BPFCmdName(r.Cmd)), r.Cmd)
+		}
+		if in.TruncatedBPFAudit {
+			fmt.Fprintf(b, "\n*Showing last %d of %d — full stream in JSONL.*\n",
+				len(in.BPFAuditRows), in.BPFAuditTotal)
+		}
+	}
+	b.WriteString("\n</details>\n\n")
+}
+
+// writeBPFHookStatusTable lists every BPF probe and its load status.
+func writeBPFHookStatusTable(b *strings.Builder, in DigestInput) {
+	if len(in.BPF) == 0 {
+		return
+	}
+	b.WriteString("#### BPF hook status\n\n")
+	b.WriteString("| BPF hook | Status |\n|:--|:--|\n")
+	for _, row := range in.BPF {
+		st := "ok"
+		if !row.OK {
+			st = "skipped/degraded"
+		}
+		detail := ""
+		if row.Detail != "" {
+			detail = " — " + sanitizeCell(row.Detail)
+		}
+		fmt.Fprintf(b, "| `%s` | %s%s |\n", sanitizeCell(row.Name), st, detail)
+	}
+	b.WriteString("\n")
+}
+
+// writeKPISemantics emits the long-form KPI prose (truncation note, TCP/TLS
+// caveats, etc.) as a bulleted list.
+func writeKPISemantics(b *strings.Builder, in DigestInput, max int) {
+	b.WriteString("#### Notes\n\n")
 	b.WriteString("- **UDP KPI** counts IPv4 `sendto` and `sendmsg` egress (first iovec length; destination from `msg_name` or connected-socket cache).\n")
 	b.WriteString("- **HTTP KPI** counts cleartext HTTP/1 request bytes on `sendto` to destination port 80 only; HTTPS traffic appears as TCP connect events.\n")
 	if tlsKPIVisible(in) {
@@ -523,10 +711,10 @@ func writeTechnicalDetails(b *strings.Builder, in DigestInput, max int) {
 		trunc = append(trunc, "fs_event")
 	}
 	if len(trunc) > 0 {
-		b.WriteString(fmt.Sprintf("- **Truncated sections:** %s — showing up to **%d** newest rows per section; totals in KPI are full counts.\n",
-			strings.Join(trunc, ", "), max))
+		fmt.Fprintf(b, "- **Truncated sections:** %s — showing up to **%d** newest rows per section; totals in KPI are full counts.\n",
+			strings.Join(trunc, ", "), max)
 	} else {
-		b.WriteString(fmt.Sprintf("- **Row cap:** up to **%d** rows per section when activity exceeds the cap.\n", max))
+		fmt.Fprintf(b, "- **Row cap:** up to **%d** rows per section when activity exceeds the cap.\n", max)
 	}
 	b.WriteString("- **TCP semantics:** rows reflect `connect(2)` attempts at syscall enter, not confirmed established sockets.\n")
 	if tlsKPIVisible(in) {
@@ -537,28 +725,33 @@ func writeTechnicalDetails(b *strings.Builder, in DigestInput, max int) {
 	if procForkKPIVisible(in) {
 		b.WriteString("- **Process tree:** parent/child IDs come from `sched_process_fork`; correlation with TGID/exec is best-effort on shared runners.\n")
 	}
-
-	// BPF hook status table — moved out of the main body, Fix 5.
-	if len(in.BPF) > 0 {
-		b.WriteString("\n**BPF hook status**\n\n")
-		b.WriteString("| BPF hook | Status |\n|:--|:--|\n")
-		for _, row := range in.BPF {
-			st := "ok"
-			if !row.OK {
-				st = "skipped/degraded"
-			}
-			detail := ""
-			if row.Detail != "" {
-				detail = " — " + sanitizeCell(row.Detail)
-			}
-			b.WriteString(fmt.Sprintf("| `%s` | %s%s |\n", sanitizeCell(row.Name), st, detail))
-		}
-	}
-
-	b.WriteString("\n</details>\n\n")
+	b.WriteString("\n")
 }
 
-// BuildDetectMarkdown returns GFM + limited HTML for `.coldstep-detect.md`.
+func writeTechnicalDetails(b *strings.Builder, in DigestInput, max int) {
+	b.WriteString("<details>\n<summary>Technical details — full KPI, event rows, BPF status, notes</summary>\n\n")
+	writeFullKPITable(b, in)
+	writeRollups(b, in)
+	writeDefendDetails(b, in)
+	writeRunInfo(b, in)
+	writeEventTables(b, in, max)
+	writeBPFHookStatusTable(b, in)
+	writeKPISemantics(b, in, max)
+	b.WriteString("</details>\n\n")
+}
+
+func writeFooter(b *strings.Builder, in DigestInput) {
+	path := in.JSONLPath
+	if path == "" {
+		path = ".coldstep-events.jsonl"
+	}
+	fmt.Fprintf(b, "> Full event log: `%s`\n", sanitizeCell(path))
+}
+
+// BuildDetectMarkdown returns GFM + the GFM HTML subset (<details>, <summary>,
+// <br>, <hr>, <table>) for `.coldstep-detect.md` / GITHUB_STEP_SUMMARY. The
+// visible portion (above the Technical details fold) is intentionally compact:
+// header, one-row KPI, optional Top destinations, Triage, footer.
 func BuildDetectMarkdown(in DigestInput) string {
 	max := in.MaxRowsPerSection
 	if max <= 0 {
@@ -566,202 +759,12 @@ func BuildDetectMarkdown(in DigestInput) string {
 	}
 
 	var b strings.Builder
-	if isBlockingDigestMode(in.DefendMode) {
-		b.WriteString("## Coldstep · defend\n\n")
-		b.WriteString("<p align=\"center\"><strong>eBPF runtime audit trail</strong><br/>\n")
-		b.WriteString("<sub>Defend mode: cgroup-scoped IPv4 egress is allowlisted on GitHub-hosted ephemeral Linux runners (not a substitute for self-hosted hardening); denied connects and UDP sends are blocked and appear as <code>deny</code> JSONL. Cleartext HTTP/80 is still observed via syscall hooks where enabled. <code>comm</code> is the kernel task name (16 bytes), not argv. Executable path comes from the tracepoint (BPF-capped).</sub></p>\n\n")
-	} else {
-		b.WriteString("## Coldstep · detect\n\n")
-		b.WriteString("<p align=\"center\"><strong>eBPF runtime audit trail</strong><br/>\n")
-		b.WriteString("<sub>Detect-only: observe, do not block. <code>comm</code> is the kernel task name (16 bytes), not argv. Executable path comes from the tracepoint (BPF-capped).</sub></p>\n\n")
-	}
-	writeHeadlineBadge(&b, in)
-	writeHotEgressTable(&b, in)
-	writeTriageRibbon(&b, in)
-	writeKPITable(&b, in)
-	writeRollups(&b, in)
-	// Marker: end of new writer chain; the legacy inline KPI / sub blob / standalone
-	// BPF hook table that used to live here is removed below this point.
-	if in.DefendMode != "" || in.DefendAllowlistSize > 0 || in.DefendDenyCount > 0 || in.DefendDenyReserveFailures > 0 || in.DefendFirstDeny != nil {
-		b.WriteString("### Defend\n\n")
-		b.WriteString("| Field | Value |\n|:--|:--|\n")
-		mode := digestModeCell(in.DefendMode)
-		b.WriteString(fmt.Sprintf("| Mode | `%s` |\n", sanitizeCell(mode)))
-		b.WriteString(fmt.Sprintf("| Allowlist size | %d |\n", in.DefendAllowlistSize))
-		b.WriteString(fmt.Sprintf("| Deny count | %d |\n", in.DefendDenyCount))
-		if in.DefendDenyReserveFailures > 0 {
-			b.WriteString(fmt.Sprintf("| Deny ringbuf reserve failures (blocked, no JSONL) | %d |\n", in.DefendDenyReserveFailures))
-		}
-		b.WriteString("\n")
-
-		if in.DefendFirstDeny != nil {
-			row := in.DefendFirstDeny
-			b.WriteString("**First deny**\n\n")
-			b.WriteString("| Time (UTC) | PID | Comm | Protocol | Remote | Reason |\n|:--|--:|:-|:-|:-|:-|\n")
-			b.WriteString(fmt.Sprintf("| %s | `%d` | `%s` | `%s` | `%s:%d` | `%s` |\n\n",
-				sanitizeCell(row.TS),
-				row.PID,
-				sanitizeCell(row.Comm),
-				sanitizeCell(row.Protocol),
-				sanitizeCell(row.Dst),
-				row.Dport,
-				sanitizeCell(row.Reason),
-			))
-		}
-	}
-
-	writeExec := func() {
-		b.WriteString("<details>\n<summary><strong>Exec (recent)</strong></summary>\n\n")
-		b.WriteString("| Time (UTC) | PID (TGID) | TID | Comm | Executable (BPF-capped) |\n|:--|--:|--:|:-|:-|\n")
-		for _, r := range in.ExecRows {
-			b.WriteString(fmt.Sprintf("| %s | `%d` | `%d` | `%s` | `%s` |\n",
-				sanitizeCell(r.TS), r.PID, r.ThreadID, sanitizeCell(r.Comm), sanitizeCell(r.Exe)))
-		}
-		b.WriteString("\n</details>\n\n")
-	}
-	writeProcessTree := func() {
-		if !procForkKPIVisible(in) {
-			return
-		}
-		b.WriteString("<details>\n<summary><strong>Process tree (recent)</strong></summary>\n\n")
-		b.WriteString("| Outline |\n|:-|\n")
-		if len(in.ProcessTreeLines) == 0 {
-			b.WriteString(fmt.Sprintf("| %s |\n", sanitizeCell(protocolEmptyReason(in.ProcForkDegraded, in.ProcForkReaderErrors))))
-		} else {
-			for _, line := range in.ProcessTreeLines {
-				b.WriteString(fmt.Sprintf("| %s |\n", sanitizeCell(line)))
-			}
-		}
-		b.WriteString("\n</details>\n\n")
-	}
-	writeTCP := func() {
-		b.WriteString("<details>\n<summary><strong>TCP connect attempts (recent)</strong></summary>\n\n")
-		b.WriteString("| Time (UTC) | PID | Comm | Remote | Notes | Policy |\n|:--|--:|:-|:-|:-|:-|\n")
-		if len(in.TCPRows) == 0 {
-			b.WriteString(fmt.Sprintf("| — | — | — | — | — | %s |\n", sanitizeCell(protocolEmptyReason(in.TCPDegradedHook, in.TCPReaderErrors))))
-		} else {
-			for _, r := range in.TCPRows {
-				b.WriteString(fmt.Sprintf("| %s | `%d` | `%s` | %s | %s | %s |\n",
-					sanitizeCell(r.TS), r.PID, sanitizeCell(r.Comm),
-					sanitizeCell(r.Remote), sanitizeCell(r.Notes), sanitizeCell(r.Policy)))
-			}
-		}
-		b.WriteString("\n</details>\n\n")
-	}
-	writeUDP := func() {
-		b.WriteString("<details>\n<summary><strong>UDP sendto (recent)</strong></summary>\n\n")
-		b.WriteString("| Time (UTC) | PID | Comm | Remote | Len | FQDN | Policy |\n|:--|--:|:-|:-|--:|:-|:-|\n")
-		if len(in.UDPRows) == 0 {
-			b.WriteString(fmt.Sprintf("| — | — | — | — | — | — | %s |\n", sanitizeCell(protocolEmptyReason(in.UDPDegradedHook, in.UDPReaderErrors))))
-		} else {
-			for _, r := range in.UDPRows {
-				fq := r.FQDN
-				if fq == "" {
-					fq = "—"
-				}
-				b.WriteString(fmt.Sprintf("| %s | `%d` | `%s` | %s | %d | %s | %s |\n",
-					sanitizeCell(r.TS), r.PID, sanitizeCell(r.Comm),
-					sanitizeCell(r.Remote), r.DgramLen, sanitizeCell(fq), sanitizeCell(r.Policy)))
-			}
-		}
-		b.WriteString("\n</details>\n\n")
-	}
-	writeHTTP := func() {
-		b.WriteString("<details>\n<summary><strong>HTTP/1 cleartext (recent)</strong></summary>\n\n")
-		b.WriteString("| Time (UTC) | PID | Comm | Method | Host | Path (summary) | Remote | Policy |\n|:--|--:|:-|:-|:-|:-|:-|:-|\n")
-		if len(in.HTTPRows) == 0 {
-			b.WriteString(fmt.Sprintf("| — | — | — | — | — | — | — | %s |\n", sanitizeCell(protocolEmptyReason(in.HTTPDegradedHook, in.HTTPReaderErrors))))
-		} else {
-			for _, r := range in.HTTPRows {
-				b.WriteString(fmt.Sprintf("| %s | `%d` | `%s` | `%s` | `%s` | `%s` | %s | %s |\n",
-					sanitizeCell(r.TS), r.PID, sanitizeCell(r.Comm),
-					sanitizeCell(r.Method), sanitizeCell(r.Host), sanitizeCell(r.Path),
-					sanitizeCell(r.Remote), sanitizeCell(r.Policy)))
-			}
-		}
-		b.WriteString("\n</details>\n\n")
-	}
-	writeTLS := func() {
-		if !tlsKPIVisible(in) {
-			return
-		}
-		b.WriteString("<details>\n<summary><strong>TLS ClientHello / SNI (recent)</strong></summary>\n\n")
-		b.WriteString("| Time (UTC) | PID | Comm | SNI | Remote | Policy |\n|:--|--:|:-|:-|:-|:-|\n")
-		if len(in.TLSRows) == 0 {
-			b.WriteString(fmt.Sprintf("| — | — | — | — | — | %s |\n", sanitizeCell(protocolEmptyReason(in.TLSDegradedHook, in.TLSReaderErrors))))
-		} else {
-			for _, r := range in.TLSRows {
-				b.WriteString(fmt.Sprintf("| %s | `%d` | `%s` | `%s` | %s | %s |\n",
-					sanitizeCell(r.TS), r.PID, sanitizeCell(r.Comm),
-					sanitizeCell(r.SNI), sanitizeCell(r.Remote), sanitizeCell(r.Policy)))
-			}
-		}
-		b.WriteString("\n</details>\n\n")
-	}
-	writeFS := func() {
-		if !in.FSGate {
-			return
-		}
-		b.WriteString("<details>\n<summary><strong>Filesystem (recent)</strong></summary>\n\n")
-		b.WriteString("| Time | PID | Comm | Op | Path |\n|:--|--:|:--|:--|:--|\n")
-		if len(in.FSRows) == 0 {
-			reason := "no events"
-			if in.FSDegradedHook {
-				reason = "degraded hook"
-			} else if in.FSReaderErrors > 0 {
-				reason = fmt.Sprintf("reader errors (%d)", in.FSReaderErrors)
-			}
-			b.WriteString(fmt.Sprintf("| — | — | — | — | %s |\n", reason))
-		} else {
-			for _, r := range in.FSRows {
-				b.WriteString(fmt.Sprintf("| `%s` | %d | `%s` | `%s` | `%s` |\n",
-					sanitizeCell(r.TS), r.PID, sanitizeCell(r.Comm), sanitizeCell(r.Op), sanitizeCell(r.Path)))
-			}
-			if in.TruncatedFS {
-				b.WriteString(fmt.Sprintf("\n*Showing last %d of %d — full stream in JSONL.*\n",
-					len(in.FSRows), in.FSTotal))
-			}
-		}
-		b.WriteString("\n</details>\n\n")
-	}
-	writeBPFAudit := func() {
-		if in.BPFAuditTotal == 0 && !in.BPFAuditDegradedHook && in.BPFAuditReaderErrors == 0 {
-			return
-		}
-		b.WriteString("<details>\n<summary><strong>BPF audit (recent)</strong></summary>\n\n")
-		b.WriteString("| Time (UTC) | PID | Comm | Command |\n|:--|--:|:-|:-|\n")
-		if len(in.BPFAuditRows) == 0 {
-			reason := "no events"
-			if in.BPFAuditDegradedHook {
-				reason = "degraded hook"
-			} else if in.BPFAuditReaderErrors > 0 {
-				reason = fmt.Sprintf("reader errors (%d)", in.BPFAuditReaderErrors)
-			}
-			b.WriteString(fmt.Sprintf("| — | — | — | %s |\n", reason))
-		} else {
-			for _, r := range in.BPFAuditRows {
-				b.WriteString(fmt.Sprintf("| %s | `%d` | `%s` | `%s` (%d) |\n",
-					sanitizeCell(r.TS), r.PID, sanitizeCell(r.Comm), sanitizeCell(BPFCmdName(r.Cmd)), r.Cmd))
-			}
-			if in.TruncatedBPFAudit {
-				b.WriteString(fmt.Sprintf("\n*Showing last %d of %d — full stream in JSONL.*\n",
-					len(in.BPFAuditRows), in.BPFAuditTotal))
-			}
-		}
-		b.WriteString("\n</details>\n\n")
-	}
-
-	writeExec()
-	writeBPFAudit()
-	writeProcessTree()
-	writeTCP()
-	writeUDP()
-	writeHTTP()
-	writeTLS()
-	writeFS()
-
-	writeRunInfo(&b, in)
+	writeHeader(&b, in)
+	writeCompactKPI(&b, in)
+	writeTopDestinations(&b, in)
+	writeTriageTable(&b, in)
 	writeTechnicalDetails(&b, in, max)
+	writeFooter(&b, in)
 
 	s := b.String()
 	if len(s) > summarySoftByteBudget {

--- a/internal/report/digest_test.go
+++ b/internal/report/digest_test.go
@@ -72,7 +72,7 @@ func TestBuildDetectMarkdown_TriageRibbon_TruthfulnessInterpretation(t *testing.
 	}
 }
 
-func TestBuildDetectMarkdown_HotEgressDestinations(t *testing.T) {
+func TestBuildDetectMarkdown_TopDestinations(t *testing.T) {
 	md := BuildDetectMarkdown(DigestInput{
 		TCPRows: []TCPDigestRow{{
 			TS: "t", PID: 1, Comm: "curl", Remote: "`10.0.0.1:443`", Policy: "monitor",
@@ -83,10 +83,21 @@ func TestBuildDetectMarkdown_HotEgressDestinations(t *testing.T) {
 		}},
 		MaxRowsPerSection: 50,
 	})
-	for _, needle := range []string{"### Hot egress destinations", "registry.npmjs.org", "10.0.0.1:443", "tcp", "http"} {
+	for _, needle := range []string{"### Top destinations", "registry.npmjs.org", "10.0.0.1:443", "tcp", "http"} {
 		if !strings.Contains(md, needle) {
 			t.Fatalf("missing %q in:\n%s", needle, md)
 		}
+	}
+}
+
+func TestBuildDetectMarkdown_TopDestinations_HiddenWhenEmpty(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{
+		BPF:               []telemetry.BPFStatus{{Name: "exec", OK: true}},
+		ExecTotal:         3,
+		MaxRowsPerSection: 50,
+	})
+	if strings.Contains(md, "### Top destinations") {
+		t.Fatalf("Top destinations should be hidden when no egress rows present:\n%s", md)
 	}
 }
 
@@ -127,7 +138,7 @@ func TestBuildDetectMarkdown_ProcessTreeSection(t *testing.T) {
 	}
 }
 
-func TestBuildDetectMarkdown_KPIAndSections(t *testing.T) {
+func TestBuildDetectMarkdown_HeaderAndCompactKPI(t *testing.T) {
 	md := BuildDetectMarkdown(DigestInput{
 		BPF:       []telemetry.BPFStatus{{Name: "syscalls", OK: true}},
 		ExecTotal: 1, TCPTotal: 2, UDPTotal: 3, HTTPTotal: 4,
@@ -148,15 +159,72 @@ func TestBuildDetectMarkdown_KPIAndSections(t *testing.T) {
 		MaxRowsPerSection: 5,
 	})
 	for _, needle := range []string{
-		"## Coldstep · detect",
-		"Detect-only: observe, do not block.",
-		"### KPI", "| **exec** | 1 |", "| **udp** | 3 |", "| **http** | 4 |",
+		"## ✅ coldstep — detect",
+		"| exec | tcp | udp | http | tls |",
+		"| 1 | 2 | 3 | 4 | — |",
+		"<details>",
+		"<summary>Technical details",
+		"#### Full KPI",
+		"| **exec** | 1 |", "| **udp** | 3 |", "| **http** | 4 |",
 		"UDP sendto", "HTTP/1 cleartext", "Canonical log (JSONL)", "connect(2)",
 		"PID (TGID)", "| `99` |", "`sh`", "Executable (BPF-capped)", "`/bin/sh`",
 		"**UDP KPI**",
+		"> Full event log: `/tmp/x.jsonl`",
 	} {
 		if !strings.Contains(md, needle) {
 			t.Fatalf("missing %q in:\n%s", needle, md)
+		}
+	}
+}
+
+func TestBuildDetectMarkdown_HeaderEmojiVerdicts(t *testing.T) {
+	clean := BuildDetectMarkdown(DigestInput{
+		BPF:       []telemetry.BPFStatus{{Name: "exec", OK: true}},
+		ExecTotal: 1,
+	})
+	if !strings.Contains(clean, "## ✅ coldstep — detect") {
+		t.Fatalf("clean-run header missing ✅:\n%s", clean)
+	}
+
+	review := BuildDetectMarkdown(DigestInput{
+		BPF:                       []telemetry.BPFStatus{{Name: "exec", OK: true}},
+		UDPRingbufReserveFailures: 1,
+	})
+	if !strings.Contains(review, "## ⚠️ coldstep — detect") {
+		t.Fatalf("review-state header missing ⚠️:\n%s", review)
+	}
+
+	alert := BuildDetectMarkdown(DigestInput{
+		BPF: []telemetry.BPFStatus{{Name: "exec", OK: false}},
+	})
+	if !strings.Contains(alert, "## 🚨 coldstep — detect") {
+		t.Fatalf("alert-state header missing 🚨:\n%s", alert)
+	}
+}
+
+func TestBuildDetectMarkdown_NoForbiddenGFMTags(t *testing.T) {
+	// Job Summaries render GFM; <font>, <p align>, <sub>, <center> are not in
+	// the allowlist and would appear as literal text. This guards against
+	// regression that might re-introduce them.
+	inputs := []DigestInput{
+		{},
+		{ExecTotal: 1, TCPTotal: 1, BPF: []telemetry.BPFStatus{{Name: "x", OK: true}}},
+		{
+			DefendMode: "defend", DefendDenyCount: 1, DefendAllowlistSize: 1,
+			BPF: []telemetry.BPFStatus{{Name: "x", OK: true}},
+		},
+		{
+			BPFMapIntegrityFailures: 2,
+			BPF:                     []telemetry.BPFStatus{{Name: "x", OK: false}},
+		},
+	}
+	forbidden := []string{"<font", "<p align", "<sub>", "</sub>", "<center"}
+	for i, in := range inputs {
+		md := BuildDetectMarkdown(in)
+		for _, tag := range forbidden {
+			if strings.Contains(md, tag) {
+				t.Fatalf("case %d: forbidden tag %q present in digest:\n%s", i, tag, md)
+			}
 		}
 	}
 }
@@ -315,10 +383,10 @@ func TestBuildDetectMarkdown_DefendPlusLabelBlocking(t *testing.T) {
 		MaxRowsPerSection:   50,
 	})
 	for _, needle := range []string{
-		"## Coldstep · defend",
+		"coldstep — defend",
 		"| **Mode** | `defend`",
 		"**deny events:** 4",
-		"### Defend",
+		"#### Defend",
 		"| Mode | `defend+cgroup` |",
 	} {
 		if !strings.Contains(md, needle) {
@@ -343,9 +411,8 @@ func TestBuildDetectMarkdown_DefendSection(t *testing.T) {
 		},
 	})
 	for _, needle := range []string{
-		"## Coldstep · defend",
-		"Defend mode: cgroup-scoped IPv4 egress is allowlisted",
-		"### Defend",
+		"coldstep — defend",
+		"#### Defend",
 		"| Mode | `defend` |",
 		"| Allowlist size | 3 |",
 		"| Deny count | 2 |",
@@ -361,8 +428,10 @@ func TestBuildDetectMarkdown_DefendSection(t *testing.T) {
 			t.Fatalf("missing %q in:\n%s", needle, md)
 		}
 	}
-	if strings.Contains(md, "Detect-only: observe, do not block.") {
-		t.Fatalf("defend digest should not use detect-only banner:\n%s", md)
+	// The previous design had a Detect-only banner; the new compact header drops it.
+	// Defend digests must still announce the mode in the header.
+	if strings.Contains(md, "coldstep — detect") {
+		t.Fatalf("defend digest should not announce detect mode:\n%s", md)
 	}
 }
 
@@ -429,8 +498,8 @@ func TestBuildDetectMarkdown_DefendDenyReserveFailures(t *testing.T) {
 		DefendDenyReserveFailures: 5,
 	})
 	for _, needle := range []string{
-		"## Coldstep · defend",
-		"### Defend",
+		"coldstep — defend",
+		"#### Defend",
 		"| Deny ringbuf reserve failures (blocked, no JSONL) | 5 |",
 	} {
 		if !strings.Contains(md, needle) {
@@ -506,5 +575,38 @@ func TestBuildDetectMarkdown_DroppedEventCounters(t *testing.T) {
 		if !strings.Contains(md, needle) {
 			t.Fatalf("missing %q in:\n%s", needle, md)
 		}
+	}
+}
+
+func TestBuildDetectMarkdown_FooterAlwaysPresent(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{})
+	if !strings.Contains(md, "> Full event log:") {
+		t.Fatalf("missing footer:\n%s", md)
+	}
+	if !strings.Contains(md, ".coldstep-events.jsonl") {
+		t.Fatalf("footer should default to .coldstep-events.jsonl when path unset:\n%s", md)
+	}
+}
+
+func TestBuildDetectMarkdown_VisibleLineBudget(t *testing.T) {
+	// A typical detect run should produce a compact visible section (above the
+	// Technical details fold). Count visible lines until the first <details> at
+	// column 0 — that's our budget for what an operator sees by default.
+	md := BuildDetectMarkdown(DigestInput{
+		BPF:       []telemetry.BPFStatus{{Name: "syscalls", OK: true}},
+		ExecTotal: 12, TCPTotal: 4, UDPTotal: 3, HTTPTotal: 0,
+		TCPRows: []TCPDigestRow{{
+			TS: "t", PID: 1, Comm: "curl", Remote: "`1.2.3.4:443`", Policy: "monitor",
+		}},
+		MaxRowsPerSection: 50,
+	})
+	idx := strings.Index(md, "<details>")
+	if idx < 0 {
+		t.Fatalf("expected Technical details fold; got:\n%s", md)
+	}
+	visible := md[:idx]
+	lines := strings.Count(visible, "\n")
+	if lines > 30 {
+		t.Fatalf("visible portion is %d lines, budget is 30:\n%s", lines, visible)
 	}
 }


### PR DESCRIPTION
## Summary

Job Summaries on GitHub Actions render **GitHub Flavored Markdown** (GFM) — standard Markdown plus a narrow HTML subset (`<details>`, `<summary>`, `<br>`, `<hr>`, `<table>`). Anything outside that subset — `<font color="">`, `<p align="center">`, `<sub>`, `<center>` — is rendered as literal text in the Job Summary. The previous detect-digest design used all four. This PR removes them and cuts the visible portion of the digest by ~80%.

Reference: [Supercharging GitHub Actions with Job Summaries](https://github.blog/news-insights/product-news/supercharging-github-actions-with-job-summaries/).

### What changed in the markdown

The visible portion of the digest (everything above the Technical details fold) is now:

1. `## <emoji> coldstep — <mode>` — one-line headline. Emoji is the verdict (`✅` / `⚠️` / `🚨`) computed from BPF status, capture gaps, canary, heartbeat, etc.
2. One-row 5-column KPI table — `exec | tcp | udp | http | tls`. TLS cell renders as `—` when the `tls_sni` gate is off.
3. **Top destinations** (was "Hot egress destinations") — capped at 10 rows, hidden entirely when no egress was observed.
4. **Triage** table — `Mode`, `BPF hooks`, plus only the rows that have something to say (`JSONL decode drops`, `Capture gaps`, `Observability (partial / bypass-class)`, `Ringbuf reserve pressure`).
5. `> Full event log: \`.coldstep-events.jsonl\`` footer.

Everything else — full per-channel KPI table, policy / dropped rollups, defend section, run info, per-protocol event rows (Exec, BPF audit, Process tree, TCP, UDP, HTTP, TLS, FS), BPF hook status table, and KPI semantics prose — now lives inside a single `<details><summary>Technical details — …</summary>…</details>` fold. Each per-protocol event table is its own nested `<details>` so operators can drill into one protocol without scrolling past the rest.

For a typical detect run (1 BPF probe, some TCP rows), the visible portion is **~19 lines** (budget enforced by `TestBuildDetectMarkdown_VisibleLineBudget` at 30).

### What changed in code

- `internal/report/digest.go`
  - Dropped the `<p align="center">…<sub>…</sub>` banner block and the blockquote headline-badge — the verdict now lives in the `##` heading emoji.
  - Replaced `<font color="red">` on `bpf_map_integrity_failures` with plain `**bold**`.
  - New visible writers: `writeHeader`, `writeCompactKPI`, `writeTopDestinations`, `writeTriageTable`, `writeFooter`.
  - All per-channel KPIs, defend section, run info, per-protocol event tables, BPF hook status, and KPI semantics moved inside `writeTechnicalDetails`.
  - The existing `buildHotEgressList` / `hotKindTags` helpers in `digest_aggregation.go` are reused (top-10 cap applied in the writer; the helper still caps at 15 for any downstream consumer).
- `internal/report/digest_test.go`
  - Updated header-related needles (`## Coldstep · detect` → `## ✅ coldstep — detect`, etc.).
  - Renamed `HotEgressDestinations` test to `TopDestinations`; added `TopDestinations_HiddenWhenEmpty`.
  - Added `HeaderEmojiVerdicts` (✅/⚠️/🚨 paths), `NoForbiddenGFMTags` (regression guard on `<font>`/`<p align>`/`<sub>`/`<center>`), `FooterAlwaysPresent`, and `VisibleLineBudget` (≤30 lines above `<details>`).
  - Defend tests now assert on `coldstep — defend` and `#### Defend` (inside the fold) instead of `## Coldstep · defend` and `### Defend`.

No `DigestInput` or `telemetry.Summary` field added or removed. No agent / BPF code touched. No public Go API change.

## Test plan

- [x] `go test ./internal/report/... -count=1` — all tests pass.
- [x] `gofmt -l internal/report/digest.go internal/report/digest_test.go` — clean.
- [x] `go vet ./internal/report/...` — clean.
- [x] Manually rendered a typical detect-mode digest and confirmed visible portion is 19 lines (budget 30).
- [ ] CI: `coldstep-ci.yml` matrix (`unit`, `unit-arm64`, `integration`, `detect-mode`, `defend-mode`) — verified on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
