### PR TITLE
sec(report,integrity): learning-mode poisoning mitigations (P1-2)

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -15,6 +15,29 @@ If you still have `mode: enforce` or `CI_GUARD_MODE: enforce`, replace with **`d
 
 ---
 
+## Promoting detect observations to an allowlist
+
+Detect mode records **everything** your build talks to. The whole point is to use those JSONL records to build the `allow:` list you will run in `defend`. **A supply-chain compromise that occurs while you are still recording will get baked straight into the allowlist** — there is no built-in trust signal that says "this domain is legitimate, that one is the attacker." Treat allowlist promotion as a code change with the same review bar as any other security-sensitive merge.
+
+Recommended workflow:
+
+1. **Collect ≥ 3 builds.** Run detect across at least three different PRs or branches (preferably touching different parts of the codebase). One short run on one branch is the easiest poisoning target.
+2. **Diff against a baseline.** Before promoting domains to `allow:`, compare the new JSONL against a known-good baseline:
+   ```bash
+   coldstep-report diff \
+     --baseline baseline.jsonl \
+     --current  .coldstep-events.jsonl \
+     --summary  diff-summary.md \
+     --fail-on-new-domain
+   ```
+   `--fail-on-new-domain` exits non-zero when any FQDN appears in the current run but not the baseline. Wire it into CI on PRs that touch `.github/coldstep/egress-allow.txt`.
+3. **Reject short windows.** Use `coldstep-report build-model --min-observation-hours 24` (or set `COLDSTEP_MIN_OBS_HOURS=24`) so a run that observed less than 24 hours of wall-clock traffic flags `short_observation_window=true` in the model — `coldstep-report assert-integrity` then hard-fails. Tune the threshold to whatever observation period your team actually trusts.
+4. **Require a second-engineer review.** Newly observed domains in the diff output get a separate human approval before they land in the `allow:` list. Treat the diff as a code review, not as an automated step that closes itself.
+
+`build-model` additionally flags **suspicious domains** in the report model (`suspicious_domains` field): high-entropy subdomains (Shannon entropy > 3.5 bits/char on labels longer than 8 chars), domains observed only once across the entire run, and HTTP/TLS observations on non-standard ports. `render-summary` surfaces a `[!WARNING]` block when any are present so reviewers see them before approving the diff.
+
+---
+
 ## Bare minimum
 
 Smallest workflow that runs Coldstep in **detect** mode: **`checkout` → single `uses:` block → your steps**. The action's node24 `pre` hook starts the agent before your build steps; `post` flushes the digest at job end.

--- a/cmd/coldstep-report/assert_integrity.go
+++ b/cmd/coldstep-report/assert_integrity.go
@@ -37,6 +37,17 @@ func assertIntegrity(args []string) error {
 		return err
 	}
 
+	// P1-2 / 4a: hard-fail when build-model marked the observation window as
+	// too short. Allowlist promotion off a short detect window is a known
+	// poisoning vector — surface it as an actionable workflow error.
+	if m.ShortObservationWindow {
+		fmt.Printf(
+			"::error title=Coldstep short observation window::observation window %.2fh is shorter than required minimum %.2fh — refusing to promote allowlist (P1-2)\n",
+			m.ObservationHours, m.MinObservationHours,
+		)
+		return errors.New("integrity gate verdict=fail (short_observation_window)")
+	}
+
 	switch m.CapabilityEval.Verdict {
 	case integrity.VerdictPass:
 		fmt.Printf("Coldstep Integrity Pass: verdict=%s score=%d\n", m.CapabilityEval.Verdict, m.CapabilityEval.Score)

--- a/cmd/coldstep-report/build_model.go
+++ b/cmd/coldstep-report/build_model.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -22,6 +24,11 @@ func buildModel(args []string) error {
 	current := fs.String("current", envOr("COLDSTEP_REPORT_CURRENT_JSONL", filepath.Join(envOr("GITHUB_WORKSPACE", "."), ".coldstep-events.jsonl")), "")
 	baseline := fs.String("baseline", envOr("COLDSTEP_REPORT_BASELINE_JSONL", ""), "")
 	out := fs.String("out", envOr("COLDSTEP_REPORT_MODEL_OUT", filepath.Join(envOr("GITHUB_WORKSPACE", "."), ".coldstep-report-model.json")), "")
+	minObs := fs.Float64(
+		"min-observation-hours",
+		parseFloatEnv("COLDSTEP_MIN_OBS_HOURS"),
+		"minimum required wall-clock observation window in hours; sets short_observation_window=true on the model when shorter (P1-2 learning-mode-poisoning gate)",
+	)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -61,6 +68,17 @@ func buildModel(args []string) error {
 		return err
 	}
 
+	observationHours := model.ObservationHours(events)
+	short := false
+	if *minObs > 0 && observationHours < *minObs {
+		short = true
+		fmt.Fprintf(
+			os.Stderr,
+			"::warning title=Coldstep short observation window::observation window %.2fh is shorter than --min-observation-hours=%.2f; allowlist promotion is risky (P1-2)\n",
+			observationHours, *minObs,
+		)
+	}
+
 	m := &model.Report{
 		SchemaVersion: model.SchemaVersion,
 		ProducedBy:    fmt.Sprintf("%s@%s", model.ProducedByPrefix, buildVersion),
@@ -72,15 +90,19 @@ func buildModel(args []string) error {
 			RunnerLabel:   os.Getenv("NS_RUNNER_LABEL"),
 			DetectProfile: prof,
 		},
-		CapabilityMatrix: model.BuildCapabilityMatrix(events),
-		EventsByType:     model.BuildEventsByType(events),
-		Timeline:         model.BuildTimeline(events),
-		EgressSankey:     model.BuildEgressSankey(events),
-		Diff:             model.BuildDiff(events, baseEvents),
-		IPClassification: []model.ClassifiedIndicator{}, // populated in Plan 3
-		CapabilityEval:   integrity.EvaluateForDetectProfile(events, prof),
-		OTX:              json.RawMessage(`null`),
-		RDNS:             json.RawMessage(`null`),
+		CapabilityMatrix:       model.BuildCapabilityMatrix(events),
+		EventsByType:           model.BuildEventsByType(events),
+		Timeline:               model.BuildTimeline(events),
+		EgressSankey:           model.BuildEgressSankey(events),
+		Diff:                   model.BuildDiff(events, baseEvents),
+		IPClassification:       []model.ClassifiedIndicator{}, // populated in Plan 3
+		CapabilityEval:         integrity.EvaluateForDetectProfile(events, prof),
+		OTX:                    json.RawMessage(`null`),
+		RDNS:                   json.RawMessage(`null`),
+		ObservationHours:       roundTo(observationHours, 4),
+		ShortObservationWindow: short,
+		MinObservationHours:    *minObs,
+		SuspiciousDomains:      model.BuildSuspiciousDomains(events),
 	}
 
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
@@ -128,4 +150,23 @@ func firstNonEmptyEnv(keys ...string) string {
 		}
 	}
 	return ""
+}
+
+// parseFloatEnv reads a float-valued env var. Returns 0 when unset, empty,
+// or unparseable (matches the "flag absent" default for --min-observation-hours).
+func parseFloatEnv(key string) float64 {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return 0
+	}
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+func roundTo(f float64, places int) float64 {
+	pow := math.Pow(10, float64(places))
+	return math.Round(f*pow) / pow
 }

--- a/cmd/coldstep-report/diff.go
+++ b/cmd/coldstep-report/diff.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/coldstep-io/coldstep/internal/report/model"
 	"github.com/coldstep-io/coldstep/internal/safepath"
@@ -16,6 +18,16 @@ func diffSummary(args []string) error {
 	baseline := fs.String("baseline", envOr("NS_BASELINE", ""), "")
 	summary := fs.String("summary", envOr("NS_SUMMARY", envOr("GITHUB_STEP_SUMMARY", "")), "")
 	marker := fs.String("marker", envOr("NS_MARKER", "coldstep-prev-diff"), "")
+	// P1-2 / 4c: strict mode. When set, any destination domain that
+	// appears in current but not in baseline causes a non-zero exit and
+	// is printed to stderr. The intended use is a baseline-diff gate in
+	// CI that catches a supply-chain compromise sneaking a new endpoint
+	// into the observed surface.
+	failOnNewDomain := fs.Bool(
+		"fail-on-new-domain",
+		false,
+		"exit non-zero when current introduces destination domains not in baseline (P1-2 learning-mode-poisoning gate)",
+	)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -59,6 +71,8 @@ func diffSummary(args []string) error {
 		result = "changed"
 	}
 
+	newDomains := newDestinationDomains(currentEvents, baselineEvents)
+
 	f, err := os.OpenFile(summaryPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return err
@@ -66,7 +80,7 @@ func diffSummary(args []string) error {
 
 	if _, err := fmt.Fprintf(
 		f,
-		"\n#### Previous-run traffic diff (compact)\n\n- %s.result=%s\n- %s.traffic_new=%d\n- %s.traffic_gone=%d\n- %s.traffic_changed=%d\n",
+		"\n#### Previous-run traffic diff (compact)\n\n- %s.result=%s\n- %s.traffic_new=%d\n- %s.traffic_gone=%d\n- %s.traffic_changed=%d\n- %s.new_domains=%d\n",
 		*marker,
 		result,
 		*marker,
@@ -75,9 +89,93 @@ func diffSummary(args []string) error {
 		len(diff.TrafficGone),
 		*marker,
 		len(diff.TrafficChanged),
+		*marker,
+		len(newDomains),
 	); err != nil {
 		_ = f.Close()
 		return err
 	}
-	return f.Close()
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	if *failOnNewDomain && len(newDomains) > 0 {
+		fmt.Fprintf(
+			os.Stderr,
+			"::error title=Coldstep new destination domains::%d domain(s) present in current but absent from baseline (P1-2): %s\n",
+			len(newDomains),
+			strings.Join(newDomains, ", "),
+		)
+		return fmt.Errorf("diff: %d new destination domain(s) not present in baseline", len(newDomains))
+	}
+	return nil
+}
+
+// newDestinationDomains returns the sorted set of FQDNs (falling back to
+// host/sni when fqdn is empty) that appear in current's egress events
+// (tcp/udp/http/tls) but never in baseline's. Bare IPs are excluded:
+// they are already covered by the traffic_new fingerprint count and
+// would create constant churn for runners whose dial-time IPs rotate.
+func newDestinationDomains(current, baseline []model.Event) []string {
+	base := destinationDomainSet(baseline)
+	cur := destinationDomainSet(current)
+	out := make([]string, 0)
+	for dom := range cur {
+		if _, ok := base[dom]; !ok {
+			out = append(out, dom)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func destinationDomainSet(events []model.Event) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, e := range events {
+		typ := e.AsString("type")
+		switch typ {
+		case "tcp", "udp", "http", "tls":
+		default:
+			continue
+		}
+		host := strings.TrimSpace(strings.ToLower(firstNonEmpty(e.AsString("fqdn"), e.AsString("host"), e.AsString("sni"))))
+		if host == "" {
+			continue
+		}
+		if isBareIP(host) {
+			continue
+		}
+		out[host] = struct{}{}
+	}
+	return out
+}
+
+func firstNonEmpty(args ...string) string {
+	for _, a := range args {
+		if a != "" {
+			return a
+		}
+	}
+	return ""
+}
+
+// isBareIP returns true when host is an IPv4 dotted-quad (all digit/dot
+// labels, four labels). Cheap heuristic — full ParseIP would also accept
+// IPv6 and CIDR variants we never emit here.
+func isBareIP(host string) bool {
+	labels := strings.Split(host, ".")
+	if len(labels) != 4 {
+		return false
+	}
+	for _, l := range labels {
+		if l == "" {
+			return false
+		}
+		for _, r := range l {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+	}
+	return true
 }

--- a/cmd/coldstep-report/learning_poisoning_test.go
+++ b/cmd/coldstep-report/learning_poisoning_test.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildModelEmitsObservationHours(t *testing.T) {
+	tmp := t.TempDir()
+	jsonl := filepath.Join(tmp, "events.jsonl")
+	body := `{"type":"meta","ts":"2026-05-18T10:00:00Z"}
+{"type":"exec","ts":"2026-05-18T11:00:00Z","comm":"bash"}
+{"type":"tcp","ts":"2026-05-18T13:00:00Z","dst":"1.1.1.1"}
+`
+	if err := os.WriteFile(jsonl, []byte(body), 0o644); err != nil {
+		t.Fatalf("setup jsonl: %v", err)
+	}
+	out := filepath.Join(tmp, "model.json")
+	if err := buildModel([]string{"--current=" + jsonl, "--out=" + out}); err != nil {
+		t.Fatalf("buildModel: %v", err)
+	}
+	m := readModelOrFail(t, out)
+	if got := floatField(m, "observation_hours"); got < 2.99 || got > 3.01 {
+		t.Errorf("observation_hours = %v; want ~3.0", got)
+	}
+	if _, ok := m["short_observation_window"]; ok {
+		// omitempty: when no threshold was supplied, the field should be absent
+		t.Errorf("short_observation_window unexpectedly present: %v", m["short_observation_window"])
+	}
+}
+
+func TestBuildModelFlagsShortObservationWindow(t *testing.T) {
+	tmp := t.TempDir()
+	jsonl := filepath.Join(tmp, "events.jsonl")
+	body := `{"type":"meta","ts":"2026-05-18T10:00:00Z"}
+{"type":"tcp","ts":"2026-05-18T10:30:00Z","dst":"1.1.1.1"}
+`
+	if err := os.WriteFile(jsonl, []byte(body), 0o644); err != nil {
+		t.Fatalf("setup jsonl: %v", err)
+	}
+	out := filepath.Join(tmp, "model.json")
+	if err := buildModel([]string{"--current=" + jsonl, "--out=" + out, "--min-observation-hours=24"}); err != nil {
+		t.Fatalf("buildModel: %v", err)
+	}
+	m := readModelOrFail(t, out)
+	if got := m["short_observation_window"]; got != true {
+		t.Fatalf("short_observation_window = %v; want true", got)
+	}
+	if got := floatField(m, "min_observation_hours"); got != 24 {
+		t.Errorf("min_observation_hours = %v; want 24", got)
+	}
+}
+
+func TestBuildModelEmitsSuspiciousDomains(t *testing.T) {
+	tmp := t.TempDir()
+	jsonl := filepath.Join(tmp, "events.jsonl")
+	body := `{"type":"meta","ts":"2026-05-18T10:00:00Z"}
+{"type":"tls","ts":"2026-05-18T10:00:01Z","sni":"abcdefghijklmnop.example.com","dport":443}
+{"type":"tls","ts":"2026-05-18T10:00:02Z","sni":"abcdefghijklmnop.example.com","dport":443}
+`
+	if err := os.WriteFile(jsonl, []byte(body), 0o644); err != nil {
+		t.Fatalf("setup jsonl: %v", err)
+	}
+	out := filepath.Join(tmp, "model.json")
+	if err := buildModel([]string{"--current=" + jsonl, "--out=" + out}); err != nil {
+		t.Fatalf("buildModel: %v", err)
+	}
+	m := readModelOrFail(t, out)
+	sd, ok := m["suspicious_domains"].([]any)
+	if !ok || len(sd) == 0 {
+		t.Fatalf("suspicious_domains missing or empty: %#v", m["suspicious_domains"])
+	}
+}
+
+func TestAssertIntegrityFailsOnShortObservationWindow(t *testing.T) {
+	tmp := t.TempDir()
+	in := filepath.Join(tmp, "model.json")
+	body := `{"schema_version":"3.0","observation_hours":0.5,"min_observation_hours":24,"short_observation_window":true,"capability_eval":{"verdict":"pass","score":95,"reasons":[]}}`
+	if err := os.WriteFile(in, []byte(body), 0o644); err != nil {
+		t.Fatalf("setup fixture: %v", err)
+	}
+	err := assertIntegrity([]string{"--in=" + in})
+	if err == nil {
+		t.Fatal("err = nil; want short-window fail")
+	}
+	if !strings.Contains(err.Error(), "short_observation_window") {
+		t.Errorf("err = %q; expected short_observation_window marker", err)
+	}
+}
+
+func TestDiffSummaryFailsOnNewDomain(t *testing.T) {
+	tmp := t.TempDir()
+	current := filepath.Join(tmp, "current.jsonl")
+	baseline := filepath.Join(tmp, "baseline.jsonl")
+	summary := filepath.Join(tmp, "summary.md")
+	curBody := `{"type":"tls","ts":"2026-05-18T10:00:00Z","sni":"new.evil.example","dport":443,"fqdn":"new.evil.example"}
+{"type":"tcp","ts":"2026-05-18T10:00:01Z","dst":"1.1.1.1","fqdn":"api.github.com","dport":443}
+`
+	baseBody := `{"type":"tcp","ts":"2026-05-18T09:00:00Z","dst":"1.1.1.1","fqdn":"api.github.com","dport":443}
+`
+	if err := os.WriteFile(current, []byte(curBody), 0o644); err != nil {
+		t.Fatalf("setup current: %v", err)
+	}
+	if err := os.WriteFile(baseline, []byte(baseBody), 0o644); err != nil {
+		t.Fatalf("setup baseline: %v", err)
+	}
+
+	err := diffSummary([]string{
+		"--current=" + current,
+		"--baseline=" + baseline,
+		"--summary=" + summary,
+		"--fail-on-new-domain",
+	})
+	if err == nil {
+		t.Fatal("err = nil; want fail-on-new-domain failure")
+	}
+	if !strings.Contains(err.Error(), "new destination domain") {
+		t.Errorf("err = %q; want new-domain message", err)
+	}
+	// The summary marker still gets written even on failure.
+	raw, readErr := os.ReadFile(summary)
+	if readErr != nil {
+		t.Fatalf("read summary: %v", readErr)
+	}
+	if !strings.Contains(string(raw), "new_domains=1") {
+		t.Errorf("summary missing new_domains count: %s", string(raw))
+	}
+}
+
+func TestDiffSummarySucceedsWhenNoNewDomain(t *testing.T) {
+	tmp := t.TempDir()
+	current := filepath.Join(tmp, "current.jsonl")
+	baseline := filepath.Join(tmp, "baseline.jsonl")
+	summary := filepath.Join(tmp, "summary.md")
+	body := `{"type":"tcp","ts":"2026-05-18T10:00:00Z","dst":"1.1.1.1","fqdn":"api.github.com","dport":443}
+`
+	if err := os.WriteFile(current, []byte(body), 0o644); err != nil {
+		t.Fatalf("setup current: %v", err)
+	}
+	if err := os.WriteFile(baseline, []byte(body), 0o644); err != nil {
+		t.Fatalf("setup baseline: %v", err)
+	}
+	if err := diffSummary([]string{
+		"--current=" + current,
+		"--baseline=" + baseline,
+		"--summary=" + summary,
+		"--fail-on-new-domain",
+	}); err != nil {
+		t.Fatalf("diffSummary = %v; want nil (no new domains)", err)
+	}
+}
+
+func TestDiffSummaryNewDomainsIgnoresBareIPs(t *testing.T) {
+	tmp := t.TempDir()
+	current := filepath.Join(tmp, "current.jsonl")
+	baseline := filepath.Join(tmp, "baseline.jsonl")
+	summary := filepath.Join(tmp, "summary.md")
+	// Current has a new bare-IP destination but no new FQDN -> strict mode
+	// should pass. New-domain churn from IP-rotation isn't actionable.
+	curBody := `{"type":"tcp","ts":"2026-05-18T10:00:00Z","dst":"9.9.9.9","dport":443}
+{"type":"tls","ts":"2026-05-18T10:00:01Z","sni":"api.github.com","dport":443}
+`
+	baseBody := `{"type":"tls","ts":"2026-05-18T09:00:00Z","sni":"api.github.com","dport":443}
+`
+	if err := os.WriteFile(current, []byte(curBody), 0o644); err != nil {
+		t.Fatalf("setup current: %v", err)
+	}
+	if err := os.WriteFile(baseline, []byte(baseBody), 0o644); err != nil {
+		t.Fatalf("setup baseline: %v", err)
+	}
+	if err := diffSummary([]string{
+		"--current=" + current,
+		"--baseline=" + baseline,
+		"--summary=" + summary,
+		"--fail-on-new-domain",
+	}); err != nil {
+		t.Fatalf("diffSummary = %v; want nil (new dst is bare IP)", err)
+	}
+}
+
+func TestRenderSummaryShowsSuspiciousDomainsWarning(t *testing.T) {
+	tmp := t.TempDir()
+	in := writeModelMapFixture(t, tmp, map[string]any{
+		"egress_sankey": []any{
+			map[string]any{"source": "abcdefghijklmnop.example.com", "target": "allowed", "value": 2, "protocol": "tls", "port": 443},
+		},
+		"suspicious_domains": []any{
+			map[string]any{"domain": "abcdefghijklmnop.example.com", "reasons": []any{"high_entropy"}, "occurrences": 2},
+		},
+	})
+	summary := filepath.Join(tmp, "summary.md")
+	if err := renderSummary([]string{"--in=" + in, "--summary=" + summary}); err != nil {
+		t.Fatalf("renderSummary: %v", err)
+	}
+	raw, err := os.ReadFile(summary)
+	if err != nil {
+		t.Fatalf("read summary: %v", err)
+	}
+	body := string(raw)
+	if !strings.Contains(body, "suspicious domains flagged") {
+		t.Fatalf("summary missing suspicious-domain warning: %s", body)
+	}
+}
+
+func TestRenderSummaryShowsShortWindowWarning(t *testing.T) {
+	tmp := t.TempDir()
+	in := writeModelMapFixture(t, tmp, map[string]any{
+		"egress_sankey":            []any{map[string]any{"source": "api.github.com", "target": "allowed", "value": 1, "protocol": "tls", "port": 443}},
+		"observation_hours":        0.5,
+		"min_observation_hours":    24.0,
+		"short_observation_window": true,
+	})
+	summary := filepath.Join(tmp, "summary.md")
+	if err := renderSummary([]string{"--in=" + in, "--summary=" + summary}); err != nil {
+		t.Fatalf("renderSummary: %v", err)
+	}
+	raw, err := os.ReadFile(summary)
+	if err != nil {
+		t.Fatalf("read summary: %v", err)
+	}
+	if !strings.Contains(string(raw), "Observation window only") {
+		t.Fatalf("summary missing short-window warning: %s", string(raw))
+	}
+}
+
+func readModelOrFail(t *testing.T, path string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read model: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal model: %v", err)
+	}
+	return m
+}
+
+func floatField(m map[string]any, key string) float64 {
+	switch v := m[key].(type) {
+	case float64:
+		return v
+	case int:
+		return float64(v)
+	case int64:
+		return float64(v)
+	}
+	return 0
+}

--- a/cmd/coldstep-report/render.go
+++ b/cmd/coldstep-report/render.go
@@ -108,6 +108,30 @@ func renderSummary(args []string) error {
 			len(unidentified), maliciousCount)
 	}
 
+	// P1-2 / 4b: surface suspicious-domain heuristics. Counts come from
+	// build-model (model.SuspiciousDomains). We only render the alert when
+	// at least one row was flagged so a clean baseline stays terse.
+	suspRows := suspiciousDomainsFromModel(m)
+	if len(suspRows) > 0 {
+		he, rare, port := countSuspiciousReasons(suspRows)
+		fmt.Fprintf(
+			&sb,
+			"> [!WARNING]\n> %d suspicious domains flagged (high entropy: %d, rare: %d, port anomaly: %d). Review before promoting to `allow:` (P1-2).\n\n",
+			len(suspRows), he, rare, port,
+		)
+	}
+
+	// P1-2 / 4a: surface a short-observation-window warning when build-model
+	// recorded one. The hard fail lives in assert-integrity; the summary
+	// notice keeps eyes on the report even when integrity is disabled.
+	if observationHoursFromModel(m) > 0 && shortObservationWindowFromModel(m) {
+		fmt.Fprintf(
+			&sb,
+			"> [!WARNING]\n> Observation window only %.2fh (< %.2fh threshold). Allowlist promotion off this run is risky (P1-2).\n\n",
+			observationHoursFromModel(m), minObservationHoursFromModel(m),
+		)
+	}
+
 	writeSection := func(heading string, rows []egressRow, showReason bool) {
 		if len(rows) == 0 {
 			return
@@ -326,4 +350,81 @@ func mapFromAny(v any) (map[string]any, bool) {
 func sliceFromAny(v any) ([]any, bool) {
 	s, ok := v.([]any)
 	return s, ok
+}
+
+func floatFromAny(v any) float64 {
+	switch n := v.(type) {
+	case float64:
+		return n
+	case int:
+		return float64(n)
+	case int64:
+		return float64(n)
+	}
+	return 0
+}
+
+func boolFromAny(v any) bool {
+	b, ok := v.(bool)
+	return ok && b
+}
+
+// observationHoursFromModel / shortObservationWindowFromModel /
+// minObservationHoursFromModel pull the P1-2 / 4a fields out of the
+// generic map form used by render-summary (readModelMap unmarshals into
+// map[string]any). They tolerate missing keys / wrong types because the
+// build-model output evolves and old artifacts may not carry them.
+func observationHoursFromModel(m map[string]any) float64 {
+	return floatFromAny(m["observation_hours"])
+}
+
+func shortObservationWindowFromModel(m map[string]any) bool {
+	return boolFromAny(m["short_observation_window"])
+}
+
+func minObservationHoursFromModel(m map[string]any) float64 {
+	return floatFromAny(m["min_observation_hours"])
+}
+
+// suspiciousDomainsFromModel decodes Report.SuspiciousDomains from the
+// generic map form. Returns an empty slice when the field is missing or
+// malformed.
+func suspiciousDomainsFromModel(m map[string]any) []map[string]any {
+	raw, ok := sliceFromAny(m["suspicious_domains"])
+	if !ok {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(raw))
+	for _, r := range raw {
+		row, ok := mapFromAny(r)
+		if !ok {
+			continue
+		}
+		out = append(out, row)
+	}
+	return out
+}
+
+func countSuspiciousReasons(rows []map[string]any) (highEntropy, rare, portAnomaly int) {
+	for _, r := range rows {
+		reasons, ok := sliceFromAny(r["reasons"])
+		if !ok {
+			continue
+		}
+		for _, raw := range reasons {
+			s, ok := stringFromAny(raw)
+			if !ok {
+				continue
+			}
+			switch s {
+			case "high_entropy":
+				highEntropy++
+			case "rare":
+				rare++
+			case "port_anomaly":
+				portAnomaly++
+			}
+		}
+	}
+	return
 }

--- a/internal/report/integrity/observation.go
+++ b/internal/report/integrity/observation.go
@@ -1,0 +1,27 @@
+package integrity
+
+import (
+	"fmt"
+
+	"github.com/coldstep-io/coldstep/internal/report/model"
+)
+
+// RequireMinObservationHours returns an error when the JSONL stream's
+// wall-clock observation window is shorter than min. min <= 0 disables
+// the check. This is the learning-mode-poisoning gate (P1-2 / 4a):
+// allowlists derived from very short detect runs are more likely to bake
+// in a transient compromise.
+//
+// The window is computed by model.ObservationWindow (meta-event start
+// when available, latest event for end). When the stream has no usable
+// timestamps the window is 0h and the check fails.
+func RequireMinObservationHours(events []model.Event, min float64) error {
+	if min <= 0 {
+		return nil
+	}
+	hours := model.ObservationHours(events)
+	if hours < min {
+		return fmt.Errorf("observation window %.2fh is shorter than required minimum %.2fh", hours, min)
+	}
+	return nil
+}

--- a/internal/report/integrity/observation_test.go
+++ b/internal/report/integrity/observation_test.go
@@ -1,0 +1,51 @@
+package integrity
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/coldstep-io/coldstep/internal/report/model"
+)
+
+func TestRequireMinObservationHoursDisabledWhenThresholdZero(t *testing.T) {
+	events := []model.Event{
+		{"type": "meta", "ts": "2026-05-18T10:00:00Z"},
+		{"type": "tcp", "ts": "2026-05-18T10:00:01Z"},
+	}
+	if err := RequireMinObservationHours(events, 0); err != nil {
+		t.Fatalf("err = %v; want nil when min <= 0", err)
+	}
+}
+
+func TestRequireMinObservationHoursPassesWhenWindowMeetsThreshold(t *testing.T) {
+	events := []model.Event{
+		{"type": "meta", "ts": "2026-05-18T10:00:00Z"},
+		{"type": "tcp", "ts": "2026-05-18T13:00:00Z"},
+	}
+	if err := RequireMinObservationHours(events, 2.0); err != nil {
+		t.Fatalf("err = %v; want nil (3h >= 2h)", err)
+	}
+}
+
+func TestRequireMinObservationHoursFailsWhenWindowTooShort(t *testing.T) {
+	events := []model.Event{
+		{"type": "meta", "ts": "2026-05-18T10:00:00Z"},
+		{"type": "tcp", "ts": "2026-05-18T10:30:00Z"},
+	}
+	err := RequireMinObservationHours(events, 24)
+	if err == nil {
+		t.Fatal("err = nil; want short-window error")
+	}
+	if !strings.Contains(err.Error(), "0.50") {
+		t.Errorf("err = %q; expected current hours in message", err)
+	}
+}
+
+func TestRequireMinObservationHoursFailsWhenNoTimestamps(t *testing.T) {
+	events := []model.Event{
+		{"type": "tcp", "dst": "1.1.1.1"},
+	}
+	if err := RequireMinObservationHours(events, 1); err == nil {
+		t.Fatal("err = nil; want error (0h window)")
+	}
+}

--- a/internal/report/model/observation.go
+++ b/internal/report/model/observation.go
@@ -1,0 +1,62 @@
+package model
+
+import (
+	"strings"
+	"time"
+)
+
+// ObservationWindow returns the earliest and latest event timestamps in
+// the stream and the duration between them. start is taken from the first
+// "meta" event when available (the agent emits one meta record at startup,
+// see internal/telemetry/meta_linux.go BuildMeta); otherwise from the
+// earliest valid ts in the stream. end is the latest valid ts.
+//
+// Used by build-model to populate Report.ObservationHours so detect-mode
+// learning windows can be gated for length (P1-2 / 4a).
+func ObservationWindow(events []Event) (start, end time.Time, dur time.Duration) {
+	var firstMeta time.Time
+	for _, e := range events {
+		ts := e.AsString("ts")
+		if ts == "" {
+			continue
+		}
+		t, err := parseEventTS(ts)
+		if err != nil {
+			continue
+		}
+		if e.AsString("type") == "meta" && firstMeta.IsZero() {
+			firstMeta = t
+		}
+		if start.IsZero() || t.Before(start) {
+			start = t
+		}
+		if t.After(end) {
+			end = t
+		}
+	}
+	if !firstMeta.IsZero() {
+		start = firstMeta
+	}
+	if !start.IsZero() && !end.IsZero() && !end.Before(start) {
+		dur = end.Sub(start)
+	}
+	return
+}
+
+// ObservationHours returns the wall-clock duration of the JSONL stream in
+// hours (0 when no valid timestamps were present, or when the latest event
+// preceded the start).
+func ObservationHours(events []Event) float64 {
+	_, _, dur := ObservationWindow(events)
+	if dur <= 0 {
+		return 0
+	}
+	return dur.Hours()
+}
+
+func parseEventTS(ts string) (time.Time, error) {
+	if t, err := time.Parse(time.RFC3339Nano, strings.Replace(ts, "Z", "+00:00", 1)); err == nil {
+		return t, nil
+	}
+	return time.Parse(time.RFC3339, ts)
+}

--- a/internal/report/model/observation_test.go
+++ b/internal/report/model/observation_test.go
@@ -1,0 +1,52 @@
+package model
+
+import (
+	"math"
+	"testing"
+)
+
+func TestObservationHoursUsesMetaAsStart(t *testing.T) {
+	events := []Event{
+		{"type": "meta", "ts": "2026-05-18T10:00:00Z"},
+		{"type": "tcp", "ts": "2026-05-18T11:30:00Z", "dst": "1.1.1.1"},
+		{"type": "tcp", "ts": "2026-05-18T14:00:00Z", "dst": "2.2.2.2"},
+	}
+	got := ObservationHours(events)
+	if math.Abs(got-4.0) > 1e-6 {
+		t.Fatalf("ObservationHours = %v; want 4.0", got)
+	}
+}
+
+func TestObservationHoursFallsBackToEarliestEventWhenNoMeta(t *testing.T) {
+	events := []Event{
+		{"type": "tcp", "ts": "2026-05-18T10:00:00Z", "dst": "1.1.1.1"},
+		{"type": "tcp", "ts": "2026-05-18T11:00:00Z", "dst": "2.2.2.2"},
+	}
+	got := ObservationHours(events)
+	if math.Abs(got-1.0) > 1e-6 {
+		t.Fatalf("ObservationHours = %v; want 1.0", got)
+	}
+}
+
+func TestObservationHoursZeroWhenNoTimestamps(t *testing.T) {
+	events := []Event{
+		{"type": "tcp", "dst": "1.1.1.1"},
+		{"type": "exec", "comm": "bash"},
+	}
+	got := ObservationHours(events)
+	if got != 0 {
+		t.Fatalf("ObservationHours = %v; want 0", got)
+	}
+}
+
+func TestObservationHoursIgnoresMalformedTS(t *testing.T) {
+	events := []Event{
+		{"type": "meta", "ts": "not a timestamp"},
+		{"type": "tcp", "ts": "2026-05-18T10:00:00Z", "dst": "1.1.1.1"},
+		{"type": "tcp", "ts": "2026-05-18T12:00:00Z", "dst": "2.2.2.2"},
+	}
+	got := ObservationHours(events)
+	if math.Abs(got-2.0) > 1e-6 {
+		t.Fatalf("ObservationHours = %v; want 2.0", got)
+	}
+}

--- a/internal/report/model/report.go
+++ b/internal/report/model/report.go
@@ -16,6 +16,33 @@ type Report struct {
 	CapabilityEval   CapabilityEval        `json:"capability_eval"`
 	OTX              json.RawMessage       `json:"otx"`
 	RDNS             json.RawMessage       `json:"rdns"`
+	// ObservationHours is the wall-clock span from the meta event (or
+	// earliest observed event) to the last event in the JSONL stream.
+	// Surfaces in build-model output so post-run gates can reject
+	// short learning windows (P1-2 / 4a: learning-mode poisoning).
+	ObservationHours float64 `json:"observation_hours"`
+	// ShortObservationWindow is set by build-model when ObservationHours
+	// is below the --min-observation-hours threshold. assert-integrity
+	// promotes it to a hard fail.
+	ShortObservationWindow bool `json:"short_observation_window,omitempty"`
+	// MinObservationHours echoes the threshold supplied to build-model
+	// (0 when no threshold was requested). Lets the digest explain why
+	// a window was flagged.
+	MinObservationHours float64 `json:"min_observation_hours,omitempty"`
+	// SuspiciousDomains is the union of high-entropy / rare / port-anomaly
+	// flagged destinations (P1-2 / 4b). render-summary surfaces the count.
+	SuspiciousDomains []SuspiciousDomain `json:"suspicious_domains,omitempty"`
+}
+
+// SuspiciousDomain captures why a destination was flagged during build-model.
+// Reasons is a non-empty, sorted, de-duped set of: "high_entropy",
+// "rare", "port_anomaly".
+type SuspiciousDomain struct {
+	Domain      string   `json:"domain"`
+	Reasons     []string `json:"reasons"`
+	Entropy     float64  `json:"entropy,omitempty"`
+	Occurrences int      `json:"occurrences,omitempty"`
+	Ports       []int    `json:"ports,omitempty"`
 }
 
 type RunMeta struct {

--- a/internal/report/model/suspicious.go
+++ b/internal/report/model/suspicious.go
@@ -1,0 +1,233 @@
+package model
+
+import (
+	"math"
+	"sort"
+	"strings"
+)
+
+// suspiciousReasonHighEntropy etc. are the closed reason set surfaced in
+// Report.SuspiciousDomains[].Reasons. Keep these strings stable; consumers
+// (render-summary, downstream tooling) match on them.
+const (
+	suspiciousReasonHighEntropy = "high_entropy"
+	suspiciousReasonRare        = "rare"
+	suspiciousReasonPortAnomaly = "port_anomaly"
+)
+
+// Heuristic thresholds for the P1-2 / 4b learning-mode-poisoning checks.
+//
+//   - Entropy threshold of 3.5 bits/char on the leftmost DNS label picks
+//     up DGA-style subdomains (random base32/base36 strings) while
+//     leaving human-readable subdomains alone.
+//   - 8-char minimum avoids false-positives on short labels like "api",
+//     "www", "cdn3" that can clear the entropy threshold by accident.
+const (
+	highEntropyMinLabelLen    = 8
+	highEntropyMinBitsPerChar = 3.5
+)
+
+// standardEgressPorts is the closed allowlist of "common" destination
+// ports that do not raise a port_anomaly flag on an HTTP/S-bearing domain.
+// Keep this set explicit per CLAUDE.md (3000/8000 included because CI
+// workflows commonly stand up local servers there during detect runs).
+var standardEgressPorts = map[int]struct{}{
+	22:   {},
+	25:   {},
+	53:   {},
+	80:   {},
+	443:  {},
+	465:  {},
+	587:  {},
+	3000: {},
+	8000: {},
+	8080: {},
+	8443: {},
+}
+
+// domainStats accumulates per-destination evidence for the suspicious-
+// domain heuristics. It is keyed by the normalized FQDN/host string.
+type domainStats struct {
+	occurrences int
+	httpish     bool
+	ports       map[int]struct{}
+}
+
+// BuildSuspiciousDomains scans egress events (tcp, udp, http, tls) and
+// returns destinations flagged by any of the P1-2 / 4b heuristics:
+//
+//   - high_entropy: Shannon entropy of the leftmost DNS label exceeds
+//     highEntropyMinBitsPerChar AND label length exceeds
+//     highEntropyMinLabelLen.
+//   - rare: domain observed exactly once across the entire stream.
+//   - port_anomaly: an http/tls observation against the domain on a
+//     non-standard port (anything outside standardEgressPorts).
+//
+// Domains without a printable hostname (IP-only egress) are skipped — the
+// entropy check is meaningless on numeric addresses, and rare-IP signal
+// is already covered by the egress sankey.
+func BuildSuspiciousDomains(events []Event) []SuspiciousDomain {
+	stats := map[string]*domainStats{}
+	for _, e := range events {
+		typ := e.AsString("type")
+		if _, ok := egressTypes[typ]; !ok {
+			continue
+		}
+		host := firstNonEmpty(e.AsString("fqdn"), e.AsString("host"), e.AsString("sni"))
+		host = strings.TrimSpace(strings.ToLower(host))
+		if host == "" {
+			continue
+		}
+		if !looksLikeDomain(host) {
+			continue
+		}
+		s := stats[host]
+		if s == nil {
+			s = &domainStats{ports: map[int]struct{}{}}
+			stats[host] = s
+		}
+		s.occurrences++
+		if typ == "http" || typ == "tls" {
+			s.httpish = true
+		}
+		port := int(e.AsFloat("dport"))
+		if port == 0 {
+			port = int(e.AsFloat("port"))
+		}
+		if port > 0 {
+			s.ports[port] = struct{}{}
+		}
+	}
+
+	out := make([]SuspiciousDomain, 0)
+	for host, s := range stats {
+		reasons := map[string]struct{}{}
+		entropy := labelShannonEntropy(host)
+		label := leftmostLabel(host)
+		if len(label) > highEntropyMinLabelLen && entropy > highEntropyMinBitsPerChar {
+			reasons[suspiciousReasonHighEntropy] = struct{}{}
+		}
+		if s.occurrences == 1 {
+			reasons[suspiciousReasonRare] = struct{}{}
+		}
+		if s.httpish {
+			for p := range s.ports {
+				if _, ok := standardEgressPorts[p]; !ok {
+					reasons[suspiciousReasonPortAnomaly] = struct{}{}
+					break
+				}
+			}
+		}
+		if len(reasons) == 0 {
+			continue
+		}
+		sd := SuspiciousDomain{
+			Domain:      host,
+			Reasons:     sortedKeys(reasons),
+			Occurrences: s.occurrences,
+		}
+		if _, ok := reasons[suspiciousReasonHighEntropy]; ok {
+			sd.Entropy = roundTo(entropy, 4)
+		}
+		if _, ok := reasons[suspiciousReasonPortAnomaly]; ok {
+			sd.Ports = sortedPorts(s.ports)
+		}
+		out = append(out, sd)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Domain < out[j].Domain })
+	return out
+}
+
+func leftmostLabel(host string) string {
+	if i := strings.IndexByte(host, '.'); i >= 0 {
+		return host[:i]
+	}
+	return host
+}
+
+// labelShannonEntropy returns the Shannon entropy in bits/char of the
+// leftmost DNS label. Returns 0 when the label is empty.
+func labelShannonEntropy(host string) float64 {
+	label := leftmostLabel(host)
+	if label == "" {
+		return 0
+	}
+	counts := map[rune]int{}
+	total := 0
+	for _, r := range label {
+		counts[r]++
+		total++
+	}
+	if total == 0 {
+		return 0
+	}
+	var h float64
+	for _, c := range counts {
+		p := float64(c) / float64(total)
+		h -= p * math.Log2(p)
+	}
+	return h
+}
+
+// looksLikeDomain rejects bare IPv4 / IPv6 literals so the entropy check
+// is not applied to numeric addresses. We accept any string containing
+// at least one non-digit, non-separator rune (covers FQDNs, wildcard
+// hosts like *.svc, and local hosts like "registry"); pure-numeric input
+// like "1.2.3.4" is rejected.
+func looksLikeDomain(host string) bool {
+	if host == "" {
+		return false
+	}
+	for _, r := range host {
+		if r == '.' || r == '-' {
+			continue
+		}
+		if r >= '0' && r <= '9' {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func sortedKeys(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedPorts(set map[int]struct{}) []int {
+	out := make([]int, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Ints(out)
+	return out
+}
+
+func roundTo(f float64, places int) float64 {
+	pow := math.Pow(10, float64(places))
+	return math.Round(f*pow) / pow
+}
+
+// SuspiciousDomainCounts breaks down a SuspiciousDomain slice by reason
+// for human-readable summary output. Each domain contributes once per
+// reason it carries.
+func SuspiciousDomainCounts(rows []SuspiciousDomain) (highEntropy, rare, portAnomaly int) {
+	for _, r := range rows {
+		for _, reason := range r.Reasons {
+			switch reason {
+			case suspiciousReasonHighEntropy:
+				highEntropy++
+			case suspiciousReasonRare:
+				rare++
+			case suspiciousReasonPortAnomaly:
+				portAnomaly++
+			}
+		}
+	}
+	return
+}

--- a/internal/report/model/suspicious_test.go
+++ b/internal/report/model/suspicious_test.go
@@ -1,0 +1,98 @@
+package model
+
+import (
+	"testing"
+)
+
+func TestBuildSuspiciousDomainsFlagsHighEntropyLabel(t *testing.T) {
+	// A 16-char base32-ish leftmost label clears the entropy threshold.
+	events := []Event{
+		{"type": "tls", "ts": "2026-05-18T10:00:00Z", "sni": "abcdefghijklmnop.example.com", "dport": 443},
+		{"type": "tls", "ts": "2026-05-18T10:00:01Z", "sni": "abcdefghijklmnop.example.com", "dport": 443},
+	}
+	rows := BuildSuspiciousDomains(events)
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d; want 1 (%v)", len(rows), rows)
+	}
+	if rows[0].Domain != "abcdefghijklmnop.example.com" {
+		t.Errorf("domain = %q; want abcdefghijklmnop.example.com", rows[0].Domain)
+	}
+	if !containsString(rows[0].Reasons, "high_entropy") {
+		t.Errorf("reasons = %v; want high_entropy", rows[0].Reasons)
+	}
+}
+
+func TestBuildSuspiciousDomainsFlagsRareDomain(t *testing.T) {
+	events := []Event{
+		{"type": "tls", "ts": "2026-05-18T10:00:00Z", "sni": "rare.example.com", "dport": 443},
+		{"type": "tls", "ts": "2026-05-18T10:00:01Z", "sni": "common.example.com", "dport": 443},
+		{"type": "tls", "ts": "2026-05-18T10:00:02Z", "sni": "common.example.com", "dport": 443},
+	}
+	rows := BuildSuspiciousDomains(events)
+	var rare *SuspiciousDomain
+	for i := range rows {
+		if rows[i].Domain == "rare.example.com" {
+			rare = &rows[i]
+		}
+	}
+	if rare == nil {
+		t.Fatalf("rows = %v; want a row for rare.example.com", rows)
+	}
+	if !containsString(rare.Reasons, "rare") {
+		t.Errorf("reasons = %v; want rare", rare.Reasons)
+	}
+	if rare.Occurrences != 1 {
+		t.Errorf("occurrences = %d; want 1", rare.Occurrences)
+	}
+}
+
+func TestBuildSuspiciousDomainsFlagsPortAnomalyOnHTTPish(t *testing.T) {
+	events := []Event{
+		{"type": "tls", "ts": "2026-05-18T10:00:00Z", "sni": "weirdport.example.com", "dport": 9999},
+		{"type": "tls", "ts": "2026-05-18T10:00:01Z", "sni": "weirdport.example.com", "dport": 9999},
+	}
+	rows := BuildSuspiciousDomains(events)
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d; want 1 (%v)", len(rows), rows)
+	}
+	if !containsString(rows[0].Reasons, "port_anomaly") {
+		t.Errorf("reasons = %v; want port_anomaly", rows[0].Reasons)
+	}
+	if len(rows[0].Ports) == 0 || rows[0].Ports[0] != 9999 {
+		t.Errorf("ports = %v; want [9999]", rows[0].Ports)
+	}
+}
+
+func TestBuildSuspiciousDomainsIgnoresStandardPorts(t *testing.T) {
+	events := []Event{
+		{"type": "http", "ts": "2026-05-18T10:00:00Z", "host": "api.github.com", "dport": 443},
+		{"type": "http", "ts": "2026-05-18T10:00:01Z", "host": "api.github.com", "dport": 443},
+		{"type": "tls", "ts": "2026-05-18T10:00:02Z", "sni": "api.github.com", "dport": 443},
+	}
+	rows := BuildSuspiciousDomains(events)
+	if len(rows) != 0 {
+		t.Fatalf("rows = %v; want 0 for an ordinary api host on 443", rows)
+	}
+}
+
+func TestBuildSuspiciousDomainsSkipsBareIPs(t *testing.T) {
+	events := []Event{
+		{"type": "tcp", "ts": "2026-05-18T10:00:00Z", "dst": "1.2.3.4", "dport": 443},
+	}
+	rows := BuildSuspiciousDomains(events)
+	if len(rows) != 0 {
+		t.Fatalf("rows = %v; want 0 — bare IP host has no FQDN", rows)
+	}
+}
+
+func TestSuspiciousDomainCountsByReason(t *testing.T) {
+	rows := []SuspiciousDomain{
+		{Domain: "a", Reasons: []string{"high_entropy", "rare"}},
+		{Domain: "b", Reasons: []string{"port_anomaly"}},
+		{Domain: "c", Reasons: []string{"rare"}},
+	}
+	he, rare, port := SuspiciousDomainCounts(rows)
+	if he != 1 || rare != 2 || port != 1 {
+		t.Fatalf("counts = (he=%d, rare=%d, port=%d); want (1,2,1)", he, rare, port)
+	}
+}


### PR DESCRIPTION
## Summary

Implements **P1-2 / learning-mode poisoning** mitigations from the security-hardening plan. The detect workflow records every endpoint a build talks to so teams can promote those observations into the `allow:` list — a supply-chain compromise that lands during the recording window gets baked into the allowlist with no diff, no minimum sample size, and no heuristic flag. This change adds the four tractable post-run gates from the plan (no BPF or `action.yml` changes).

- **4a — Minimum observation window (`build-model --min-observation-hours`, env `COLDSTEP_MIN_OBS_HOURS`)**
  - Computes wall-clock span from the agent's `meta` event (or earliest event if absent) to the last event in the JSONL stream.
  - Records `observation_hours`, `min_observation_hours`, and `short_observation_window` on `report.Report`.
  - `assert-integrity` hard-fails when `short_observation_window=true` so CI cannot promote an allowlist from a too-short run.
  - `integrity.RequireMinObservationHours(events, hours)` exposes the same check for ad-hoc use.

- **4b — Suspicious-domain heuristics (`model.BuildSuspiciousDomains`)**
  - High-entropy leftmost DNS label (Shannon > 3.5 bits/char on labels longer than 8 chars).
  - Single-observation `rare` flag.
  - Port anomaly: HTTP/TLS observation on a port outside `{22, 25, 53, 80, 443, 465, 587, 3000, 8000, 8080, 8443}`.
  - `render-summary` adds a `[!WARNING]` block with the per-reason breakdown.

- **4c — Baseline diff strict mode (`diff --fail-on-new-domain`)**
  - Compares destination FQDNs (with host/sni fallbacks) between current and baseline. Bare-IP destinations are excluded so IP rotation doesn't create churn.
  - Exits non-zero with a `::error` annotation and adds `.new_domains=N` to the diff summary marker.

- **4d — `QUICK_START.md` workflow guidance**
  - New "Promoting detect observations to an allowlist" section: ≥ 3 builds → `diff --fail-on-new-domain` → second-engineer review → `build-model --min-observation-hours 24` gate.

## Test plan

- [x] `go test ./internal/report/... ./cmd/coldstep-report/... -count=1`
- [x] `go vet ./internal/report/... ./cmd/coldstep-report/...`
- [x] `gofmt -l cmd internal` (clean)
- [x] New tests cover: build-model writes observation_hours + short_observation_window, assert-integrity hard-fails on short window, BuildSuspiciousDomains flags high-entropy / rare / port-anomaly, diff strict mode passes on no-new-domain and fails on new domain, bare-IP destinations excluded from new-domain check, render-summary surfaces both new warnings.
- [ ] CI: ubuntu unit / unit-arm64 / detect-mode / defend-mode (Marketplace flow is untouched but verifies the report binary still builds).

## Notes

- New schema fields use `omitempty` (`short_observation_window`, `min_observation_hours`, `suspicious_domains`) so older `.coldstep-report-model.json` artifacts deserialize cleanly.
- No `action.yml` inputs added — the flags are post-run (`coldstep-report` CLI), matching how existing report subcommands are wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
