### PR TITLE
sec(digest): add coverage scope block and ringbuf drop visibility (P0-2, P0-3)

### DIFF
--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -73,12 +73,27 @@ func verdictEmoji(in DigestInput) string {
 }
 
 // writeHeader renders the single-line `## <emoji> coldstep — <mode>` heading.
+// When partial-coverage signals fired (ringbuf drops or partial-observe
+// counters), a blockquote note steers the reader to the Coverage block — the ✅
+// badge alone would otherwise imply complete observation.
 func writeHeader(b *strings.Builder, in DigestInput) {
 	mode := "detect"
 	if isBlockingDigestMode(in.DefendMode) {
 		mode = "defend"
 	}
 	fmt.Fprintf(b, "## %s coldstep — %s\n\n", verdictEmoji(in), mode)
+	if hasPartialCoverageSignals(in) {
+		b.WriteString("> ⚠️ Partial coverage — see Coverage block below.\n\n")
+	}
+}
+
+// writeCoverage emits a one-line scope statement so users do not misread ✅ as
+// "every byte of egress observed". IPv6 and QUIC/HTTP3 are statically out of
+// scope today (no BPF coverage); the "Payloads beyond iov[0]" cell flips to
+// ⚠️ partial when BG-01 partial-observe counters fired this run.
+func writeCoverage(b *strings.Builder, in DigestInput) {
+	fmt.Fprintf(b, "**Coverage this run:** IPv4 TCP/UDP ✓ observed | IPv6 ✗ not observed | QUIC/HTTP3 ✗ not observed | Payloads beyond iov[0]: %s\n\n",
+		coveragePayloadState(in))
 }
 
 // writeCompactKPI emits a single-row 5-column KPI table. The full per-channel
@@ -305,6 +320,9 @@ func writeFullKPITable(b *strings.Builder, in DigestInput) {
 
 	if dt := droppedTotal(in); dt > 0 {
 		fmt.Fprintf(b, "| **dropped events (decode/jsonl)** | %d |\n", dt)
+	}
+	if rb := totalDetectRingbufReserveFailures(in); rb > 0 {
+		fmt.Fprintf(b, "| **⚠️ Ringbuf drops (detect-path total)** | %d events dropped |\n", rb)
 	}
 
 	// --- health (last) ---
@@ -761,6 +779,7 @@ func BuildDetectMarkdown(in DigestInput) string {
 	var b strings.Builder
 	writeHeader(&b, in)
 	writeCompactKPI(&b, in)
+	writeCoverage(&b, in)
 	writeTopDestinations(&b, in)
 	writeTriageTable(&b, in)
 	writeTechnicalDetails(&b, in, max)

--- a/internal/report/digest_aggregation.go
+++ b/internal/report/digest_aggregation.go
@@ -104,6 +104,31 @@ func hotKindTags(kinds map[string]struct{}) string {
 	return strings.Join(tags, ", ")
 }
 
+// hasPartialCoverageSignals is true when any counter indicates traffic was
+// recorded with reduced fidelity: ringbuf reserve drops (events lost), the
+// BG-01 per-syscall partial-observe paths (sendfile / splice / sendmmsg first-
+// message-only), or scatter/gather syscalls whose iov[1..N] / msg[1..N] payload
+// is not captured. Drives the headline note that the ✅ badge would otherwise
+// imply complete observation.
+func hasPartialCoverageSignals(in DigestInput) bool {
+	return totalDetectRingbufReserveFailures(in) > 0 ||
+		partialEgressTotal(in) > 0 ||
+		in.UDPSendmsgMultiIovecObserved > 0 ||
+		in.TLSWritevMultiIovecObserved > 0 ||
+		in.SendmmsgMultiMessage > 0 ||
+		in.DefendDenyReserveFailures > 0
+}
+
+// coveragePayloadState returns the "Payloads beyond iov[0]" cell text used in
+// the headline Coverage block. Partial when any BG-01 partial-observe counter
+// fired this run.
+func coveragePayloadState(in DigestInput) string {
+	if in.SendmmsgFirstOnly > 0 || in.SendfileObserved > 0 || in.SpliceObserved > 0 {
+		return "⚠️ partial"
+	}
+	return "✓ observed"
+}
+
 // totalDetectRingbufReserveFailures sums ringbuf reserve failures across detect-path
 // telemetry channels (excludes defend deny-event reserves; those are separate).
 func totalDetectRingbufReserveFailures(in DigestInput) int {

--- a/internal/report/digest_test.go
+++ b/internal/report/digest_test.go
@@ -578,6 +578,81 @@ func TestBuildDetectMarkdown_DroppedEventCounters(t *testing.T) {
 	}
 }
 
+func TestBuildDetectMarkdown_CoverageScopeBlock_AlwaysPresent(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   DigestInput
+	}{
+		{"clean detect", DigestInput{
+			BPF:       []telemetry.BPFStatus{{Name: "exec", OK: true}},
+			ExecTotal: 1,
+		}},
+		{"defend", DigestInput{
+			DefendMode:          "defend",
+			DefendAllowlistSize: 1,
+			DefendDenyCount:     0,
+			BPF:                 []telemetry.BPFStatus{{Name: "connect", OK: true}},
+		}},
+	}
+	for _, c := range cases {
+		md := BuildDetectMarkdown(c.in)
+		for _, needle := range []string{
+			"**Coverage this run:**",
+			"IPv4 TCP/UDP ✓ observed",
+			"IPv6 ✗ not observed",
+			"QUIC/HTTP3 ✗ not observed",
+			"Payloads beyond iov[0]: ✓ observed",
+		} {
+			if !strings.Contains(md, needle) {
+				t.Fatalf("[%s] missing %q in digest:\n%s", c.name, needle, md)
+			}
+		}
+	}
+}
+
+func TestBuildDetectMarkdown_CoverageScopeBlock_PartialWhenSendmmsgFirstOnly(t *testing.T) {
+	t.Parallel()
+	md := BuildDetectMarkdown(DigestInput{
+		BPF:               []telemetry.BPFStatus{{Name: "syscalls", OK: true}},
+		SendmmsgFirstOnly: 2,
+	})
+	for _, needle := range []string{
+		"## ⚠️ coldstep — detect",
+		"> ⚠️ Partial coverage — see Coverage block below.",
+		"Payloads beyond iov[0]: ⚠️ partial",
+	} {
+		if !strings.Contains(md, needle) {
+			t.Fatalf("missing %q in digest:\n%s", needle, md)
+		}
+	}
+}
+
+func TestBuildDetectMarkdown_RingbufDropKPIRow(t *testing.T) {
+	t.Parallel()
+	md := BuildDetectMarkdown(DigestInput{
+		BPF:                           []telemetry.BPFStatus{{Name: "syscalls", OK: true}},
+		ConnectRingbufReserveFailures: 4,
+		HTTPRingbufReserveFailures:    1,
+	})
+	for _, needle := range []string{
+		"## ⚠️ coldstep — detect",
+		"> ⚠️ Partial coverage — see Coverage block below.",
+		"| **⚠️ Ringbuf drops (detect-path total)** | 5 events dropped |",
+	} {
+		if !strings.Contains(md, needle) {
+			t.Fatalf("missing %q in digest:\n%s", needle, md)
+		}
+	}
+	cleanMD := BuildDetectMarkdown(DigestInput{
+		BPF:       []telemetry.BPFStatus{{Name: "syscalls", OK: true}},
+		ExecTotal: 1,
+	})
+	if strings.Contains(cleanMD, "Ringbuf drops (detect-path total)") {
+		t.Fatalf("ringbuf drop row should be hidden when no drops; got:\n%s", cleanMD)
+	}
+}
+
 func TestBuildDetectMarkdown_FooterAlwaysPresent(t *testing.T) {
 	md := BuildDetectMarkdown(DigestInput{})
 	if !strings.Contains(md, "> Full event log:") {


### PR DESCRIPTION
## Summary

A ✅ Clean run badge previously implied complete observation, but IPv6, QUIC/HTTP3, and payloads past the first iovec / zero-copy paths are out of scope, and ringbuf reserve drops could silently lose events. This PR makes those gaps explicit in every digest. Pure Go change — no BPF compile required.

### P0-2 — Coverage scope block (`internal/report/digest.go`, `digest_aggregation.go`)

- Emit a one-line **Coverage this run** statement after the compact KPI table in every digest (detect and defend):
  ```
  **Coverage this run:** IPv4 TCP/UDP ✓ observed | IPv6 ✗ not observed | QUIC/HTTP3 ✗ not observed | Payloads beyond iov[0]: <state>
  ```
- The `Payloads beyond iov[0]` cell flips to `⚠️ partial` when any BG-01 partial-observe counter fired this run (`SendmmsgFirstOnly` / `SendfileObserved` / `SpliceObserved`); otherwise `✓ observed`.
- When partial-coverage signals are present, the heading emits an extra blockquote subtitle steering the reader to the block:
  ```
  > ⚠️ Partial coverage — see Coverage block below.
  ```
- The existing `verdictEmoji` review threshold already flipped to ⚠️ on these counters (ringbuf reserve drops, sendmmsg first-only, sendfile/splice partial-observe, multi-iov/multi-message, defend deny-reserve, etc.) — this PR layers user-visible scope text on top, no badge-threshold semantics changed.

### P0-3 — Ringbuf drop visibility

- Counters flow end-to-end already: BPF `PERCPU_ARRAY` → `agent_linux_policy_maps.go` reader → `runStats` field → `telemetry.Summary` → `DigestInput`. No agent-side changes needed.
- Surface a single aggregate row in the Full KPI table when the detect-path sum is non-zero, alongside the existing per-channel rows:
  ```
  | **⚠️ Ringbuf drops (detect-path total)** | N events dropped |
  ```
- Same `hasPartialCoverageSignals` predicate drives the headline note, so non-zero drops also trip the blockquote subtitle.

### Tests (`internal/report/digest_test.go`)

- `TestBuildDetectMarkdown_CoverageScopeBlock_AlwaysPresent` — Coverage block ships in both detect and defend digests.
- `TestBuildDetectMarkdown_CoverageScopeBlock_PartialWhenSendmmsgFirstOnly` — ⚠️ in heading + Coverage block cell flips when `SendmmsgFirstOnly > 0`.
- `TestBuildDetectMarkdown_RingbufDropKPIRow` — aggregate row appears when drops > 0, hidden otherwise.
- All existing tests still pass, including `TestBuildDetectMarkdown_VisibleLineBudget` (visible portion ≤ 30 lines).

## Test plan

- [x] `go vet ./internal/report/...`
- [x] `go test ./internal/report/... -count=1` — all suites green
- [x] `bash scripts/check-gofmt.sh && bash scripts/check-encoding.sh`
- [ ] CI: `coldstep-ci-runner.yml` unit / unit-arm64 / detect-mode / defend-mode all green
