### PR TITLE
P1-5: JSONL injection hardening — sanitize string fields at ring-reader decode point

### DIFF
--- a/internal/agent/agent_linux_policy_maps.go
+++ b/internal/agent/agent_linux_policy_maps.go
@@ -583,7 +583,10 @@ func appendDenyFromRaw(cfg config.Config, raw []byte, seq *telemetry.SeqGen, jso
 	}
 	dstIP := net.IPv4(daddr16[0], daddr16[1], daddr16[2], daddr16[3])
 	dst := dstIP.String()
-	comm := string(bytes.TrimRight(commb[:], "\x00"))
+	// P1-5: sanitize attacker-controlled comm before it lands in JSONL — a
+	// blocked process whose argv[0] embeds newline / control bytes must not
+	// be able to forge an extra record in the event log.
+	comm := telemetry.SanitizeField(string(bytes.TrimRight(commb[:], "\x00")), 16)
 	ts := time.Now().UTC().Format(time.RFC3339Nano)
 	matchKind := "unknown"
 	if dns != nil && dns.Lookup(dstIP) != "" {

--- a/internal/agent/agent_linux_ring_read.go
+++ b/internal/agent/agent_linux_ring_read.go
@@ -46,8 +46,13 @@ func readExecRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, st
 			continue
 		}
 
-		comm := string(bytes.TrimRight(ev.Comm[:], "\x00"))
-		exe := string(bytes.TrimRight(ev.ExePath[:], "\x00"))
+		// P1-5: sanitize attacker-controlled strings at the decode point so
+		// every downstream consumer (digest rows + JSONL writer) sees the same
+		// safe value. Stripping C0/C1 controls here is what prevents JSONL
+		// injection — a process whose argv[0] embeds `\n{"type":"meta"...}`
+		// could otherwise forge a record into the append-only event log.
+		comm := telemetry.SanitizeField(nullTermStr(ev.Comm[:]), 16)
+		exe := telemetry.SanitizeField(nullTermStr(ev.ExePath[:]), 4096)
 		stats.addExec()
 		ts := time.Now().UTC().Format(time.RFC3339Nano)
 		rows.addExec(report.ExecDigestRow{
@@ -111,8 +116,8 @@ func readForkRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, st
 			continue
 		}
 
-		pcomm := string(bytes.TrimRight(ev.ParentComm[:], "\x00"))
-		ccomm := string(bytes.TrimRight(ev.ChildComm[:], "\x00"))
+		pcomm := telemetry.SanitizeField(nullTermStr(ev.ParentComm[:]), 16)
+		ccomm := telemetry.SanitizeField(nullTermStr(ev.ChildComm[:]), 16)
 		forkBuf.add(proctree.Edge{
 			ParentTGID:    ev.ParentPID,
 			ChildTGID:     ev.ChildPID,
@@ -213,8 +218,8 @@ func readFSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, stat
 			continue
 		}
 
-		comm := nullTermStr(ev.Comm[:])
-		path := nullTermStr(ev.Path[:])
+		comm := telemetry.SanitizeField(nullTermStr(ev.Comm[:]), 16)
+		path := telemetry.SanitizeField(nullTermStr(ev.Path[:]), 4096)
 		op := fsOpName(ev.Op)
 		ts := time.Now().UTC().Format(time.RFC3339Nano)
 
@@ -293,11 +298,14 @@ func readConnectRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader,
 		if ip == nil {
 			continue
 		}
-		comm := string(bytes.TrimRight(commb[:], "\x00"))
+		comm := telemetry.SanitizeField(nullTermStr(commb[:]), 16)
 		fqdn, fqdnProv := "", "unknown"
 		if dns != nil {
 			fqdn, fqdnProv = dns.LookupProvenance(ip)
 		}
+		// FQDN ultimately derives from on-wire DNS labels captured in BPF — sanitize
+		// before any use (digest row, classifier display, JSONL).
+		fqdn = telemetry.SanitizeField(fqdn, 253)
 		cl := pol.Classify(fqdn, ip)
 		stats.addTCP(cl)
 		stats.incDomainCount(fqdn)
@@ -371,12 +379,14 @@ func readTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, pol
 		if ip == nil {
 			continue
 		}
-		comm := string(bytes.TrimRight(commb[:], "\x00"))
+		comm := telemetry.SanitizeField(nullTermStr(commb[:]), 16)
 		sni, parsed := telemetry.ParseClientHelloSNI(rawPay)
 		if !parsed {
 			stats.addDropped("tls_sni_parse")
 			continue
 		}
+		// SNI is parsed from an attacker-controlled TLS ClientHello buffer.
+		sni = telemetry.SanitizeField(sni, 253)
 		cl := pol.Classify(sni, ip)
 		stats.addTLS(cl)
 
@@ -443,11 +453,12 @@ func readUDPRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, dns
 		if ip == nil {
 			continue
 		}
-		comm := string(bytes.TrimRight(commb[:], "\x00"))
+		comm := telemetry.SanitizeField(nullTermStr(commb[:]), 16)
 		fqdn, fqdnProv := "", "unknown"
 		if dns != nil {
 			fqdn, fqdnProv = dns.LookupProvenance(ip)
 		}
+		fqdn = telemetry.SanitizeField(fqdn, 253)
 		cl := pol.Classify(fqdn, ip)
 		stats.addUDP(cl)
 		stats.incDomainCount(fqdn)
@@ -516,12 +527,16 @@ func readHTTPRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, po
 		if ip == nil {
 			continue
 		}
-		comm := string(bytes.TrimRight(commb[:], "\x00"))
+		comm := telemetry.SanitizeField(nullTermStr(commb[:]), 16)
 		method, host, path, parsed := telemetry.ParseHTTPRequestPrefix(rawPay)
 		if !parsed {
 			stats.addDropped("http_prefix_parse")
 			continue
 		}
+		// HTTP request prefix is parsed from a kernel-captured first-write buffer.
+		method = telemetry.SanitizeField(method, 16)
+		host = telemetry.SanitizeField(host, 253)
+		path = telemetry.SanitizeField(path, 4096)
 		cl := pol.Classify(host, ip)
 		stats.addHTTP(cl)
 
@@ -616,7 +631,7 @@ func readBPFAuditRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader
 		}
 
 		stats.addBPFAudit()
-		comm := string(bytes.TrimRight(commb[:], "\x00"))
+		comm := telemetry.SanitizeField(nullTermStr(commb[:]), 16)
 		ts := time.Now().UTC().Format(time.RFC3339Nano)
 
 		slog.Info("bpf syscall audit", "tgid", tgid, "comm", comm, "cmd", cmd)

--- a/internal/telemetry/sanitize.go
+++ b/internal/telemetry/sanitize.go
@@ -1,0 +1,51 @@
+package telemetry
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// SanitizeField removes control characters (including \n \r \t and other
+// C0/C1 controls) and truncates to maxLen bytes. It replaces any invalid
+// UTF-8 sequences with the Unicode replacement character (U+FFFD). The
+// result is safe to embed as a JSON string value in an append-only JSONL
+// stream — no caller-controlled bytes can introduce a record boundary or
+// terminate the surrounding JSON string.
+//
+// Field-size budgets at the call sites (P1-5):
+//   - Comm           16   bytes (TASK_COMM_LEN)
+//   - Exe            4096 bytes (PATH_MAX)
+//   - SNI/Host/FQDN  253  bytes (RFC 1035 max FQDN)
+//   - Path           4096 bytes (PATH_MAX)
+//   - Cmdline        4096 bytes
+//
+// maxLen is a byte budget, not a rune budget; truncation walks back to a
+// valid UTF-8 rune boundary so the output stays a valid UTF-8 string.
+func SanitizeField(s string, maxLen int) string {
+	if maxLen <= 0 {
+		return ""
+	}
+	if !utf8.ValidString(s) {
+		s = strings.ToValidUTF8(s, "�")
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		// Strip C0 (U+0000–U+001F), DEL (U+007F), and C1 (U+0080–U+009F)
+		// control characters. Everything else (including all printable
+		// Unicode, including non-ASCII) passes through unchanged.
+		if r < 0x20 || r == 0x7F || (r >= 0x80 && r <= 0x9F) {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	out := b.String()
+	if len(out) > maxLen {
+		cut := maxLen
+		for cut > 0 && !utf8.RuneStart(out[cut]) {
+			cut--
+		}
+		out = out[:cut]
+	}
+	return out
+}

--- a/internal/telemetry/sanitize.go
+++ b/internal/telemetry/sanitize.go
@@ -26,12 +26,16 @@ func SanitizeField(s string, maxLen int) string {
 		return ""
 	}
 	if !utf8.ValidString(s) {
-		s = strings.ToValidUTF8(s, "�")
+		// U+FFFD written as a \u escape so this source file stays free of
+		// raw EF BF BD bytes — scripts/check-encoding.sh rejects any
+		// tracked text file containing the replacement-character byte
+		// sequence (it usually indicates paste / shell damage, not intent).
+		s = strings.ToValidUTF8(s, "\uFFFD")
 	}
 	var b strings.Builder
 	b.Grow(len(s))
 	for _, r := range s {
-		// Strip C0 (U+0000–U+001F), DEL (U+007F), and C1 (U+0080–U+009F)
+		// Strip C0 (U+0000-U+001F), DEL (U+007F), and C1 (U+0080-U+009F)
 		// control characters. Everything else (including all printable
 		// Unicode, including non-ASCII) passes through unchanged.
 		if r < 0x20 || r == 0x7F || (r >= 0x80 && r <= 0x9F) {

--- a/internal/telemetry/sanitize_fuzz_test.go
+++ b/internal/telemetry/sanitize_fuzz_test.go
@@ -1,0 +1,49 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func FuzzSanitizeField(f *testing.F) {
+	f.Add("normal.domain.com", 253)
+	f.Add("evil\ninjection", 253)
+	f.Add("bad\x00byte", 16)
+	f.Add(strings.Repeat("a", 10000), 253)
+	f.Add("café", 4)
+	f.Add("\xff\xfe\xfd", 16)
+	f.Add("", 16)
+	f.Fuzz(func(t *testing.T, s string, maxLen int) {
+		if maxLen <= 0 || maxLen > 8192 {
+			return
+		}
+		result := SanitizeField(s, maxLen)
+		// Property 1: must be JSON-marshalable as a string value.
+		b, err := json.Marshal(result)
+		if err != nil {
+			t.Fatalf("SanitizeField(%q, %d) = %q: not JSON-marshalable: %v", s, maxLen, result, err)
+		}
+		// Property 2: no raw newline / carriage return survives — these are
+		// the only characters that could break JSONL record framing.
+		if strings.ContainsAny(result, "\n\r") {
+			t.Fatalf("SanitizeField(%q, %d) = %q: contains raw newline", s, maxLen, result)
+		}
+		// Property 3: byte-length budget honored.
+		if len(result) > maxLen {
+			t.Fatalf("SanitizeField(%q, %d) = %q: len=%d exceeds maxLen", s, maxLen, result, len(result))
+		}
+		// Property 4: output is valid UTF-8 (truncation must not split a rune).
+		if !utf8.ValidString(result) {
+			t.Fatalf("SanitizeField(%q, %d) = %q: not valid UTF-8", s, maxLen, result)
+		}
+		// Property 5: no C0 or C1 control bytes (excluding DEL) survive.
+		for _, r := range result {
+			if r < 0x20 || r == 0x7F || (r >= 0x80 && r <= 0x9F) {
+				t.Fatalf("SanitizeField(%q, %d) = %q: control char U+%04X survived", s, maxLen, result, r)
+			}
+		}
+		_ = b
+	})
+}

--- a/internal/telemetry/sanitize_test.go
+++ b/internal/telemetry/sanitize_test.go
@@ -102,7 +102,7 @@ func TestSanitizeField_InvalidUTF8ReplacedWithU_FFFD(t *testing.T) {
 	// 0xFF is not a valid UTF-8 start byte.
 	in := "ok\xffend"
 	got := SanitizeField(in, 16)
-	if !strings.Contains(got, "�") {
+	if !strings.Contains(got, "\uFFFD") {
 		t.Fatalf("expected replacement char in %q", got)
 	}
 	// Must remain valid JSON when serialized.

--- a/internal/telemetry/sanitize_test.go
+++ b/internal/telemetry/sanitize_test.go
@@ -1,0 +1,163 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeField_NormalASCIIPassThrough(t *testing.T) {
+	in := "curl"
+	got := SanitizeField(in, 16)
+	if got != in {
+		t.Fatalf("normal ASCII mutated: got %q want %q", got, in)
+	}
+}
+
+func TestSanitizeField_StripsNewlineAndCarriageReturn(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"lf", "evil\ninjection", "evilinjection"},
+		{"cr", "evil\rinjection", "evilinjection"},
+		{"crlf", "evil\r\ninjection", "evilinjection"},
+		{"tab", "evil\tinjection", "evilinjection"},
+		{"forged_record", "bash\n{\"type\":\"meta\",\"forged\":true}", "bash{\"type\":\"meta\",\"forged\":true}"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SanitizeField(tc.in, 4096)
+			if got != tc.want {
+				t.Fatalf("got %q want %q", got, tc.want)
+			}
+			if strings.ContainsAny(got, "\n\r\t") {
+				t.Fatalf("control chars survived: %q", got)
+			}
+		})
+	}
+}
+
+func TestSanitizeField_StripsNULByte(t *testing.T) {
+	got := SanitizeField("bad\x00byte", 16)
+	if got != "badbyte" {
+		t.Fatalf("got %q want %q", got, "badbyte")
+	}
+	if strings.ContainsRune(got, 0x00) {
+		t.Fatalf("NUL survived: %q", got)
+	}
+}
+
+func TestSanitizeField_StripsC0AndC1Controls(t *testing.T) {
+	// Build a string containing every C0 and C1 control byte plus DEL,
+	// interleaved with printable ASCII so we can verify only the controls
+	// are removed.
+	var raw strings.Builder
+	for r := rune(0); r < 0x20; r++ {
+		raw.WriteRune(r)
+		raw.WriteRune('x')
+	}
+	raw.WriteRune(0x7F)
+	raw.WriteRune('x')
+	for r := rune(0x80); r <= 0x9F; r++ {
+		raw.WriteRune(r)
+		raw.WriteRune('x')
+	}
+	got := SanitizeField(raw.String(), 4096)
+	want := strings.Repeat("x", 0x20+1+(0x9F-0x80+1))
+	if got != want {
+		t.Fatalf("control-strip mismatch: got %q want %q", got, want)
+	}
+}
+
+func TestSanitizeField_TruncatesAtMaxLenBytes(t *testing.T) {
+	in := strings.Repeat("a", 100)
+	got := SanitizeField(in, 16)
+	if len(got) != 16 {
+		t.Fatalf("len=%d want 16", len(got))
+	}
+	if got != strings.Repeat("a", 16) {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestSanitizeField_TruncateWalksBackToRuneBoundary(t *testing.T) {
+	// "é" is 2 bytes (0xC3 0xA9). With maxLen=3 over "aéé", the naive cut
+	// at byte 3 would split the second "é" in half; truncation must walk
+	// back to a valid rune start, leaving "aé" (3 bytes total... actually
+	// "aé" is 1+2=3 bytes, no walk-back needed; with maxLen=4 over "aéé"
+	// the cut at byte 4 is the middle of "é" and must walk back to 3).
+	in := "aéé" // a é é, total 5 bytes
+	got := SanitizeField(in, 4)
+	if got != "aé" {
+		t.Fatalf("rune-boundary truncation failed: got %q (% x) want %q", got, got, "aé")
+	}
+	if len(got) > 4 {
+		t.Fatalf("exceeded maxLen: len=%d", len(got))
+	}
+}
+
+func TestSanitizeField_InvalidUTF8ReplacedWithU_FFFD(t *testing.T) {
+	// 0xFF is not a valid UTF-8 start byte.
+	in := "ok\xffend"
+	got := SanitizeField(in, 16)
+	if !strings.Contains(got, "�") {
+		t.Fatalf("expected replacement char in %q", got)
+	}
+	// Must remain valid JSON when serialized.
+	if _, err := json.Marshal(got); err != nil {
+		t.Fatalf("not JSON-marshalable: %v", err)
+	}
+}
+
+func TestSanitizeField_EmptyString(t *testing.T) {
+	if got := SanitizeField("", 16); got != "" {
+		t.Fatalf("empty in -> %q", got)
+	}
+}
+
+func TestSanitizeField_ZeroOrNegativeMaxLenReturnsEmpty(t *testing.T) {
+	if got := SanitizeField("anything", 0); got != "" {
+		t.Fatalf("maxLen=0 -> %q want \"\"", got)
+	}
+	if got := SanitizeField("anything", -1); got != "" {
+		t.Fatalf("maxLen=-1 -> %q want \"\"", got)
+	}
+}
+
+func TestSanitizeField_NonASCIIPrintablePassesThrough(t *testing.T) {
+	// Printable non-ASCII (CJK, accented Latin) must survive.
+	cases := []string{
+		"café",             // café
+		"中文",               // 中文
+		"\U0001F600 emoji", // grinning face
+		"naïve résumé",     //nolint:gosmopolitan // intentional UTF-8 test fixture
+	}
+	for _, in := range cases {
+		got := SanitizeField(in, 4096)
+		if got != in {
+			t.Fatalf("printable non-ASCII mutated: in=%q got=%q", in, got)
+		}
+	}
+}
+
+// Demonstrates the security property: a sanitized value, embedded as a JSON
+// string in a JSONL line, can never close the surrounding string or insert
+// a new record.
+func TestSanitizeField_OutputIsJSONLSafe(t *testing.T) {
+	in := "bash\n{\"type\":\"meta\",\"forged\":true}\nmore"
+	cleaned := SanitizeField(in, 4096)
+	if strings.ContainsAny(cleaned, "\n\r") {
+		t.Fatalf("newline survived: %q", cleaned)
+	}
+	line, err := json.Marshal(struct {
+		Comm string `json:"comm"`
+	}{Comm: cleaned})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Count(string(line), "\n") != 0 {
+		t.Fatalf("JSONL line contains raw newline: %q", line)
+	}
+}


### PR DESCRIPTION
## Summary

P1-5 — sanitize attacker-controlled string fields at the BPF ring-buffer decode point so they can never break JSONL framing or forge records in `.coldstep-events.jsonl`.

**Threat.** A process whose `argv[0]`/`comm`, a captured DNS label, a TLS SNI, or an HTTP request prefix embeds a raw newline followed by a forged JSON object could splice an extra record into the append-only event log — e.g. fake `meta`/`exec`/`deny` lines that would round-trip through `coldstep-report build-model` and downstream integrity scoring.

**Fix.** New helper `telemetry.SanitizeField(s, maxLen)`:
- strips C0 controls (U+0000–U+001F), DEL (U+007F), and C1 controls (U+0080–U+009F) — covers `\n`, `\r`, `\t`, NUL, ESC, etc.
- replaces invalid UTF-8 with U+FFFD via `strings.ToValidUTF8`
- truncates to `maxLen` bytes and walks back to a valid UTF-8 rune boundary

Applied at the single decode point per event type — `internal/agent/agent_linux_ring_read.go` for exec / proc_fork / fs_event / tcp / udp / tls / http / bpf_audit, plus `agent_linux_policy_maps.go::appendDenyFromRaw` for the defend deny path. Every downstream consumer (digest rows, classifier, JSONL writer) sees the already-sanitized value, so there's no second sanitize site to drift out of sync.

Field budgets:

| Field           | Budget   | Source                |
| :-------------- | :------- | :-------------------- |
| `comm`          | 16 B     | `TASK_COMM_LEN`       |
| `exe`, `path`   | 4096 B   | `PATH_MAX`            |
| `fqdn`, `sni`, `host` | 253 B | RFC 1035 max FQDN |
| HTTP `method`   | 16 B     | longest RFC verb + slack |

## Tests

- `internal/telemetry/sanitize_test.go` — newline / CR / NUL strip, full C0+DEL+C1 control sweep, byte-length truncation, UTF-8 rune-boundary truncation, invalid-UTF-8 → U+FFFD, empty input, zero/negative `maxLen`, non-ASCII printable pass-through, and an end-to-end JSONL-safety property assertion.
- `internal/telemetry/sanitize_fuzz_test.go` — `FuzzSanitizeField` asserts five properties on every input: JSON-marshalable, no raw `\n`/`\r`, byte budget honored, valid UTF-8, no control bytes survive. Local run: ~48k execs / 1s baseline, 0 crashes.

## Test plan

- [x] `gofmt -l` clean on touched files
- [x] `go vet ./internal/telemetry/...` passes
- [x] `go test ./internal/telemetry/... -count=1` passes
- [x] `go test -run=^$ -fuzz=FuzzSanitizeField -fuzztime=1s ./internal/telemetry/` passes
- [ ] CI: full `coldstep-ci-runner.yml` matrix (unit, unit-arm64, integration, detect-mode, defend-mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
