### PR TITLE
fix(bpf,defend): pre-check kernel BTF for socket_sendpage LSM hook

### DIFF
--- a/internal/bpf/defend/loader.go
+++ b/internal/bpf/defend/loader.go
@@ -4,8 +4,10 @@ package defend
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/btf"
 )
 
 // LoadDefendObjectsForKernel populates obj with the cgroup defend programs
@@ -39,11 +41,37 @@ func LoadDefendObjectsForKernel(obj *DefendObjects, wantLSM bool) error {
 		// sendpage_observed lives in the LSM section; strip it when LSM is
 		// disabled so we don't pin a per-cpu counter nobody reads.
 		delete(spec.Maps, "sendpage_observed")
+	} else if !kernelHasLSMHook("socket_sendpage") {
+		// Kernel 6.5+ removed the socket_sendpage LSM hook (proto_ops
+		// ->sendpage and security_socket_sendpage were dropped together).
+		// On those kernels sendfile(2)/splice(2) route through sendmsg
+		// with MSG_SPLICE_PAGES, so cgroup/sendmsg4 + lsm/socket_sendmsg
+		// already cover them. Leaving the program in the spec would fail
+		// prog_load (ENOENT on the BTF attach target) and bring down the
+		// whole defend collection. The sendpage_observed counter is also
+		// stripped because nothing will write to it.
+		delete(spec.Programs, "lsm_socket_sendpage")
+		delete(spec.Maps, "sendpage_observed")
 	}
 
 	coll, err := ebpf.NewCollection(spec)
 	if err != nil {
-		return err
+		// Defensive fallback: BTF lookup may have succeeded but prog_load
+		// still rejected sendpage for some other reason (BTF mismatch,
+		// CONFIG_SECURITY_NETWORK off, etc.). Strip the program and retry
+		// once so the rest of the LSM section still loads.
+		if wantLSM && isSendpageLoadFailure(err) {
+			spec2, err2 := LoadDefend()
+			if err2 != nil {
+				return err2
+			}
+			delete(spec2.Programs, "lsm_socket_sendpage")
+			delete(spec2.Maps, "sendpage_observed")
+			coll, err = ebpf.NewCollection(spec2)
+		}
+		if err != nil {
+			return err
+		}
 	}
 	success := false
 	defer func() {
@@ -197,4 +225,29 @@ func detachMapIfPresent(coll *ebpf.Collection, name string, dst **ebpf.Map) {
 		*dst = m
 		delete(coll.Maps, name)
 	}
+}
+
+// kernelHasLSMHook reports whether the running kernel's BTF declares
+// bpf_lsm_<name>, indicating the LSM hook is attachable. Returns false
+// when kernel BTF cannot be loaded or the symbol is absent — caller
+// should treat false as "do not load this hook".
+func kernelHasLSMHook(name string) bool {
+	spec, err := btf.LoadKernelSpec()
+	if err != nil {
+		return false
+	}
+	var fn *btf.Func
+	return spec.TypeByName("bpf_lsm_"+name, &fn) == nil
+}
+
+// isSendpageLoadFailure pattern-matches an ebpf.NewCollection error to
+// detect prog_load rejection of lsm_socket_sendpage specifically. Used
+// as a defensive fallback when the BTF pre-check missed the kernel's
+// removal of the hook.
+func isSendpageLoadFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "lsm_socket_sendpage") || strings.Contains(s, "socket_sendpage")
 }


### PR DESCRIPTION
## Summary

PR #157 (sendfile/splice defend gap) landed on main with failing CI: every integration job and the defend-mode workflow reject the new `lsm/socket_sendpage` program at prog_load with `socket_sendpage LSM hook not supported`. Kernel 6.5 removed the hook (`proto_ops->sendpage` and `security_socket_sendpage` were dropped together), and GHA hosted runners are on kernel 6.8.

This fix makes `defend.LoadDefendObjectsForKernel` query kernel BTF for `bpf_lsm_socket_sendpage` and strip the program + its `sendpage_observed` observe counter from the spec when the symbol is absent — so `ebpf.NewCollection` no longer trips on a hook the kernel removed. On those kernels sendfile/splice route through `sendmsg(MSG_SPLICE_PAGES)` and are already covered by `cgroup/sendmsg4` + `lsm/socket_sendmsg`, so dropping the program is a no-op for coverage. A defensive retry-without-sendpage path handles the edge case where BTF lookup succeeds but prog_load still rejects the hook (CONFIG mismatch, BTF skew).

The hook still loads normally on older kernels (5.15 era) that retain `socket_sendpage`, closing the original sendfile/splice gap as intended.

## Test plan

- [ ] `hosted-linux / integration (ubuntu-latest|22.04|22.04-arm|24.04-arm)` — must all pass
- [ ] `hosted-linux / defend-mode` — must pass (agent reaches ready)
- [ ] `hosted-linux / detect-mode` — must still pass (no regression)
- [ ] `hosted-linux / unit` + `unit-arm64` — must still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
