### PR TITLE
sec(bpf,agent): eBPF safety audit — null checks, ringbuf pairing, loop bounds, CO-RE (P1-3)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,6 +66,26 @@ When a workflow supplies a non-empty **`OTX_API_KEY`** repository secret to the 
 
 The tracked workflow **`.github/workflows/codeql.yml`** runs CodeQL for **Go**, **JavaScript/TypeScript**, **C/C++**, and **GitHub Actions** only — **not Python**, because this repository does not ship Python sources. If **Code scanning “Default setup”** is also enabled in **Settings → Code security**, either **disable Default setup** in favor of that workflow, or **edit Default setup** and **remove the Python language** so analyses stay aligned and redundant jobs do not run.
 
+### eBPF safety audit (P1-3, 2026-05-19)
+
+A systematic audit of every BPF C translation unit and the Go-side attach
+sequence ran on 2026-05-19 against the seven audit categories below. Inline
+`AUDIT(5x)` comments on each verified call site make the review visible at
+the source; this section is the audit-level summary.
+
+| Category | Sites audited | Issues found | Fix |
+| -------- | :-----------: | :----------: | --- |
+| **5a — Map lookup null checks** | 24 (`bpf_map_lookup_elem`) | 0 | All sites already pair the lookup with a `!ptr` early return or guard the deref behind `if (ptr)`/`&&`. |
+| **5b — Ringbuf reserve/discard pairing** | 11 (`bpf_ringbuf_reserve`) | 0 | Every reservation has a paired `bpf_ringbuf_submit` on success and `bpf_ringbuf_discard` on the probe-read-failure path. The `!ev` early returns hold no slot, so no discard is needed there. |
+| **5c — Pointer arithmetic bounds** | 4 | 0 | `iov_base + sizeof(coldstep_iovec)` (two iov[1] peeks) is bounded by the kernel-side check inside `bpf_probe_read_user`; `msgvec_ptr + i*64` uses a `#pragma unroll` induction variable in [1, 7]; `__data_loc` offset is verifier-guarded `< 4096`. |
+| **5d — Loop bounds** | 1 (`for` loop) | 0 | The only loop is the `#pragma unroll`'d sendmmsg extras walk with `SENDMMSG_EXTRA_MAX = 7`. |
+| **5e — BTF CO-RE field stability** | 5 (`BPF_CORE_READ`) | 0 | All accessed fields (`task_struct.pid`, `task_struct.group_leader`, `signal_struct.pids[PIDTYPE_SID]`, `pid.numbers[0].nr`, `task_struct.nsproxy.pid_ns_for_children.ns.inum`) have been stable on kernels 5.15–6.x. |
+| **5f — Helper return value checks** | 26 (`bpf_probe_read_*`) | 0 (1 hardening) | Probe-read returns are either explicitly checked OR the destination is zero-initialized so a failure fails closed. Hardening: `lsm_socket_connect` was relying on kernel 5.5+ probe-failure zeroing for `family`/`sk`/`protocol`/`daddr`/`dport`; the variables are now explicitly initialized to match the sibling `lsm_socket_sendmsg` pattern (defense in depth, no behavior change on supported kernels). |
+| **5g — Cgroup attach cleanup** | 1 (`agent_linux.go` defend block) | 0 | LSM and cgroup attaches register `defer X.Close()` immediately after each successful attach, and an explicit `lnk1.Close()` runs if `lnk2` attach fails. `defendObjs.Close()` is registered once at the top of the block so the collection is always released on the partial-attach error returns. |
+| **5h — Allowlist TOCTOU note** | 2 (cgroup + LSM loaders) | n/a | Added explicit `slog.Info("allowlist loaded into BPF map", …)` at startup with the entry counts; both loaders carry an `AUDIT(5h)` comment noting that the allowlist is a startup snapshot — runtime DNS rotation is not reflected until the next agent restart. |
+
+The audit categories follow the in-repo security plan. Sites that look suspicious but are verified safe carry an inline note explaining why (e.g. unchecked `bpf_probe_read_kernel_str` paired with a `__builtin_memset` of the destination). The superseded standalone defend translation units (`bpf/trace_defend.bpf.c`, `bpf/trace_lsm_defend.bpf.c`) were not annotated because no Go package generates from them; they share their active logic with `bpf/defend_policy.inc` which is annotated.
+
 ### Further reading
 
 Maintain optional extended design material under repo-root **`design/`** (e.g. **`egress-truthfulness-spec.md`**, **`egress-truthfulness-implementation-plan.md`**) or **`docs/`** in your clone; those trees are **gitignored** and **not** published from Git. The consumer-facing summary is the **GitHub Actions** sections above and **README** → Requirements.

--- a/bpf/defend_policy.inc
+++ b/bpf/defend_policy.inc
@@ -46,6 +46,7 @@
 static __always_inline int defense_enabled(void)
 {
 	__u32 key = COLDSTEP_DEFEND_KEY_MODE;
+	/* AUDIT(5a): null checked — `mode &&` guards deref below. */
 	__u32 *mode = bpf_map_lookup_elem(&CS_DEF_ARR_DEFEND_CFG, &key);
 
 	return mode && *mode == COLDSTEP_DEFEND_MODE_DEFEND;
@@ -57,12 +58,15 @@ static __always_inline int dst_is_allowlisted(__be32 addr)
 
 	k.prefixlen = 32;
 	k.addr = addr;
+	/* AUDIT(5a): null checked — only used inside `if (ok)`. */
 	__u8 *ok = bpf_map_lookup_elem(&CS_DEF_TRIE_ALLOWED, &k);
 	if (ok)
 		return 1;
 
+	/* AUDIT(5a): null checked — `if (domain)` guards downstream lookup. */
 	char *domain = bpf_map_lookup_elem(&dns_cache, &addr);
 	if (domain) {
+		/* AUDIT(5a): null checked — only used inside `if (dom_ok)`. */
 		__u8 *dom_ok = bpf_map_lookup_elem(&allowed_domains, domain);
 		if (dom_ok)
 			return 1;
@@ -77,6 +81,7 @@ static __always_inline int dst_in_ignored(__be32 daddr)
 
 	k.prefixlen = 32;
 	k.addr = daddr;
+	/* AUDIT(5a): null checked — pointer used only as boolean (`v != 0`). */
 	__u8 *v = bpf_map_lookup_elem(&CS_DEF_TRIE_IGNORED, &k);
 
 	return v != 0;
@@ -85,6 +90,7 @@ static __always_inline int dst_in_ignored(__be32 daddr)
 static __always_inline void note_deny_ring_reserve_failed(void)
 {
 	__u32 k = 0;
+	/* AUDIT(5a): null checked — early return guards `(*v)++`. */
 	__u32 *v = bpf_map_lookup_elem(&CS_DEF_PC_DENY_FAIL, &k);
 
 	if (!v)
@@ -94,6 +100,8 @@ static __always_inline void note_deny_ring_reserve_failed(void)
 
 static __always_inline void emit_deny_event_ipv4(__u8 protocol, const __u8 *dst4, __be16 dport, __u8 reason)
 {
+	/* AUDIT(5b): submit/discard paired — only exit path between reserve and
+	 * submit is the `!de` early return (no slot held). Submit at end. */
 	struct deny_event *de = bpf_ringbuf_reserve(&CS_DEF_RB_DENY, sizeof(*de), 0);
 
 	if (!de) {

--- a/bpf/trace_bpf_audit.bpf.c
+++ b/bpf/trace_bpf_audit.bpf.c
@@ -36,6 +36,7 @@ struct {
 static __always_inline void note_bpf_audit_reserve_failed(void)
 {
 	__u32 k = 0;
+	/* AUDIT(5a): null checked — early return guards `(*v)++`. */
 	__u32 *v = bpf_map_lookup_elem(&bpf_audit_reserve_failures, &k);
 
 	if (!v)
@@ -59,6 +60,8 @@ int handle_raw_sys_enter_bpf(struct bpf_raw_tracepoint_args *ctx)
 	if (ns_read_syscall_arg(regs, 0, &cmd_ul))
 		return 0;
 
+	/* AUDIT(5b): submit/discard paired — only exit between reserve and
+	 * submit is the `!ev` early return (no slot held). Submit unconditional. */
 	struct bpf_audit_event *ev = bpf_ringbuf_reserve(&bpf_audit_events, sizeof(*ev), 0);
 	if (!ev) {
 		note_bpf_audit_reserve_failed();

--- a/bpf/trace_connect.bpf.c
+++ b/bpf/trace_connect.bpf.c
@@ -241,6 +241,10 @@ struct {
 	__uint(max_entries, 1 << 24);
 } tls_events SEC(".maps");
 
+/*
+ * AUDIT(5a): null checked — every `note_*` counter helper below follows the
+ * same pattern: bpf_map_lookup_elem then `if (!v) return;` before deref.
+ */
 static __always_inline void note_connect4_tuple_update_failed(void)
 {
 	__u32 k = 0;
@@ -356,11 +360,14 @@ static __always_inline void note_partial_egress(int slot)
 static __always_inline void maybe_emit_canary(void)
 {
 	__u32 k = 0;
+	/* AUDIT(5a): null checked — `!seq` short-circuits before `*seq`. */
 	__u64 *seq = bpf_map_lookup_elem(&canary_trigger, &k);
 
 	if (!seq || *seq == 0)
 		return;
 
+	/* AUDIT(5b): submit/discard paired — only exit between reserve and
+	 * submit is the `!ev` early return (no slot held). Submit unconditional. */
 	struct canary_event *ev = bpf_ringbuf_reserve(&connect_events,
 						      sizeof(struct canary_event), 0);
 	if (!ev) {
@@ -556,6 +563,7 @@ int handle_raw_sys_enter(struct bpf_raw_tracepoint_args *ctx)
 #define SENDMMSG_EXTRA_MAX 7
 		if (vlen_ul > 1) {
 			__u32 k = 0;
+			/* AUDIT(5a): null checked — used only inside `if (v)`. */
 			__u32 *v = bpf_map_lookup_elem(&sendmmsg_multi_message_observed, &k);
 
 			if (v)
@@ -569,6 +577,16 @@ int handle_raw_sys_enter(struct bpf_raw_tracepoint_args *ctx)
 			 * -Wpass-failed=transform-warning under -Werror. Guard
 			 * the body with an `if` instead so all 7 iterations are
 			 * statically present and skipped when i >= vlen32.
+			 *
+			 * AUDIT(5c): pointer arithmetic bounded — `i` is the
+			 * unrolled loop induction variable in [1, 7]; the
+			 * resulting offset (i * 64) is at most 448 bytes from
+			 * the userspace mmsghdr vector base, well within the
+			 * kernel sys_sendmmsg argument range. Pointer is fed
+			 * to bpf_probe_read_user inside the helper, which
+			 * performs the kernel-side bound check.
+			 * AUDIT(5d): loop bound is constant — SENDMMSG_EXTRA_MAX=7,
+			 * verifier-provable. #pragma unroll forces full unroll.
 			 */
 #pragma unroll
 			for (int i = 1; i <= SENDMMSG_EXTRA_MAX; i++) {
@@ -580,6 +598,7 @@ int handle_raw_sys_enter(struct bpf_raw_tracepoint_args *ctx)
 
 			if (vlen32 > SENDMMSG_EXTRA_MAX + 1) {
 				__u32 ke = 0;
+				/* AUDIT(5a): null checked — used only inside `if (ve)`. */
 				__u32 *ve = bpf_map_lookup_elem(&sendmmsg_unobserved_extra, &ke);
 
 				if (ve)

--- a/bpf/trace_connect_obs.h
+++ b/bpf/trace_connect_obs.h
@@ -238,6 +238,7 @@ static __always_inline int read_ipv4_sockaddr(unsigned long sockaddr_ptr, __be16
 
 	if (!sockaddr_ptr || !port || !addr)
 		return -1;
+	/* AUDIT(5f): return checked — non-zero return propagates -1 to caller. */
 	if (bpf_probe_read_user(scratch, sizeof(scratch), (void *)sockaddr_ptr))
 		return -1;
 	return coldstep_parse_ipv4_sockaddr16(scratch, port, addr);
@@ -252,6 +253,7 @@ static __always_inline int http_prefix_looks_like_request(unsigned long buf_ptr,
 	if (!buf_ptr)
 		return 0;
 	/* Constant size 4 for strict verifiers (see read_ipv4_sockaddr). */
+	/* AUDIT(5f): return checked — non-zero return aborts the sniff (returns 0). */
 	if (bpf_probe_read_user(p, 4, (void *)buf_ptr))
 		return 0;
 	return coldstep_http_prefix_is_request(p);

--- a/bpf/trace_defend_cgroup.inc
+++ b/bpf/trace_defend_cgroup.inc
@@ -155,6 +155,7 @@ static __always_inline int cg_ipv6_is_loopback(struct bpf_sock_addr *ctx)
 static __always_inline void cg_bump_percpu_u32(void *map)
 {
 	__u32 key = 0;
+	/* AUDIT(5a): null checked — only used inside `if (val)`. */
 	__u32 *val = bpf_map_lookup_elem(map, &key);
 	if (val)
 		__sync_fetch_and_add(val, 1);

--- a/bpf/trace_dns.bpf.c
+++ b/bpf/trace_dns.bpf.c
@@ -97,6 +97,10 @@ struct {
 	__type(value, __u32);
 } tcp_dns_skipped_short_read SEC(".maps");
 
+/*
+ * AUDIT(5a): null checked — every `note_*` counter helper below follows the
+ * same pattern: bpf_map_lookup_elem then `if (!v) return;` before deref.
+ */
 static __always_inline void note_dns_ringbuf_reserve_failed(void)
 {
 	__u32 k = 0;
@@ -198,6 +202,7 @@ int handle_raw_sys_exit_dns(struct bpf_raw_tracepoint_args *ctx)
 		return 0;
 
 	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	/* AUDIT(5a): null checked — `!pending` returns before deref. */
 	pending = bpf_map_lookup_elem(&recvfrom_buf, &pid_tgid);
 	if (!pending)
 		return 0;
@@ -212,6 +217,7 @@ int handle_raw_sys_exit_dns(struct bpf_raw_tracepoint_args *ctx)
 		return 0;
 
 	if (orig_nr == (unsigned long)COLDSTEP_NR_RECVFROM) {
+		/* AUDIT(5f): return checked — non-zero aborts before deref. */
 		if (bpf_probe_read_user(hdr, sizeof(hdr), (void *)pending->buf_user))
 			return 0;
 		/* QR bit must be 1 (response) */
@@ -229,6 +235,7 @@ int handle_raw_sys_exit_dns(struct bpf_raw_tracepoint_args *ctx)
 			return 0;
 		}
 		__u8 tcp_hdr[5];
+		/* AUDIT(5f): return checked — non-zero aborts before deref. */
 		if (bpf_probe_read_user(tcp_hdr, sizeof(tcp_hdr), (void *)pending->buf_user))
 			return 0;
 		/* QR bit (byte 2 of DNS header) is at offset 4 */
@@ -256,6 +263,8 @@ int handle_raw_sys_exit_dns(struct bpf_raw_tracepoint_args *ctx)
 	if (copy_len > DNS_SNIFF_MAX)
 		copy_len = DNS_SNIFF_MAX;
 
+	/* AUDIT(5b): submit/discard paired — `!ev` early return holds no slot;
+	 * the probe-read-failure path discards before return; success submits. */
 	ev = bpf_ringbuf_reserve(&dns_events, sizeof(*ev), 0);
 	if (!ev) {
 		note_dns_ringbuf_reserve_failed();
@@ -267,6 +276,7 @@ int handle_raw_sys_exit_dns(struct bpf_raw_tracepoint_args *ctx)
 	__builtin_memset(ev->_pad, 0, sizeof(ev->_pad));
 	_Static_assert(sizeof(ev->data) == DNS_SNIFF_MAX,
 		       "dns sniff data array vs DNS_SNIFF_MAX");
+	/* AUDIT(5f): return checked — non-zero path discards the reserved slot. */
 	if (bpf_probe_read_user(ev->data, sizeof(ev->data), (void *)pending->buf_user)) {
 		bpf_ringbuf_discard(ev, 0);
 		return 0;

--- a/bpf/trace_exec.bpf.c
+++ b/bpf/trace_exec.bpf.c
@@ -32,6 +32,7 @@ struct {
 static __always_inline void note_exec_ringbuf_reserve_failed(void)
 {
 	__u32 k = 0;
+	/* AUDIT(5a): null checked — `!v` returns before deref. */
 	__u32 *v = bpf_map_lookup_elem(&exec_ringbuf_reserve_failures, &k);
 
 	if (!v)
@@ -50,6 +51,10 @@ int handle_sched_process_exec(void *ctx)
 	void *src;
 
 	e = (struct trace_event_raw_sched_process_exec *)ctx;
+	/* AUDIT(5b): submit/discard paired — only exit between reserve and
+	 * submit is the `!ev` early return (no slot held). Submit unconditional;
+	 * probe_read_kernel_str return is intentionally ignored (ev->exe_path
+	 * was memset to zero so failure leaves a zero-filled path). */
 	ev = bpf_ringbuf_reserve(&events, sizeof(*ev), 0);
 	if (!ev) {
 		note_exec_ringbuf_reserve_failed();
@@ -71,6 +76,12 @@ int handle_sched_process_exec(void *ctx)
 	 * start of the trace record. Guard both: off must be non-zero (offset 0
 	 * is the fixed record header, never the dynamic string section) and
 	 * reasonably small (trace records are page-bounded).
+	 *
+	 * AUDIT(5c): pointer arithmetic bounded — `off` is verifier-guarded
+	 * (0 < off < 4096) and `len` is clamped to EXE_PATH_MAX-1 below;
+	 * bpf_probe_read_kernel_str performs the kernel-side bound on src.
+	 * AUDIT(5f): return intentionally not checked — destination buffer was
+	 * memset to zero above so failure yields an empty exe_path string.
 	 */
 	if (len > 0 && off > 0 && off < 4096) {
 		src = (void *)((__u64)e + off); /* __data_loc: offset from trace record start */

--- a/bpf/trace_fork.bpf.c
+++ b/bpf/trace_fork.bpf.c
@@ -41,6 +41,7 @@ struct {
 static __always_inline void note_fork_ringbuf_reserve_failed(void)
 {
 	__u32 k = 0;
+	/* AUDIT(5a): null checked — `!v` returns before deref. */
 	__u32 *v = bpf_map_lookup_elem(&fork_ringbuf_reserve_failures, &k);
 
 	if (!v)
@@ -62,6 +63,8 @@ int handle_sched_process_fork(struct bpf_raw_tracepoint_args *ctx)
 	struct task_struct *child = (void *)ctx->args[1];
 	pid_t ppid, cpid;
 
+	/* AUDIT(5b): submit/discard paired — only exit between reserve and
+	 * submit is the `!ev` early return (no slot held). Submit unconditional. */
 	ev = bpf_ringbuf_reserve(&fork_events, sizeof(*ev), 0);
 	if (!ev) {
 		note_fork_ringbuf_reserve_failed();
@@ -71,14 +74,18 @@ int handle_sched_process_fork(struct bpf_raw_tracepoint_args *ctx)
 	__builtin_memset(ev->parent_comm, 0, sizeof(ev->parent_comm));
 	__builtin_memset(ev->child_comm, 0, sizeof(ev->child_comm));
 
+	/* AUDIT(5e): field stable 5.15+ — task_struct.pid has been a pid_t
+	 * field at the same offset since the kernel began publishing BTF. */
 	ppid = BPF_CORE_READ(parent, pid);
 	cpid = BPF_CORE_READ(child, pid);
 	ev->parent_pid = (__u32)ppid;
 	ev->child_pid = (__u32)cpid;
 
 	/* task_struct.comm is a fixed array; read through the kernel pointer. */
+	/* AUDIT(5f): return checked — non-zero zeroes the destination. */
 	if (bpf_probe_read_kernel_str(ev->parent_comm, sizeof(ev->parent_comm), &parent->comm))
 		__builtin_memset(ev->parent_comm, 0, sizeof(ev->parent_comm));
+	/* AUDIT(5f): return checked — non-zero zeroes the destination. */
 	if (bpf_probe_read_kernel_str(ev->child_comm, sizeof(ev->child_comm), &child->comm))
 		__builtin_memset(ev->child_comm, 0, sizeof(ev->child_comm));
 
@@ -87,6 +94,10 @@ int handle_sched_process_fork(struct bpf_raw_tracepoint_args *ctx)
 		pid_t sid = 0;
 		struct pid *spid;
 
+		/* AUDIT(5e): field stable 5.15+ — `task_struct.group_leader`,
+		 * `signal_struct.pids[PIDTYPE_SID]`, and `pid.numbers[0].nr` have
+		 * been stable since the 4.18 struct-pid rework; load failure
+		 * yields a NULL `spid` and `sid` stays zero. */
 		spid = BPF_CORE_READ(child, group_leader, signal, pids[PIDTYPE_SID]);
 		if (spid)
 			sid = BPF_CORE_READ(spid, numbers[0].nr);
@@ -94,6 +105,9 @@ int handle_sched_process_fork(struct bpf_raw_tracepoint_args *ctx)
 	}
 
 	/* v0.3: PID namespace inode — container boundary detection. */
+	/* AUDIT(5e): field stable 5.15+ — `task_struct.nsproxy`,
+	 * `nsproxy.pid_ns_for_children`, and `pid_namespace.ns.inum` (via
+	 * struct ns_common) have been stable since 3.x. */
 	ev->child_pidns_inum = (__u32)BPF_CORE_READ(child, nsproxy,
 						     pid_ns_for_children,
 						     ns.inum);

--- a/bpf/trace_fs.bpf.c
+++ b/bpf/trace_fs.bpf.c
@@ -75,6 +75,7 @@ struct {
 static __always_inline void note_fs_ringbuf_reserve_failed(void)
 {
 	__u32 k = 0;
+	/* AUDIT(5a): null checked — `!v` returns before deref. */
 	__u32 *v = bpf_map_lookup_elem(&fs_ringbuf_reserve_failures, &k);
 
 	if (!v)
@@ -85,6 +86,7 @@ static __always_inline void note_fs_ringbuf_reserve_failed(void)
 static __always_inline int fs_enabled(void)
 {
 	__u32 k = 0;
+	/* AUDIT(5a): null checked — `v &&` short-circuits before `*v`. */
 	__u8 *v = bpf_map_lookup_elem(&fs_agent_cfg, &k);
 
 	return v && *v;
@@ -97,6 +99,10 @@ static __always_inline void submit_fs_event(unsigned long path_ptr, __u8 op)
 
 	if (!path_ptr)
 		return;
+	/* AUDIT(5b): submit/discard paired — only exit between reserve and
+	 * submit is the `!ev` early return (no slot held). Submit unconditional;
+	 * probe_read_user_str return is intentionally ignored (ev->path was
+	 * memset to zero so failure leaves an empty path). */
 	ev = bpf_ringbuf_reserve(&fs_events, sizeof(*ev), 0);
 	if (!ev) {
 		note_fs_ringbuf_reserve_failed();
@@ -110,6 +116,8 @@ static __always_inline void submit_fs_event(unsigned long path_ptr, __u8 op)
 	__builtin_memset(ev->comm, 0, sizeof(ev->comm));
 	__builtin_memset(ev->path, 0, sizeof(ev->path));
 	bpf_get_current_comm(ev->comm, sizeof(ev->comm));
+	/* AUDIT(5f): return intentionally not checked — destination was memset
+	 * to zero above so failure yields an empty path string. */
 	bpf_probe_read_user_str(ev->path, sizeof(ev->path), (const void *)path_ptr);
 
 	bpf_ringbuf_submit(ev, 0);

--- a/bpf/trace_http_obs.inc
+++ b/bpf/trace_http_obs.inc
@@ -5,6 +5,8 @@
 static __always_inline void handle_http_obs_emit_pt(__u64 pt, unsigned long buf_ptr, __u32 len,
 						    __be16 sin_port, __be32 sin_addr)
 {
+	/* AUDIT(5b): submit/discard paired — `!he` early return holds no slot;
+	 * probe-read-failure path discards before return; success submits. */
 	struct http_sniff_event *he =
 		bpf_ringbuf_reserve(&http_events, sizeof(*he), 0);
 	if (!he) {
@@ -30,6 +32,7 @@ static __always_inline void handle_http_obs_emit_pt(__u64 pt, unsigned long buf_
 		__u32 sz = coldstep_probe_user_sz_http(len);
 
 		he->capture_len = (__u16)sz;
+		/* AUDIT(5f): return checked — non-zero discards the reserved slot. */
 		if (bpf_probe_read_user(he->payload, sizeof(he->payload), (void *)buf_ptr)) {
 			bpf_ringbuf_discard(he, 0);
 			return;

--- a/bpf/trace_lsm_defend_lsm.inc
+++ b/bpf/trace_lsm_defend_lsm.inc
@@ -105,24 +105,42 @@ int BPF_PROG(lsm_socket_connect, struct socket *sock, struct sockaddr *address, 
 		return 0;
 
 	struct sockaddr_in *addr4 = (struct sockaddr_in *)address;
-	short family;
+	/*
+	 * AUDIT(5f): explicit zero-init for defense in depth. Kernel 5.5+ zeros
+	 * `bpf_probe_read_*` destinations on failure (so a probe miss leaves
+	 * these as zero and fails the AF_INET / NULL guards below), but the
+	 * sibling `lsm_socket_sendmsg` path also zero-inits — keep the two
+	 * patterns consistent so a future copy-paste cannot regress to reading
+	 * stack garbage on pre-5.5 kernels or under verifier mode changes.
+	 */
+	short family = 0;
+	/* AUDIT(5f): return intentionally not checked — destination is zeroed on
+	 * failure and the AF_INET guard below fails closed (0 != AF_INET). */
 	bpf_probe_read_kernel(&family, sizeof(family), &addr4->sin_family);
 
 	if (family != AF_INET)
 		return 0;
 
-	struct sock *sk;
+	struct sock *sk = NULL;
+	/* AUDIT(5f): return intentionally not checked — `sk` zero-init + NULL
+	 * guard below means a probe failure fails closed. */
 	bpf_probe_read_kernel(&sk, sizeof(sk), &sock->sk);
 	if (!sk)
 		return 0;
 
-	short protocol;
+	short protocol = 0;
+	/* AUDIT(5f): return intentionally not checked — `protocol` zero-init
+	 * defaults to TCP (0 != IPPROTO_UDP), which is the conservative label
+	 * for the deny event when the read can't be trusted. */
 	bpf_probe_read_kernel(&protocol, sizeof(protocol), &sk->sk_protocol);
 
 	__u8 proto = (protocol == IPPROTO_UDP) ? COLDSTEP_PROTO_UDP : COLDSTEP_PROTO_TCP;
 
-	__be32 daddr;
-	__be16 dport;
+	__be32 daddr = 0;
+	__be16 dport = 0;
+	/* AUDIT(5f): return intentionally not checked — both destinations are
+	 * zero-initialized so a probe miss yields daddr=0 / dport=0 and the
+	 * allowlist / ignored-trie checks below behave deterministically. */
 	bpf_probe_read_kernel(&daddr, sizeof(daddr), &addr4->sin_addr.s_addr);
 	bpf_probe_read_kernel(&dport, sizeof(dport), &addr4->sin_port);
 
@@ -141,6 +159,7 @@ int BPF_PROG(lsm_socket_connect, struct socket *sock, struct sockaddr *address, 
 static __always_inline void lsm_bump_percpu_u32(void *map)
 {
 	__u32 key = 0;
+	/* AUDIT(5a): null checked — only used inside `if (val)`. */
 	__u32 *val = bpf_map_lookup_elem(map, &key);
 	if (val)
 		__sync_fetch_and_add(val, 1);
@@ -164,16 +183,23 @@ int BPF_PROG(lsm_socket_sendmsg, struct socket *sock, struct msghdr *msg, int si
 	 */
 
 	struct sock *sk = NULL;
+	/* AUDIT(5f): return intentionally not checked — `sk` zero-init + NULL
+	 * guard fails closed. */
 	bpf_probe_read_kernel(&sk, sizeof(sk), &sock->sk);
 	if (!sk)
 		return 0;
 
-	short protocol;
+	short protocol = 0;
+	/* AUDIT(5f): return intentionally not checked — `protocol` zero-init
+	 * defaults to TCP for the deny-event label. */
 	bpf_probe_read_kernel(&protocol, sizeof(protocol), &sk->sk_protocol);
 	__u8 proto = (protocol == IPPROTO_UDP) ? COLDSTEP_PROTO_UDP : COLDSTEP_PROTO_TCP;
 
 	struct sockaddr *address = NULL;
 	int namelen = 0;
+	/* AUDIT(5f): return intentionally not checked — both vars are
+	 * zero-initialized; downstream `if (address && namelen >= …)` falls
+	 * through to the sock_common-derived peer path on failure. */
 	bpf_probe_read_kernel(&address, sizeof(address), &msg->msg_name);
 	bpf_probe_read_kernel(&namelen, sizeof(namelen), &msg->msg_namelen);
 
@@ -185,11 +211,16 @@ int BPF_PROG(lsm_socket_sendmsg, struct socket *sock, struct msghdr *msg, int si
 			return 0;
 	} else {
 		__u16 sk_family = 0;
+		/* AUDIT(5f): return intentionally not checked — zero-init + the
+		 * `!= AF_INET` guard below fails closed on probe failure. */
 		bpf_probe_read_kernel(&sk_family, sizeof(sk_family),
 				      &sk->__sk_common.skc_family);
 		if (sk_family != AF_INET)
 			return 0;
 
+		/* AUDIT(5f): return intentionally not checked — `daddr` /
+		 * `dport` zero-init mean a probe miss yields daddr=0, and the
+		 * `daddr == 0` guard below fails closed. */
 		bpf_probe_read_kernel(&daddr, sizeof(daddr),
 				      &sk->__sk_common.skc_daddr);
 		bpf_probe_read_kernel(&dport, sizeof(dport),
@@ -236,22 +267,26 @@ int BPF_PROG(lsm_socket_sendpage, struct socket *sock, struct page *page,
 		return 0;
 
 	struct sock *sk = NULL;
+	/* AUDIT(5f): return intentionally not checked — zero-init + NULL guard. */
 	bpf_probe_read_kernel(&sk, sizeof(sk), &sock->sk);
 	if (!sk)
 		return 0;
 
 	__u16 sk_family = 0;
+	/* AUDIT(5f): return intentionally not checked — zero-init + AF_INET guard. */
 	bpf_probe_read_kernel(&sk_family, sizeof(sk_family),
 			      &sk->__sk_common.skc_family);
 	if (sk_family != AF_INET)
 		return 0;
 
 	short protocol = 0;
+	/* AUDIT(5f): return intentionally not checked — zero-init defaults to TCP. */
 	bpf_probe_read_kernel(&protocol, sizeof(protocol), &sk->sk_protocol);
 	__u8 proto = (protocol == IPPROTO_UDP) ? COLDSTEP_PROTO_UDP : COLDSTEP_PROTO_TCP;
 
 	__be32 daddr = 0;
 	__be16 dport = 0;
+	/* AUDIT(5f): return intentionally not checked — zero-init + `daddr == 0` guard. */
 	bpf_probe_read_kernel(&daddr, sizeof(daddr),
 			      &sk->__sk_common.skc_daddr);
 	bpf_probe_read_kernel(&dport, sizeof(dport),

--- a/bpf/trace_tcp_obs.inc
+++ b/bpf/trace_tcp_obs.inc
@@ -13,6 +13,8 @@ static __always_inline int handle_tcp_obs_connect(__u32 fd32, unsigned long sock
 	if (read_ipv4_sockaddr(sockaddr_ptr, &sin_port, &sin_addr))
 		return 0;
 
+	/* AUDIT(5b): submit/discard paired — only exit between reserve and
+	 * submit is the `!ce` early return (no slot held). Submit unconditional. */
 	struct connect_event *ce =
 		bpf_ringbuf_reserve(&connect_events, sizeof(*ce), 0);
 	if (!ce) {

--- a/bpf/trace_tls_write.inc
+++ b/bpf/trace_tls_write.inc
@@ -23,6 +23,7 @@ static __always_inline void try_emit_tls_clienthello_from_tuple(struct connect4_
 {
 	{
 		__u32 key0 = 0;
+		/* AUDIT(5a): null checked — `!en` short-circuits before `*en`. */
 		__u8 *en = bpf_map_lookup_elem(&tls_agent_cfg, &key0);
 
 		if (!en || *en == 0)
@@ -41,6 +42,7 @@ static __always_inline void try_emit_tls_clienthello_from_tuple(struct connect4_
 		unsigned char peek[6];
 
 		/* Constant read size — variable peeksz trips strict verifiers on some runners. */
+		/* AUDIT(5f): return checked — non-zero aborts before deref. */
 		if (bpf_probe_read_user(peek, 6, (void *)buf_ptr))
 			return;
 		if (peek[0] != 0x16)   /* ContentType: Handshake */
@@ -56,6 +58,9 @@ static __always_inline void try_emit_tls_clienthello_from_tuple(struct connect4_
 
 	{
 		__u32 tgid = (__u32)(pt >> 32);
+		/* AUDIT(5b): submit/discard paired — `!ev` early return holds
+		 * no slot; the probe-read-failure path discards before return;
+		 * success submits at end of block. */
 		struct tls_sniff_event *ev =
 			bpf_ringbuf_reserve(&tls_events, sizeof(*ev), 0);
 
@@ -78,6 +83,7 @@ static __always_inline void try_emit_tls_clienthello_from_tuple(struct connect4_
 			_Static_assert(sizeof(ev->payload) == TLS_PAYLOAD_MAX,
 				       "tls sniff payload array vs TLS_PAYLOAD_MAX");
 			ev->capture_len = (__u16)len;
+			/* AUDIT(5f): return checked — non-zero discards the reserved slot. */
 			if (bpf_probe_read_user(ev->payload, sizeof(ev->payload), (void *)buf_ptr)) {
 				bpf_ringbuf_discard(ev, 0);
 				return;
@@ -152,6 +158,9 @@ static __always_inline int handle_write_obs_sys_enter(long id, unsigned long di_
 			 */
 			if (dx_ul > 1)
 				note_tls_writev_multi_iovec();
+			/* AUDIT(5f): return checked — only the `== 0` branch
+			 * proceeds; on probe failure iov0 stays {} and the
+			 * sniff is skipped. */
 			if (bpf_probe_read_user(&iov0, sizeof(iov0), (void *)si_ul) == 0) {
 				/*
 				 * iov_len comes from untrusted userspace memory. Cap it to
@@ -178,6 +187,13 @@ static __always_inline int handle_write_obs_sys_enter(long id, unsigned long di_
 				 */
 				if (dx_ul >= 2) {
 					struct coldstep_iovec iov1 = {};
+					/* AUDIT(5c): pointer arithmetic bounded — `si_ul` is
+					 * the userspace iovec[] base; `+ sizeof(coldstep_iovec)`
+					 * advances to iov[1]. The kernel performs the actual
+					 * bounds check inside bpf_probe_read_user; a short
+					 * iovec array yields a non-zero return below and the
+					 * branch is skipped.
+					 * AUDIT(5f): return checked — only `== 0` proceeds. */
 					if (bpf_probe_read_user(&iov1, sizeof(iov1),
 						(void *)(si_ul + sizeof(struct coldstep_iovec))) == 0) {
 						__u32 iov1_len = coldstep_syscall_len_u32(iov1.iov_len);

--- a/bpf/trace_udp_obs.inc
+++ b/bpf/trace_udp_obs.inc
@@ -9,6 +9,8 @@
 static __always_inline void handle_udp_obs_emit_pt(__u64 pt, __be16 sin_port, __be32 sin_addr,
 						    __u32 len)
 {
+	/* AUDIT(5b): submit/discard paired — only exit between reserve and
+	 * submit is the `!ue` early return (no slot held). Submit unconditional. */
 	struct udp_send_event *ue =
 		bpf_ringbuf_reserve(&udp_events, sizeof(*ue), 0);
 	if (!ue) {
@@ -52,6 +54,7 @@ static __always_inline int coldstep_connect_tuple_fetch(__u32 fd32, struct conne
 	__u64 pt = bpf_get_current_pid_tgid();
 	__u32 tgid = (__u32)(pt >> 32);
 	__u64 mkey = ((__u64)tgid << 32) | (__u64)fd32;
+	/* AUDIT(5a): null checked — `!tup` short-circuits before deref. */
 	struct connect4_tuple *tup = bpf_map_lookup_elem(&connect4_by_tgid_fd, &mkey);
 
 	if (!tup || !tup->in_use || !out || !pt_out)

--- a/bpf/trace_udp_sendmsg.inc
+++ b/bpf/trace_udp_sendmsg.inc
@@ -21,6 +21,7 @@ static __always_inline int coldstep_read_msghdr_head32(unsigned long msg_hdr_ptr
 {
 	if (!msg_hdr_ptr || !out32)
 		return -1;
+	/* AUDIT(5f): return checked — non-zero propagates -1 so callers bail. */
 	if (bpf_probe_read_user(out32, 32, (void *)msg_hdr_ptr))
 		return -1;
 	return 0;
@@ -75,6 +76,7 @@ have_dest:
 		 */
 		if (msg_iovlen > 1)
 			note_udp_sendmsg_multi_iovec();
+		/* AUDIT(5f): return checked — non-zero aborts the handler. */
 		if (bpf_probe_read_user(&iov0, sizeof(iov0), (void *)msg_iov))
 			return 0;
 		if (iov0.iov_len > 0x00100000)
@@ -101,6 +103,12 @@ have_dest:
 	if (msg_iov && msg_iovlen >= 2) {
 		struct coldstep_iovec iov1 = {};
 
+		/* AUDIT(5c): pointer arithmetic bounded — `msg_iov` is the
+		 * userspace iovec[] base; `+ sizeof(coldstep_iovec)` advances
+		 * to iov[1]. The kernel performs the actual bounds check
+		 * inside bpf_probe_read_user; a short iovec array yields a
+		 * non-zero return below and the sniff is skipped.
+		 * AUDIT(5f): return checked — only `== 0` proceeds. */
 		if (bpf_probe_read_user(&iov1, sizeof(iov1),
 					(void *)(msg_iov + sizeof(struct coldstep_iovec))) == 0) {
 			__u32 iov1_len = coldstep_syscall_len_u32(iov1.iov_len);
@@ -201,6 +209,7 @@ have_dest:
 	if (!msg_iov || msg_iovlen == 0) {
 		len = 0;
 	} else {
+		/* AUDIT(5f): return checked — non-zero aborts the handler. */
 		if (bpf_probe_read_user(&iov0, sizeof(iov0), (void *)msg_iov))
 			return;
 		if (iov0.iov_len > 0x00100000)

--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -158,6 +158,19 @@ func Run(ctx context.Context, cfg config.Config) error {
 	// Defend mode: cgroup attach before traceexec/traceconnect. Ready status is written only after
 	// syscall egress tracing attaches (defend requires it); sched_process_exec + raw_tp/sys_enter loads
 	// can each take minutes on hosted runners — GitHub Actions fail-on-error waits on .coldstep-ready.json.
+	//
+	// AUDIT(5g): all attach paths close links on failure.
+	// - LSM section (lines ~205-247): if lnk2 attach fails after lnk1 succeeded,
+	//   lnk1.Close() runs explicitly before the function returns. cilium/ebpf
+	//   guarantees AttachLSM returns (nil, err) on failure, so a non-nil
+	//   sendpageLnk with attachErr != nil is unreachable.
+	// - Cgroup section (lines ~283-338): defendConnectLnk and defendSendmsgLnk
+	//   register `defer X.Close()` immediately after each successful attach;
+	//   the optional IPv6 hooks and probe failure path therefore unwind via
+	//   defers without leaking a previously-attached link.
+	// - defendObjs.Close() is registered once at the top of this block, so
+	//   the BPF collection is always released even on the partial-attach
+	//   error returns.
 	if cfg.Mode == config.ModeDefend {
 		haveLSM := false
 		if err := features.HaveProgramType(ebpf.LSM); err == nil {

--- a/internal/agent/agent_linux_policy_maps.go
+++ b/internal/agent/agent_linux_policy_maps.go
@@ -433,6 +433,20 @@ func loadLSMDefendMaps(objs *defend.DefendObjects, compiled policy.CompileResult
 		return 0, 0, err
 	}
 
+	// AUDIT(5h): allowlist is fixed-point at startup; runtime DNS changes are
+	// not reflected. The agent resolves domains once during compileDefendAllowlist
+	// and writes the resulting /32 set + literal CIDRs into the LPM trie here.
+	// If a domain's A-record set changes after this point (DNS rotation, CDN
+	// edge migration), the BPF allowlist still reflects the startup snapshot
+	// until the next agent restart. Operators relying on DNS-backed domain
+	// rules should treat the agent's lifetime as the freshness window for the
+	// allowlist and add literal CIDRs / IPs for any destinations that need to
+	// survive DNS rotation. The dns_cache map (populated by trace_dns.bpf.c at
+	// runtime) is consulted as a fallback for reverse lookups in
+	// defend_policy.inc:dst_is_allowlisted, but the primary LPM map is
+	// snapshot-only.
+	slog.Info("allowlist loaded into BPF map", "map", "lsm_allowed_ipv4", "ipv4_entries", plan.totalEntries, "ignored_cidrs", ignoredCount)
+
 	return plan.totalEntries, ignoredCount, nil
 }
 
@@ -473,6 +487,11 @@ func loadDefendMaps(objs *defend.DefendObjects, compiled policy.CompileResult, p
 	if err := loadAllowedDomainsMap(objs.AllowedDomains, pol); err != nil {
 		return 0, 0, err
 	}
+
+	// AUDIT(5h): allowlist is fixed-point at startup; runtime DNS changes are
+	// not reflected. See loadLSMDefendMaps for the full rationale — both
+	// loaders share the same compile-once / load-into-BPF lifecycle.
+	slog.Info("allowlist loaded into BPF map", "map", "allowed_ipv4", "ipv4_entries", plan.totalEntries, "ignored_cidrs", ignoredCount)
 
 	return plan.totalEntries, ignoredCount, nil
 }


### PR DESCRIPTION
﻿## Summary

Systematic eBPF safety audit (P1-3) across every BPF C translation unit and the Go-side attach sequence. Inline `AUDIT(5x)` comments make the review visible at every call site; `SECURITY.md` carries the audit-level summary.

| Category | Sites | Issues | Fix |
| -------- | :---: | :----: | --- |
| **5a — Map lookup null checks** | 24 | 0 | all guarded |
| **5b — Ringbuf reserve/discard pairing** | 11 | 0 | all paired |
| **5c — Pointer arithmetic bounds** | 4 | 0 | bounded by verifier or `bpf_probe_read_user` |
| **5d — Loop bounds** | 1 | 0 | `#pragma unroll`, `SENDMMSG_EXTRA_MAX=7` |
| **5e — BTF CO-RE field stability** | 5 | 0 | all stable on 5.15-6.x |
| **5f — Helper return value checks** | 26 | 0 (1 hardening) | `lsm_socket_connect` now explicitly initializes `family`/`sk`/`protocol`/`daddr`/`dport` so a probe miss fails closed even on pre-5.5 kernels — matches the sibling `lsm_socket_sendmsg` path |
| **5g — Cgroup attach cleanup** | 1 | 0 | partial-attach paths close every previously-attached link |
| **5h — Allowlist TOCTOU** | 2 | n/a | `slog.Info("allowlist loaded into BPF map", …)` at startup + `AUDIT(5h)` comment noting runtime DNS rotation is not reflected |

The one defense-in-depth fix lives in `bpf/trace_lsm_defend_lsm.inc:lsm_socket_connect` (zero-init `family`/`sk`/`protocol`/`daddr`/`dport`). No behavior change on supported kernels.

## Test plan

- [x] `gofmt -l` clean on `internal/agent/agent_linux.go` and `internal/agent/agent_linux_policy_maps.go`
- [x] `go vet ./internal/policy/...` clean
- [x] `go test ./internal/policy/... ./internal/report/...` pass
- [ ] CI: `coldstep-ci.yml` (unit + integration + detect-mode + defend-mode) — gates on BPF verifier acceptance of the audit-time edits, particularly the zero-init additions in `trace_lsm_defend_lsm.inc:lsm_socket_connect`
- [ ] CI: `coldstep-ci-nightly.yml` for `go test -shuffle` + race + govulncheck

## Risk

- BPF changes are comment-only except for the five zero-init declarations in `lsm_socket_connect`; the verifier may notice the extra `= 0` initializers but those are standard patterns already present in `lsm_socket_sendmsg`.
- Go changes are two `slog.Info` calls + audit comments — no logic change.
- No generated stub changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
