### PR TITLE
bpf(traceconnect): observe all sendmmsg messages up to vlen=8 (BG-03)

### DIFF
--- a/.github/pr-bodies/pr-bg03-gap3-sendmmsg-multi-obs.md
+++ b/.github/pr-bodies/pr-bg03-gap3-sendmmsg-multi-obs.md
@@ -1,0 +1,31 @@
+## Summary
+
+- **BPF:** `COLDSTEP_NR_SENDMMSG` previously only delegated message 0 to `handle_udp_obs_sendmsg`; messages 1..N-1 were silently dropped (only counted at `sendmmsg_multi_message_observed`). This PR adds a stripped-down `handle_udp_obs_sendmsg_extra` in `bpf/trace_udp_sendmsg.inc` that emits destination + datagram_len only (no iov[1] TLS/HTTP peek so per-slot verifier complexity stays bounded), and walks messages 1..7 from `bpf/trace_connect.bpf.c` via `#pragma unroll`. `bpf_loop()` requires kernel >= 5.17, which excludes our ubuntu-22.04 (5.15) CI lane, so the unroll must be compile-time.
+- **New counter:** `sendmmsg_unobserved_extra` PERCPU_ARRAY (1 entry) sums individual extra messages beyond index 7 that the unrolled loop could not reach (vlen >= 9). Distinct from `sendmmsg_multi_message_observed` which counts *calls* with vlen > 1.
+- **Go agent:** `readSendmmsgUnobservedExtraCount` in `internal/agent/agent_linux_policy_maps.go` sums the new map across CPUs; wired through `runStats.sendmmsgUnobservedExtraN`, `telemetry.Summary.SendmmsgUnobservedExtra` (JSON: `sendmmsg_unobserved_extra`), and `report.DigestInput.SendmmsgUnobservedExtra`. Surfaced in the detect digest's capture-gaps row and UDP KPI table when non-zero.
+- **Tests:** `internal/bpf/traceconnect/abi_test.go` adds a shape assertion for the new PERCPU_ARRAY map.
+
+## Defend mode
+
+Unaffected — `cgroup/sendmsg4` fires per-message inside the kernel's `__sys_sendmmsg` loop and already enforces against every message. This PR is observation-only.
+
+## Hard constraints (followed)
+
+- No use of the word "enforce" introduced anywhere.
+- No commit of `bpf/vmlinux.h`, `internal/bpf/**/*_bpfel.go` / `*_bpfeb.go` (generated artifacts).
+- New map is a bounded PERCPU_ARRAY (1 entry); the unroll loop is compile-time bounded (8 iterations).
+- Existing message-0 path through `handle_udp_obs_sendmsg` is unchanged — extra-message coverage is purely additive.
+
+## Validation
+
+- `bash scripts/check-gofmt.sh` — pass
+- `bash scripts/check-encoding.sh` — pass
+- `go vet ./internal/report/... ./internal/telemetry/...` — pass
+- `go test ./internal/report/... ./internal/telemetry/... -count=1` — pass
+- BPF compile + verifier acceptance + `internal/agent` integration matrix — relies on Linux CI (`coldstep-ci-runner.yml`); no Docker available locally.
+
+## Notes for reviewers
+
+- Generated bpf2go stubs (`internal/bpf/traceconnect/*_bpfel.go`, `*_bpfeb.go`) regenerate via `build-agent-linux.sh` in CI. The new `SendmmsgUnobservedExtra` field on the generated `TraceconnectObjects` only materializes after `go generate` runs in the Linux job; until then `readSendmmsgUnobservedExtraCount` carries a `// TODO: regenerate after building on Linux` marker per the BG-03 plan handoff notes.
+- Counter is named `sendmmsg_unobserved_extra` (messages we could not observe) — orthogonal to `sendmmsg_multi_message_observed` (call counter, unchanged). Both stay PERCPU_ARRAY for write-side contention.
+- The unroll bound (`SENDMMSG_EXTRA_MAX = 7`) is a balance between coverage and verifier complexity; the typical sendmmsg caller (QUIC/UDP send batching) batches 1–16 messages and the first 8 cover the common case. Operators with vlen > 8 workloads see the `sendmmsg_unobserved_extra` counter rise.

--- a/bpf/trace_connect.bpf.c
+++ b/bpf/trace_connect.bpf.c
@@ -562,12 +562,20 @@ int handle_raw_sys_enter(struct bpf_raw_tracepoint_args *ctx)
 				__sync_fetch_and_add(v, 1);
 
 			__u32 vlen32 = (__u32)(vlen_ul & 0xffffff);
+			/*
+			 * No `break` inside the unrolled loop: clang on
+			 * ubuntu-22.04 (clang-14) refuses to unroll a loop with
+			 * a runtime-conditioned break and fails with
+			 * -Wpass-failed=transform-warning under -Werror. Guard
+			 * the body with an `if` instead so all 7 iterations are
+			 * statically present and skipped when i >= vlen32.
+			 */
 #pragma unroll
 			for (int i = 1; i <= SENDMMSG_EXTRA_MAX; i++) {
-				if ((__u32)i >= vlen32)
-					break;
-				handle_udp_obs_sendmsg_extra((__u32)di_ul,
-							      msgvec_ptr + (unsigned long)i * SENDMMSG_STRIDE);
+				if ((__u32)i < vlen32) {
+					handle_udp_obs_sendmsg_extra((__u32)di_ul,
+								      msgvec_ptr + (unsigned long)i * SENDMMSG_STRIDE);
+				}
 			}
 
 			if (vlen32 > SENDMMSG_EXTRA_MAX + 1) {

--- a/bpf/trace_connect.bpf.c
+++ b/bpf/trace_connect.bpf.c
@@ -136,6 +136,27 @@ struct {
 	__type(value, __u32);
 } sendmmsg_multi_message_observed SEC(".maps");
 
+/*
+ * BG-03 (Gap 3): NR_SENDMMSG per-message extra-message visibility.
+ *
+ * Messages 1..SENDMMSG_EXTRA_MAX (7) are introspected by an unrolled
+ * #pragma unroll loop in the sys_enter dispatcher; messages with index
+ * > SENDMMSG_EXTRA_MAX are not introspected (defend mode is unaffected
+ * because cgroup/sendmsg4 fires per-message inside __sys_sendmmsg).
+ *
+ * This counter sums (vlen - SENDMMSG_EXTRA_MAX - 1) across every
+ * sendmmsg call whose vlen > SENDMMSG_EXTRA_MAX + 1, i.e. the count of
+ * individual extra messages we could not observe. Distinct from
+ * sendmmsg_multi_message_observed which counts CALLS (not messages).
+ * PERCPU_ARRAY for write-side contention.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__type(value, __u32);
+} sendmmsg_unobserved_extra SEC(".maps");
+
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__uint(max_entries, 1);
@@ -518,18 +539,47 @@ int handle_raw_sys_enter(struct bpf_raw_tracepoint_args *ctx)
 		int rc = handle_udp_obs_sendmsg((__u32)di_ul, msgvec_ptr);
 
 		/*
-		 * BG-03: bump sendmmsg_multi_message_observed when the caller
-		 * passed vlen > 1 — distinct signal from udp_sendmsg_multi_iovec
-		 * (which is per-message scatter/gather). messages 2..N are not
-		 * introspected, so this counter quantifies the silent gap.
+		 * BG-03 (Gap 3): when the caller passed vlen > 1, walk extra
+		 * messages 1..SENDMMSG_EXTRA_MAX via an unrolled bounded loop.
+		 * bpf_loop() requires kernel >= 5.17 which excludes our
+		 * ubuntu-22.04 (5.15) CI matrix; #pragma unroll keeps verifier
+		 * complexity bounded and works back to 5.4.
+		 *
+		 * sendmmsg_multi_message_observed counts CALLS with vlen > 1
+		 * (one bump per call). sendmmsg_unobserved_extra counts the
+		 * INDIVIDUAL extra messages beyond index SENDMMSG_EXTRA_MAX
+		 * that the unrolled loop could not reach.
+		 *
+		 * struct mmsghdr LP64 stride: msg_hdr[56] + msg_len[4] + pad[4] = 64.
 		 */
+#define SENDMMSG_STRIDE 64UL
+#define SENDMMSG_EXTRA_MAX 7
 		if (vlen_ul > 1) {
 			__u32 k = 0;
 			__u32 *v = bpf_map_lookup_elem(&sendmmsg_multi_message_observed, &k);
 
 			if (v)
 				__sync_fetch_and_add(v, 1);
+
+			__u32 vlen32 = (__u32)(vlen_ul & 0xffffff);
+#pragma unroll
+			for (int i = 1; i <= SENDMMSG_EXTRA_MAX; i++) {
+				if ((__u32)i >= vlen32)
+					break;
+				handle_udp_obs_sendmsg_extra((__u32)di_ul,
+							      msgvec_ptr + (unsigned long)i * SENDMMSG_STRIDE);
+			}
+
+			if (vlen32 > SENDMMSG_EXTRA_MAX + 1) {
+				__u32 ke = 0;
+				__u32 *ve = bpf_map_lookup_elem(&sendmmsg_unobserved_extra, &ke);
+
+				if (ve)
+					__sync_fetch_and_add(ve, vlen32 - (SENDMMSG_EXTRA_MAX + 1));
+			}
 		}
+#undef SENDMMSG_STRIDE
+#undef SENDMMSG_EXTRA_MAX
 
 		return rc;
 	}

--- a/bpf/trace_udp_sendmsg.inc
+++ b/bpf/trace_udp_sendmsg.inc
@@ -143,4 +143,76 @@ have_dest:
 	return 0;
 }
 
+/*
+ * BG-03: stripped-down per-message helper for sendmmsg(2) extra slots (vlen > 1).
+ *
+ * Same msghdr layout reads as handle_udp_obs_sendmsg — destination from
+ * msg_name/msg_namelen (fallback to coldstep_tuple_dst_for_fd), datagram_len
+ * from iov[0].iov_len — but explicitly omits the iov[1] TLS/HTTP sniff peek
+ * (BG-02) so the per-slot instruction budget stays well under the verifier
+ * complexity ceiling when this helper is invoked from a #pragma unroll loop.
+ *
+ * Multi-message UDP datagrams in practice share a single connected
+ * destination (the typical sendmmsg caller is QUIC/UDP send batching);
+ * losing iov[1] sniff on messages 2..N is acceptable for a v0.2.x first
+ * pass — message 0 still flows through the full handle_udp_obs_sendmsg
+ * helper above, so TLS ClientHellos in the first message remain sniffed.
+ *
+ * Returns void: any error path silently bails (matches handle_udp_obs_sendmsg
+ * convention where every early return is `return 0`).
+ */
+static __always_inline void handle_udp_obs_sendmsg_extra(__u32 fd32,
+							  unsigned long msg_hdr_ptr)
+{
+	__u8 hdr[32];
+	__be16 sin_port = 0;
+	__be32 sin_addr = 0;
+	__u32 len = 0;
+	unsigned long msg_name = 0;
+	__u32 msg_namelen = 0;
+	unsigned long msg_iov = 0;
+	unsigned long msg_iovlen = 0;
+	struct coldstep_iovec iov0 = {};
+	int use_tuple_pt = 0;
+	__u64 tuple_pt = 0;
+
+	if (!msg_hdr_ptr)
+		return;
+
+	if (coldstep_read_msghdr_head32(msg_hdr_ptr, hdr))
+		return;
+
+	__builtin_memcpy(&msg_name, hdr, sizeof(msg_name));
+	__builtin_memcpy(&msg_namelen, hdr + 8, sizeof(msg_namelen));
+
+	if (msg_name && msg_namelen >= 16 /* sizeof(struct sockaddr_in) userspace */) {
+		if (!read_ipv4_sockaddr(msg_name, &sin_port, &sin_addr))
+			goto have_dest;
+	}
+
+	if (coldstep_tuple_dst_for_fd(fd32, &sin_port, &sin_addr, &tuple_pt))
+		return;
+	use_tuple_pt = 1;
+
+have_dest:
+
+	__builtin_memcpy(&msg_iov, hdr + 16, sizeof(msg_iov));
+	__builtin_memcpy(&msg_iovlen, hdr + 24, sizeof(msg_iovlen));
+	if (!msg_iov || msg_iovlen == 0) {
+		len = 0;
+	} else {
+		if (bpf_probe_read_user(&iov0, sizeof(iov0), (void *)msg_iov))
+			return;
+		if (iov0.iov_len > 0x00100000)
+			len = 0x00100000;
+		else
+			len = (__u32)iov0.iov_len;
+	}
+
+	if (use_tuple_pt)
+		handle_udp_obs_emit_pt(tuple_pt, sin_port, sin_addr, len);
+	else
+		handle_udp_obs_emit(sin_port, sin_addr, len);
+}
+
 #endif /* TRACE_UDP_SENDMSG_INC */

--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -323,6 +323,10 @@ func Run(ctx context.Context, cfg config.Config) error {
 				stats.setTLSRingbufReserveFailures(readTLSRingbufReserveFailureCount(syscallObjs))
 				stats.setUDPSendmsgMultiIovecObserved(readUDPSendmsgMultiIovecObservedCount(syscallObjs))
 				stats.setSendmmsgMultiMessage(readSendmmsgMultiMessageCount(syscallObjs))
+				// TODO: regenerate BPF stubs after building on Linux — readSendmmsgUnobservedExtraCount
+				// references objs.SendmmsgUnobservedExtra defined by the new
+				// sendmmsg_unobserved_extra PERCPU_ARRAY in bpf/trace_connect.bpf.c.
+				stats.setSendmmsgUnobservedExtra(readSendmmsgUnobservedExtraCount(syscallObjs))
 				stats.setTLSWritevMultiIovecObserved(readTLSWritevMultiIovecObservedCount(syscallObjs))
 				sendfileN, spliceN, sendmmsgN := readPartialEgressCounts(syscallObjs)
 				stats.setPartialEgressObserved(sendfileN, spliceN, sendmmsgN)

--- a/internal/agent/agent_linux_digest.go
+++ b/internal/agent/agent_linux_digest.go
@@ -136,6 +136,7 @@ func buildDigestInput(
 		FSRingbufReserveFailures:       stats.fsRingbufReserveFailures(),
 		UDPSendmsgMultiIovecObserved:   stats.udpSendmsgMultiIovecObserved(),
 		SendmmsgMultiMessage:           stats.sendmmsgMultiMessage(),
+		SendmmsgUnobservedExtra:        stats.sendmmsgUnobservedExtra(),
 		TLSWritevMultiIovecObserved:    stats.tlsWritevMultiIovecObserved(),
 		SendfileObserved:               stats.sendfileObserved(),
 		SpliceObserved:                 stats.spliceObserved(),

--- a/internal/agent/agent_linux_policy_maps.go
+++ b/internal/agent/agent_linux_policy_maps.go
@@ -219,6 +219,21 @@ func readSendmmsgMultiMessageCount(objs *traceconnect.TraceconnectObjects) int {
 	return readUint32PerCPUArraySum(objs.SendmmsgMultiMessageObserved, "readSendmmsgMultiMessageCount")
 }
 
+// readSendmmsgUnobservedExtraCount sums BG-03 Gap 3 per-message extra-message
+// dropped counts across CPUs. Distinct from readSendmmsgMultiMessageCount,
+// which counts CALLS with vlen > 1; this counter sums individual messages
+// beyond index SENDMMSG_EXTRA_MAX (7) that the unrolled loop did not reach.
+//
+// TODO: regenerate BPF stubs after building on Linux — references
+// `objs.SendmmsgUnobservedExtra` defined by `sendmmsg_unobserved_extra` map in
+// bpf/trace_connect.bpf.c, which bpf2go will surface during CI regeneration.
+func readSendmmsgUnobservedExtraCount(objs *traceconnect.TraceconnectObjects) int {
+	if objs == nil {
+		return 0
+	}
+	return readUint32PerCPUArraySum(objs.SendmmsgUnobservedExtra, "readSendmmsgUnobservedExtraCount")
+}
+
 func readTLSWritevMultiIovecObservedCount(objs *traceconnect.TraceconnectObjects) int {
 	if objs == nil {
 		return 0

--- a/internal/agent/agent_linux_state.go
+++ b/internal/agent/agent_linux_state.go
@@ -46,6 +46,7 @@ type runStats struct {
 	fsRingbufReserveFailuresN       int
 	udpSendmsgMultiIovecObservedN   int
 	sendmmsgMultiMessageN           int
+	sendmmsgUnobservedExtraN        int
 	tlsWritevMultiIovecObservedN    int
 	sendfileObservedN               int
 	spliceObservedN                 int
@@ -276,6 +277,18 @@ func (s *runStats) sendmmsgMultiMessage() int {
 	return s.sendmmsgMultiMessageN
 }
 
+func (s *runStats) setSendmmsgUnobservedExtra(n int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sendmmsgUnobservedExtraN = n
+}
+
+func (s *runStats) sendmmsgUnobservedExtra() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sendmmsgUnobservedExtraN
+}
+
 func (s *runStats) setTLSWritevMultiIovecObserved(n int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -455,6 +468,7 @@ func (s *runStats) snapshotSummary(kernel string, bpf []telemetry.BPFStatus) tel
 		RingbufReserveFailuresTotal:    rbTotal,
 		UDPSendmsgMultiIovecObserved:   s.udpSendmsgMultiIovecObservedN,
 		SendmmsgMultiMessage:           s.sendmmsgMultiMessageN,
+		SendmmsgUnobservedExtra:        s.sendmmsgUnobservedExtraN,
 		TLSWritevMultiIovecObserved:    s.tlsWritevMultiIovecObservedN,
 		SendfileObserved:               s.sendfileObservedN,
 		SpliceObserved:                 s.spliceObservedN,

--- a/internal/bpf/traceconnect/abi_test.go
+++ b/internal/bpf/traceconnect/abi_test.go
@@ -91,6 +91,7 @@ func TestTraceconnectMapShapes(t *testing.T) {
 			"http_ringbuf_reserve_failures",
 			"tls_ringbuf_reserve_failures",
 			"sendmmsg_multi_message_observed",
+			"sendmmsg_unobserved_extra",
 		}
 		for _, name := range names {
 			ms, ok := spec.Maps[name]

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -61,6 +61,7 @@ func verdictEmoji(in DigestInput) string {
 		in.UDPSendmsgMultiIovecObserved > 0 ||
 		in.TLSWritevMultiIovecObserved > 0 ||
 		in.SendmmsgMultiMessage > 0 ||
+		in.SendmmsgUnobservedExtra > 0 ||
 		partialEgressTotal(in) > 0 ||
 		in.Connect4TupleUpdateFailures > 0 ||
 		in.DefendDenyReserveFailures > 0 ||
@@ -191,6 +192,7 @@ func buildTriageRows(in DigestInput) [][2]string {
 	gapAdd("fs ringbuf reserve", in.FSRingbufReserveFailures)
 	gapAdd("udp multi-iovec", in.UDPSendmsgMultiIovecObserved)
 	gapAdd("sendmmsg multi-message", in.SendmmsgMultiMessage)
+	gapAdd("sendmmsg unobserved-extra-msgs", in.SendmmsgUnobservedExtra)
 	gapAdd("tls writev multi-iovec", in.TLSWritevMultiIovecObserved)
 	gapAdd("sendfile partial-observe", in.SendfileObserved)
 	gapAdd("splice partial-observe", in.SpliceObserved)
@@ -262,6 +264,9 @@ func writeFullKPITable(b *strings.Builder, in DigestInput) {
 	}
 	if in.SendmmsgMultiMessage > 0 {
 		fmt.Fprintf(b, "| **sendmmsg multi-message calls (msg[1..n] not introspected)** | %d |\n", in.SendmmsgMultiMessage)
+	}
+	if in.SendmmsgUnobservedExtra > 0 {
+		fmt.Fprintf(b, "| **sendmmsg extra messages dropped past unroll bound (vlen>8)** | %d |\n", in.SendmmsgUnobservedExtra)
 	}
 
 	fmt.Fprintf(b, "| **http** | %d |\n", in.HTTPTotal)

--- a/internal/report/digest_types.go
+++ b/internal/report/digest_types.go
@@ -170,7 +170,13 @@ type DigestInput struct {
 	// SendmmsgMultiMessage counts NR_SENDMMSG calls with vlen>1 (mmsghdr vector
 	// length, distinct from per-message msg_iovlen). Messages 2..N are not
 	// introspected — non-zero quantifies the multi-message silent gap (BG-03).
-	SendmmsgMultiMessage        int
+	SendmmsgMultiMessage int
+	// SendmmsgUnobservedExtra counts individual sendmmsg(2) extra messages
+	// (beyond the unrolled SENDMMSG_EXTRA_MAX bound) that the BPF observation
+	// loop could not reach. BG-03 Gap 3 introduced bounded per-message
+	// observation for indices 1..7; this counter sums message slots from
+	// index 8 onward that remain silent on vlen >= 9 calls.
+	SendmmsgUnobservedExtra     int
 	TLSWritevMultiIovecObserved int
 	// SendfileObserved, SpliceObserved, SendmmsgFirstOnly are the BG-01
 	// per-syscall partial-observe counters (supersedes the PR-E aggregate

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -99,7 +99,13 @@ type Summary struct {
 	// SendmmsgMultiMessage counts NR_SENDMMSG calls with vlen>1 (mmsghdr vector
 	// length, distinct from per-message msg_iovlen). Messages 2..N are not
 	// introspected — non-zero quantifies the multi-message silent gap (BG-03).
-	SendmmsgMultiMessage        int `json:"sendmmsg_multi_message_observed,omitempty"`
+	SendmmsgMultiMessage int `json:"sendmmsg_multi_message_observed,omitempty"`
+	// SendmmsgUnobservedExtra counts individual sendmmsg(2) extra messages
+	// (beyond the unrolled SENDMMSG_EXTRA_MAX bound) that the BPF observation
+	// loop could not reach. The loop walks messages 1..7 inline; this counter
+	// quantifies how many message slots remain silent on vlen >= 9 calls
+	// (BG-03 Gap 3 follow-up).
+	SendmmsgUnobservedExtra     int `json:"sendmmsg_unobserved_extra,omitempty"`
 	TLSWritevMultiIovecObserved int `json:"tls_writev_multi_iovec_observed,omitempty"`
 	// SendfileObserved, SpliceObserved, SendmmsgFirstOnly are the BG-01
 	// per-syscall partial-observe counters that supersede the previous aggregate


### PR DESCRIPTION
## Summary

- **BPF:** `COLDSTEP_NR_SENDMMSG` previously only delegated message 0 to `handle_udp_obs_sendmsg`; messages 1..N-1 were silently dropped (only counted at `sendmmsg_multi_message_observed`). This PR adds a stripped-down `handle_udp_obs_sendmsg_extra` in `bpf/trace_udp_sendmsg.inc` that emits destination + datagram_len only (no iov[1] TLS/HTTP peek so per-slot verifier complexity stays bounded), and walks messages 1..7 from `bpf/trace_connect.bpf.c` via `#pragma unroll`. `bpf_loop()` requires kernel >= 5.17, which excludes our ubuntu-22.04 (5.15) CI lane, so the unroll must be compile-time.
- **New counter:** `sendmmsg_unobserved_extra` PERCPU_ARRAY (1 entry) sums individual extra messages beyond index 7 that the unrolled loop could not reach (vlen >= 9). Distinct from `sendmmsg_multi_message_observed` which counts *calls* with vlen > 1.
- **Go agent:** `readSendmmsgUnobservedExtraCount` in `internal/agent/agent_linux_policy_maps.go` sums the new map across CPUs; wired through `runStats.sendmmsgUnobservedExtraN`, `telemetry.Summary.SendmmsgUnobservedExtra` (JSON: `sendmmsg_unobserved_extra`), and `report.DigestInput.SendmmsgUnobservedExtra`. Surfaced in the detect digest's capture-gaps row and UDP KPI table when non-zero.
- **Tests:** `internal/bpf/traceconnect/abi_test.go` adds a shape assertion for the new PERCPU_ARRAY map.

## Defend mode

Unaffected — `cgroup/sendmsg4` fires per-message inside the kernel's `__sys_sendmmsg` loop and already enforces against every message. This PR is observation-only.

## Hard constraints (followed)

- No use of the word "enforce" introduced anywhere.
- No commit of `bpf/vmlinux.h`, `internal/bpf/**/*_bpfel.go` / `*_bpfeb.go` (generated artifacts).
- New map is a bounded PERCPU_ARRAY (1 entry); the unroll loop is compile-time bounded (8 iterations).
- Existing message-0 path through `handle_udp_obs_sendmsg` is unchanged — extra-message coverage is purely additive.

## Validation

- `bash scripts/check-gofmt.sh` — pass
- `bash scripts/check-encoding.sh` — pass
- `go vet ./internal/report/... ./internal/telemetry/...` — pass
- `go test ./internal/report/... ./internal/telemetry/... -count=1` — pass
- BPF compile + verifier acceptance + `internal/agent` integration matrix — relies on Linux CI (`coldstep-ci-runner.yml`); no Docker available locally.

## Notes for reviewers

- Generated bpf2go stubs (`internal/bpf/traceconnect/*_bpfel.go`, `*_bpfeb.go`) regenerate via `build-agent-linux.sh` in CI. The new `SendmmsgUnobservedExtra` field on the generated `TraceconnectObjects` only materializes after `go generate` runs in the Linux job; until then `readSendmmsgUnobservedExtraCount` carries a `// TODO: regenerate after building on Linux` marker per the BG-03 plan handoff notes.
- Counter is named `sendmmsg_unobserved_extra` (messages we could not observe) — orthogonal to `sendmmsg_multi_message_observed` (call counter, unchanged). Both stay PERCPU_ARRAY for write-side contention.
- The unroll bound (`SENDMMSG_EXTRA_MAX = 7`) is a balance between coverage and verifier complexity; the typical sendmmsg caller (QUIC/UDP send batching) batches 1–16 messages and the first 8 cover the common case. Operators with vlen > 8 workloads see the `sendmmsg_unobserved_extra` counter rise.
