### PR TITLE
sec(policy,digest): DNS allowlist trust model hardening (P1-1)

### DIFF
--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -116,6 +116,23 @@ func Run(ctx context.Context, cfg config.Config) error {
 	if err != nil {
 		return err
 	}
+	allowlistCompileTime := time.Now()
+	stats.setAllowlistCompileSnapshot(
+		allowlistCompileTime,
+		defendCompiled.AllowedIPv4.Len(),
+		defendCompiled.UnresolvedDomains,
+		defendCompiled.WildcardRiskDomains,
+	)
+	for _, d := range defendCompiled.UnresolvedDomains {
+		slog.Warn("allowlist domain did not resolve", "domain", d)
+	}
+	if cfg.Mode == config.ModeDefend && len(defendCompiled.UnresolvedDomains) > 0 {
+		slog.Warn("allowlist domains unresolved — legitimate traffic to these domains may be blocked",
+			"count", len(defendCompiled.UnresolvedDomains))
+	}
+	for _, d := range defendCompiled.WildcardRiskDomains {
+		slog.Warn("high-risk wildcard in allowlist", "domain", d)
+	}
 
 	dnsCache := NewDNSCache()
 	dnsCache.SetBPFFailureCallback(stats.addDNSCacheUpdateFailure)
@@ -615,6 +632,10 @@ func Run(ctx context.Context, cfg config.Config) error {
 					meta.Capabilities = make(map[string]bool)
 				}
 				meta.Capabilities["fs_events"] = true
+			}
+			meta.AllowlistIPCount = defendCompiled.AllowedIPv4.Len()
+			if len(defendCompiled.WildcardRiskDomains) > 0 {
+				meta.WildcardRiskDomains = append([]string(nil), defendCompiled.WildcardRiskDomains...)
 			}
 			if err := telemetry.AppendJSONL(cfg.EventsLogPath, meta, signer); err != nil {
 				slog.Warn("meta jsonl", "err", err)

--- a/internal/agent/agent_linux_digest.go
+++ b/internal/agent/agent_linux_digest.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/coldstep-io/coldstep/internal/config"
 	"github.com/coldstep-io/coldstep/internal/proctree"
@@ -175,5 +176,14 @@ func buildDigestInput(
 	if seqLast == 0 {
 		in.SeqFirst = 0
 	}
+
+	compileTime, _, unresolved, wildcardRisk := stats.allowlistSnapshot()
+	in.UnresolvedAllowlistDomains = unresolved
+	in.WildcardRiskDomains = wildcardRisk
+	if !compileTime.IsZero() {
+		in.AllowlistAgeMinutes = time.Since(compileTime).Minutes()
+	}
+	in.DomainContactCounts = stats.snapshotDomainCounts()
+
 	return in
 }

--- a/internal/agent/agent_linux_ring_read.go
+++ b/internal/agent/agent_linux_ring_read.go
@@ -300,6 +300,7 @@ func readConnectRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader,
 		}
 		cl := pol.Classify(fqdn, ip)
 		stats.addTCP(cl)
+		stats.incDomainCount(fqdn)
 
 		ts := time.Now().UTC().Format(time.RFC3339Nano)
 		notes := "—"
@@ -449,6 +450,7 @@ func readUDPRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, dns
 		}
 		cl := pol.Classify(fqdn, ip)
 		stats.addUDP(cl)
+		stats.incDomainCount(fqdn)
 
 		ts := time.Now().UTC().Format(time.RFC3339Nano)
 		rows.addUDP(report.UDPDigestRow{

--- a/internal/agent/agent_linux_state.go
+++ b/internal/agent/agent_linux_state.go
@@ -20,6 +20,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/coldstep-io/coldstep/internal/policy"
 	"github.com/coldstep-io/coldstep/internal/report"
@@ -64,6 +65,17 @@ type runStats struct {
 	bpfHeartbeatFailures            int
 	policyCounts                    map[string]int
 	droppedCounts                   map[string]int
+
+	// Allowlist compile snapshot (P1-1). Set once at startup after
+	// CompileDomainAllowlist; read at shutdown by buildDigestInput.
+	allowlistCompileTime         time.Time
+	allowlistIPCount             int
+	allowlistUnresolvedDomains   []string
+	allowlistWildcardRiskDomains []string
+
+	// dstDomainCounts maps observed FQDN → connection-event count across TCP +
+	// UDP egress (P1-1 6e). Empty FQDNs are ignored.
+	dstDomainCounts map[string]int
 }
 
 func newRunStats() *runStats {
@@ -547,6 +559,56 @@ func (s *runStats) counts() (execN, tcpN, udpN, httpN, tlsN, fsN int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.execN, s.tcpN, s.udpN, s.httpN, s.tlsN, s.fsN
+}
+
+// setAllowlistCompileSnapshot records a one-shot snapshot of the resolved
+// allowlist at agent startup. Inputs are copied so the caller can free the
+// originals. Used by the shutdown digest to surface unresolved domains, the
+// IPv4-count snapshot, the wildcard-risk list, and the age-since-compile note.
+func (s *runStats) setAllowlistCompileSnapshot(t time.Time, ipCount int, unresolved, wildcardRisk []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.allowlistCompileTime = t
+	s.allowlistIPCount = ipCount
+	s.allowlistUnresolvedDomains = slices.Clone(unresolved)
+	s.allowlistWildcardRiskDomains = slices.Clone(wildcardRisk)
+}
+
+// allowlistSnapshot returns a copy of the recorded compile-time snapshot.
+func (s *runStats) allowlistSnapshot() (compileTime time.Time, ipCount int, unresolved []string, wildcardRisk []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.allowlistCompileTime, s.allowlistIPCount,
+		slices.Clone(s.allowlistUnresolvedDomains),
+		slices.Clone(s.allowlistWildcardRiskDomains)
+}
+
+// incDomainCount bumps the per-FQDN observation counter (P1-1 6e). No-op for
+// empty domain.
+func (s *runStats) incDomainCount(domain string) {
+	if domain == "" {
+		return
+	}
+	s.mu.Lock()
+	if s.dstDomainCounts == nil {
+		s.dstDomainCounts = make(map[string]int)
+	}
+	s.dstDomainCounts[domain]++
+	s.mu.Unlock()
+}
+
+// snapshotDomainCounts returns a copy of the per-FQDN observation counters.
+func (s *runStats) snapshotDomainCounts() map[string]int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.dstDomainCounts) == 0 {
+		return nil
+	}
+	out := make(map[string]int, len(s.dstDomainCounts))
+	for k, v := range s.dstDomainCounts {
+		out[k] = v
+	}
+	return out
 }
 
 // snapshotPolicyCounts returns a copy of policy classification counters for digests.

--- a/internal/policy/allowlist.go
+++ b/internal/policy/allowlist.go
@@ -82,9 +82,47 @@ func (s IPv4Set) ForEach(fn func(k [4]byte)) {
 
 // CompileResult is the deterministic output from allowlist compilation.
 type CompileResult struct {
-	Domains           []string
-	AllowedIPv4       IPv4Set
-	UnresolvedDomains []string
+	Domains             []string
+	AllowedIPv4         IPv4Set
+	UnresolvedDomains   []string
+	WildcardRiskDomains []string
+}
+
+// highRiskWildcardSuffixes lists shared-infrastructure DNS suffixes where a
+// `*.<suffix>` allowlist entry grants reach to a multi-tenant surface (any
+// GitHub-hosted user bucket, any S3 tenant, any Cloudfront/Pages-hosted
+// domain). Operators usually want a tighter literal hostname; the wildcard is
+// flagged as a "risk" for visibility in the digest, not blocked.
+var highRiskWildcardSuffixes = []string{
+	".githubusercontent.com",
+	".s3.amazonaws.com",
+	".blob.core.windows.net",
+	".azureedge.net",
+	".cloudfront.net",
+	".r2.dev",
+	".pages.dev",
+}
+
+// scoreWildcardRisk returns the subset of domains that are wildcard entries
+// (`*.<suffix>`) whose suffix matches one of the known multi-tenant
+// shared-infrastructure suffixes. Output preserves input order after the
+// caller's normalization. Operators see these in the digest so they can decide
+// whether a tighter literal entry would suffice.
+func scoreWildcardRisk(domains []string) []string {
+	var out []string
+	for _, d := range domains {
+		if !strings.HasPrefix(d, "*.") {
+			continue
+		}
+		suffix := d[1:] // strip the leading '*', keep the '.'
+		for _, risky := range highRiskWildcardSuffixes {
+			if strings.EqualFold(suffix, risky) {
+				out = append(out, d)
+				break
+			}
+		}
+	}
+	return out
 }
 
 // CompileDomainAllowlist normalizes and resolves domain allowlist entries.
@@ -183,6 +221,14 @@ func CompileDomainAllowlist(ctx context.Context, domains []string, resolver Look
 	}
 
 	slices.Sort(result.UnresolvedDomains)
+	result.WildcardRiskDomains = scoreWildcardRisk(normalized)
+
+	slog.Info("allowlist compiled",
+		"domains", len(normalized),
+		"resolved_ips", result.AllowedIPv4.Len(),
+		"unresolved_count", len(result.UnresolvedDomains),
+		"wildcard_risk_count", len(result.WildcardRiskDomains),
+	)
 	return result
 }
 

--- a/internal/policy/allowlist_test.go
+++ b/internal/policy/allowlist_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net"
 	"reflect"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -170,6 +171,60 @@ func TestCompileDomainAllowlist_MaxAttemptsFloor(t *testing.T) {
 	_ = CompileDomainAllowlist(ctx, []string{"a.example.com"}, resolver, 0)
 	if calls != 1 {
 		t.Fatalf("resolver calls: got %d want 1 (ip4 once) when maxAttempts <= 0", calls)
+	}
+}
+
+func TestScoreWildcardRisk(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{name: "empty", in: nil, want: nil},
+		{name: "no wildcards", in: []string{"github.com", "api.github.com"}, want: nil},
+		{name: "non-risky wildcard", in: []string{"*.example.org"}, want: nil},
+		{name: "githubusercontent", in: []string{"*.githubusercontent.com"}, want: []string{"*.githubusercontent.com"}},
+		{name: "s3 amazonaws", in: []string{"*.s3.amazonaws.com"}, want: []string{"*.s3.amazonaws.com"}},
+		{
+			name: "azure + cdn",
+			in:   []string{"*.blob.core.windows.net", "*.azureedge.net"},
+			want: []string{"*.blob.core.windows.net", "*.azureedge.net"},
+		},
+		{
+			name: "cloudfront + r2 + pages",
+			in:   []string{"*.cloudfront.net", "*.r2.dev", "*.pages.dev"},
+			want: []string{"*.cloudfront.net", "*.r2.dev", "*.pages.dev"},
+		},
+		{
+			name: "mixed",
+			in:   []string{"api.github.com", "*.cloudfront.net", "*.example.org", "*.s3.amazonaws.com"},
+			want: []string{"*.cloudfront.net", "*.s3.amazonaws.com"},
+		},
+		{name: "case-insensitive suffix match", in: []string{"*.S3.AMAZONAWS.COM"}, want: []string{"*.S3.AMAZONAWS.COM"}},
+		{name: "non-risky wildcard suffix", in: []string{"*.internal.corp"}, want: nil},
+		{name: "literal host on shared suffix is not flagged", in: []string{"foo.s3.amazonaws.com"}, want: nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := scoreWildcardRisk(tc.in)
+			if !slices.Equal(got, tc.want) {
+				t.Fatalf("scoreWildcardRisk(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCompileDomainAllowlist_PopulatesWildcardRiskDomains(t *testing.T) {
+	ctx := context.Background()
+	resolver := func(_ context.Context, _, _ string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("9.9.9.9")}, nil
+	}
+	got := CompileDomainAllowlist(ctx,
+		[]string{"api.github.com", "*.s3.amazonaws.com", "*.example.org"},
+		resolver, 1)
+	want := []string{"*.s3.amazonaws.com"}
+	if !slices.Equal(got.WildcardRiskDomains, want) {
+		t.Fatalf("WildcardRiskDomains: got %v want %v", got.WildcardRiskDomains, want)
 	}
 }
 

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -845,10 +845,78 @@ func writeFooter(b *strings.Builder, in DigestInput) {
 	fmt.Fprintf(b, "> Full event log: `%s`\n", sanitizeCell(path))
 }
 
+// writeAllowlistTrust emits P1-1 (DNS Allowlist Trust Model hardening)
+// surface: unresolved allowlist domains (defend-mode warning), high-risk
+// wildcard entries, and a TTL-age info note when the compile is >5 minutes
+// old. The section is skipped when there is nothing to show.
+func writeAllowlistTrust(b *strings.Builder, in DigestInput) {
+	hasUnresolved := isBlockingDigestMode(in.DefendMode) && len(in.UnresolvedAllowlistDomains) > 0
+	hasWildcard := len(in.WildcardRiskDomains) > 0
+	hasAgeNote := in.AllowlistAgeMinutes > 5
+	if !hasUnresolved && !hasWildcard && !hasAgeNote {
+		return
+	}
+
+	b.WriteString("### Allowlist trust model\n\n")
+
+	if hasUnresolved {
+		b.WriteString("> ⚠️ **Unresolved allowlist domains** — legitimate traffic to these domains may be blocked under defend.\n>\n")
+		for _, d := range in.UnresolvedAllowlistDomains {
+			b.WriteString(fmt.Sprintf("> - `%s`\n", sanitizeCell(d)))
+		}
+		b.WriteString("\n")
+	}
+
+	if hasWildcard {
+		b.WriteString("> ⚠️ **High-risk wildcards** — these entries grant reach across a shared multi-tenant surface. Prefer tighter literal hostnames where possible.\n>\n")
+		for _, d := range in.WildcardRiskDomains {
+			b.WriteString(fmt.Sprintf("> - `%s`\n", sanitizeCell(d)))
+		}
+		b.WriteString("\n")
+	}
+
+	if hasAgeNote {
+		b.WriteString(fmt.Sprintf("> ℹ️ Allowlist was compiled %.0f minutes ago — DNS TTLs may have expired. Consider shorter jobs or re-running for long CI pipelines.\n\n",
+			in.AllowlistAgeMinutes))
+	}
+}
+
+// writeDomainContactCounts emits a collapsible section listing observed FQDNs
+// across TCP + UDP egress sorted by count descending. Skipped when no FQDNs
+// were observed.
+func writeDomainContactCounts(b *strings.Builder, in DigestInput) {
+	if len(in.DomainContactCounts) == 0 {
+		return
+	}
+	type kv struct {
+		k string
+		v int
+	}
+	list := make([]kv, 0, len(in.DomainContactCounts))
+	for k, v := range in.DomainContactCounts {
+		list = append(list, kv{k, v})
+	}
+	sort.Slice(list, func(i, j int) bool {
+		if list[i].v != list[j].v {
+			return list[i].v > list[j].v
+		}
+		return list[i].k < list[j].k
+	})
+
+	b.WriteString("<details>\n<summary><strong>Domain contact counts</strong></summary>\n\n")
+	b.WriteString("Observation counts per FQDN across TCP + UDP egress (correlated via DNS cache).\n\n")
+	b.WriteString("| Domain | Count |\n|:--|--:|\n")
+	for _, e := range list {
+		b.WriteString(fmt.Sprintf("| `%s` | %d |\n", sanitizeCell(e.k), e.v))
+	}
+	b.WriteString("\n</details>\n\n")
+}
+
 // BuildDetectMarkdown returns GFM + the GFM HTML subset (<details>, <summary>,
 // <br>, <hr>, <table>) for `.coldstep-detect.md` / GITHUB_STEP_SUMMARY. The
 // visible portion (above the Technical details fold) is intentionally compact:
-// header, one-row KPI, optional Top destinations, Triage, footer.
+// header, one-row KPI, optional Top destinations, Triage, footer. Allowlist
+// trust-model warnings (P1-1) surface above the fold when applicable.
 func BuildDetectMarkdown(in DigestInput) string {
 	max := in.MaxRowsPerSection
 	if max <= 0 {
@@ -861,6 +929,8 @@ func BuildDetectMarkdown(in DigestInput) string {
 	writeCoverage(&b, in)
 	writeTopDestinations(&b, in)
 	writeTriageTable(&b, in)
+	writeAllowlistTrust(&b, in)
+	writeDomainContactCounts(&b, in)
 	writeTechnicalDetails(&b, in, max)
 	writeFooter(&b, in)
 

--- a/internal/report/digest_test.go
+++ b/internal/report/digest_test.go
@@ -628,6 +628,25 @@ func TestBuildDetectMarkdown_CoverageScopeBlock_PartialWhenSendmmsgFirstOnly(t *
 	}
 }
 
+func TestBuildDetectMarkdown_AllowlistTrust_DefendUnresolved(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{
+		DefendMode:                 "defend",
+		UnresolvedAllowlistDomains: []string{"down.example.com", "ipv6-only.example.com"},
+		MaxRowsPerSection:          50,
+	})
+	for _, needle := range []string{
+		"### Allowlist trust model",
+		"Unresolved allowlist domains",
+		"`down.example.com`",
+		"`ipv6-only.example.com`",
+		"may be blocked",
+	} {
+		if !strings.Contains(md, needle) {
+			t.Fatalf("missing %q in:\n%s", needle, md)
+		}
+	}
+}
+
 func TestBuildDetectMarkdown_RingbufDropKPIRow(t *testing.T) {
 	t.Parallel()
 	md := BuildDetectMarkdown(DigestInput{
@@ -835,5 +854,91 @@ func TestBuildDetectMarkdown_SendpageObserved_ZeroIsClean(t *testing.T) {
 	}
 	if strings.Contains(md, "lsm/socket_sendpage") {
 		t.Fatalf("sendpage KPI row must not appear when counter is zero:\n%s", md)
+	}
+}
+
+func TestBuildDetectMarkdown_AllowlistTrust_UnresolvedSuppressedInDetect(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{
+		UnresolvedAllowlistDomains: []string{"down.example.com"},
+		MaxRowsPerSection:          50,
+	})
+	if strings.Contains(md, "Unresolved allowlist domains") {
+		t.Fatalf("detect mode should not surface unresolved warning; got:\n%s", md)
+	}
+}
+
+func TestBuildDetectMarkdown_AllowlistTrust_WildcardRisk(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{
+		WildcardRiskDomains: []string{"*.s3.amazonaws.com", "*.cloudfront.net"},
+		MaxRowsPerSection:   50,
+	})
+	for _, needle := range []string{
+		"### Allowlist trust model",
+		"High-risk wildcards",
+		"`*.s3.amazonaws.com`",
+		"`*.cloudfront.net`",
+	} {
+		if !strings.Contains(md, needle) {
+			t.Fatalf("missing %q in:\n%s", needle, md)
+		}
+	}
+}
+
+func TestBuildDetectMarkdown_AllowlistTrust_AgeInfo(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{
+		AllowlistAgeMinutes: 17.4,
+		MaxRowsPerSection:   50,
+	})
+	if !strings.Contains(md, "ℹ️") || !strings.Contains(md, "17 minutes ago") {
+		t.Fatalf("expected age info note; got:\n%s", md)
+	}
+
+	mdFresh := BuildDetectMarkdown(DigestInput{
+		AllowlistAgeMinutes: 2.0,
+		MaxRowsPerSection:   50,
+	})
+	if strings.Contains(mdFresh, "minutes ago") {
+		t.Fatalf("should not surface TTL hint when allowlist is fresh; got:\n%s", mdFresh)
+	}
+}
+
+func TestBuildDetectMarkdown_AllowlistTrust_HiddenWhenEmpty(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{MaxRowsPerSection: 50})
+	if strings.Contains(md, "### Allowlist trust model") {
+		t.Fatalf("section should be suppressed when nothing to show; got:\n%s", md)
+	}
+}
+
+func TestBuildDetectMarkdown_DomainContactCounts_SortedDescending(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{
+		DomainContactCounts: map[string]int{
+			"api.github.com":                5,
+			"registry.npmjs.org":            12,
+			"sts.amazonaws.com":             2,
+			"objects.githubusercontent.com": 7,
+		},
+		MaxRowsPerSection: 50,
+	})
+	if !strings.Contains(md, "Domain contact counts") {
+		t.Fatalf("missing Domain contact counts section in:\n%s", md)
+	}
+	// Highest count must appear before the lower ones.
+	npmIdx := strings.Index(md, "registry.npmjs.org")
+	githubIdx := strings.Index(md, "objects.githubusercontent.com")
+	apiIdx := strings.Index(md, "api.github.com")
+	stsIdx := strings.Index(md, "sts.amazonaws.com")
+	if npmIdx < 0 || githubIdx < 0 || apiIdx < 0 || stsIdx < 0 {
+		t.Fatalf("missing domain rows in:\n%s", md)
+	}
+	if !(npmIdx < githubIdx && githubIdx < apiIdx && apiIdx < stsIdx) {
+		t.Fatalf("expected descending order by count; npm=%d github=%d api=%d sts=%d",
+			npmIdx, githubIdx, apiIdx, stsIdx)
+	}
+}
+
+func TestBuildDetectMarkdown_DomainContactCounts_HiddenWhenEmpty(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{MaxRowsPerSection: 50})
+	if strings.Contains(md, "Domain contact counts") {
+		t.Fatalf("section should be suppressed when empty; got:\n%s", md)
 	}
 }

--- a/internal/report/digest_types.go
+++ b/internal/report/digest_types.go
@@ -229,6 +229,24 @@ type DigestInput struct {
 	BPFMapIntegrityFailures        int
 	BPFAuditRingbufReserveFailures int
 	DroppedCounts                  map[string]int
+
+	// P1-1 DNS Allowlist Trust Model hardening surface.
+	//
+	// UnresolvedAllowlistDomains lists allowlist domains that did not yield any
+	// IPv4 A-record at compile time. Empty when all domains resolved or no
+	// allowlist was compiled.
+	UnresolvedAllowlistDomains []string
+	// WildcardRiskDomains lists allowlist entries that match a known multi-tenant
+	// shared-infrastructure wildcard surface (e.g. `*.s3.amazonaws.com`). Empty
+	// when no such entries are present.
+	WildcardRiskDomains []string
+	// AllowlistAgeMinutes is minutes between allowlist compile time and digest
+	// build time. Surfaces a TTL re-validation hint for long jobs; zero when no
+	// allowlist was compiled.
+	AllowlistAgeMinutes float64
+	// DomainContactCounts maps observed FQDN → observation count across TCP +
+	// UDP egress. Sorted descending by count in the digest section.
+	DomainContactCounts map[string]int
 }
 
 // TruncateUTF8ToMaxBytes cuts s so len(result) <= maxBytes without splitting a UTF-8 code point.

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -26,7 +26,14 @@ type MetaEvent struct {
 	BPF           []BPFStatus     `json:"bpf"`
 	Capabilities  map[string]bool `json:"capabilities,omitempty"`
 	DetectProfile string          `json:"detect_profile,omitempty"` // "standard" | "enhanced" (from COLDSTEP_DETECT_PROFILE)
-	Sig           string          `json:"sig,omitempty"`
+	// AllowlistIPCount snapshots the number of unique IPv4 addresses produced by
+	// compiling the domain allowlist (P1-1 6a). Zero when not in defend mode.
+	AllowlistIPCount int `json:"allowlist_ip_count,omitempty"`
+	// WildcardRiskDomains lists allowlist entries (e.g. `*.s3.amazonaws.com`)
+	// whose wildcard suffix matches a known multi-tenant shared-infrastructure
+	// surface (P1-1 6c). Operators can review and tighten if desired.
+	WildcardRiskDomains []string `json:"wildcard_risk_domains,omitempty"`
+	Sig                 string   `json:"sig,omitempty"`
 }
 
 // MetaGitHub holds non-secret GitHub Actions context.


### PR DESCRIPTION
## Summary

P1-1 of the security hardening plan: six telemetry + digest surfaces around the resolved DNS allowlist so operators can audit and tighten the trust model. Pure Go — no BPF / generated-stub changes.

| Sub-item | Size | What it adds |
|--|--|--|
| **6a** | S | `slog.Info` at end of `CompileDomainAllowlist` with domain + resolved-IP counts; `AllowlistIPCount` on `MetaEvent` JSONL. |
| **6d** | S | `slog.Warn` per unresolved domain + defend-mode aggregate; warning "Allowlist trust model" digest box (defend only) listing them. |
| **6b** | M | Compile-time snapshot recorded on `runStats`; info digest note when allowlist age > 5 min ("DNS TTLs may have expired"). |
| **6c** | M | New `scoreWildcardRisk` flags entries against known multi-tenant shared-infra suffixes (s3.amazonaws.com, githubusercontent.com, cloudfront.net, blob.core.windows.net, azureedge.net, r2.dev, pages.dev). Surfaced via `slog.Warn`, `MetaEvent.WildcardRiskDomains`, and a digest box. |
| **6e** | M | Thread-safe `runStats.incDomainCount` incremented from TCP + UDP ring readers when DNS-cache correlation yields a non-empty FQDN; rendered as a collapsible "Domain contact counts" digest section sorted descending. |

## Files changed

- `internal/policy/allowlist.go` — `CompileResult.WildcardRiskDomains`, `scoreWildcardRisk`, end-of-compile `slog.Info`.
- `internal/policy/allowlist_test.go` — table tests for `scoreWildcardRisk`, `CompileDomainAllowlist` populates `WildcardRiskDomains`.
- `internal/telemetry/event.go` — `MetaEvent.AllowlistIPCount`, `MetaEvent.WildcardRiskDomains`.
- `internal/agent/agent_linux.go` — capture compile-time snapshot, log unresolved + wildcard warnings, wire meta event additions.
- `internal/agent/agent_linux_state.go` — `setAllowlistCompileSnapshot`, `allowlistSnapshot`, `incDomainCount`, `snapshotDomainCounts`.
- `internal/agent/agent_linux_digest.go` — populate new `DigestInput` fields from `runStats`.
- `internal/agent/agent_linux_ring_read.go` — call `stats.incDomainCount(fqdn)` from TCP + UDP readers.
- `internal/report/digest_types.go` — new `DigestInput` fields.
- `internal/report/digest.go` — `writeAllowlistTrust`, `writeDomainContactCounts` writers + wiring.
- `internal/report/digest_test.go` — coverage for trust-model block (defend-only unresolved, wildcard list, age info, hidden-when-empty) and domain contact section (sort order, hidden when empty).

## Test plan

- [x] `go test ./internal/policy/... ./internal/report/... ./internal/telemetry/... ./internal/agent/... -count=1` (passes)
- [x] `go test -race -count=1` on the same set (passes)
- [x] `go vet ./...` (clean)
- [x] `staticcheck` on touched packages (clean)
- [x] `gofmt -l internal/ cmd/` (clean)
- [ ] CI runs full matrix (unit + integration + detect-mode + defend-mode)
