### PR TITLE
P1-4: SNI confidence scoring for TLS events

### DIFF
--- a/internal/agent/agent_linux_digest.go
+++ b/internal/agent/agent_linux_digest.go
@@ -88,6 +88,7 @@ func buildDigestInput(
 	canarySnap canarySnapshot,
 ) report.DigestInput {
 	execN, tcpN, udpN, httpN, tlsN, fsN := stats.counts()
+	tlsConfFull, tlsConfPartial, tlsConfInferred, tlsConfUnknown := stats.tlsConfidenceCounts()
 	rawTPName := "raw_tp/sys_enter (connect, sendto, http sniff, tls)"
 	in := report.DigestInput{
 		DetectProfile:                  cfg.DetectProfile,
@@ -97,6 +98,10 @@ func buildDigestInput(
 		UDPTotal:                       udpN,
 		HTTPTotal:                      httpN,
 		TLSTotal:                       tlsN,
+		TLSConfidenceFull:              tlsConfFull,
+		TLSConfidencePartial:           tlsConfPartial,
+		TLSConfidenceInferred:          tlsConfInferred,
+		TLSConfidenceUnknown:           tlsConfUnknown,
 		TLSSNIGate:                     tlsSNIGate,
 		PolicyCounts:                   stats.snapshotPolicyCounts(),
 		ExecRows:                       execRows,

--- a/internal/agent/agent_linux_ring_read.go
+++ b/internal/agent/agent_linux_ring_read.go
@@ -378,7 +378,8 @@ func readTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, pol
 			continue
 		}
 		cl := pol.Classify(sni, ip)
-		stats.addTLS(cl)
+		conf := telemetry.ScoreTLSConfidence(sni)
+		stats.addTLS(cl, conf)
 
 		ts := time.Now().UTC().Format(time.RFC3339Nano)
 		rows.addTLS(report.TLSDigestRow{
@@ -395,7 +396,8 @@ func readTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, pol
 				Type: "tls", TS: ts, Seq: n,
 				PID: tgid, TGID: tgid, ThreadID: tid,
 				Comm: comm, SNI: sni,
-				Dst: ip.String(), Dport: port,
+				Confidence: conf,
+				Dst:        ip.String(), Dport: port,
 				Policy: string(cl),
 				Note:   "ClientHello SNI from first write/writev/sendto buffer (best-effort); fragmented handshakes may be missed",
 			}

--- a/internal/agent/agent_linux_state.go
+++ b/internal/agent/agent_linux_state.go
@@ -34,6 +34,10 @@ type runStats struct {
 	udpN                            int
 	httpN                           int
 	tlsN                            int
+	tlsConfidenceFullN              int
+	tlsConfidencePartialN           int
+	tlsConfidenceInferredN          int
+	tlsConfidenceUnknownN           int
 	procForkN                       int
 	fsN                             int
 	connect4TupleUpdateFailuresN    int
@@ -153,11 +157,29 @@ func (s *runStats) addHTTP(cl policy.Class) {
 	s.addPolicyLocked(cl)
 }
 
-func (s *runStats) addTLS(cl policy.Class) {
+func (s *runStats) addTLS(cl policy.Class, conf telemetry.TLSConfidence) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.tlsN++
+	switch conf {
+	case telemetry.TLSConfidenceFull:
+		s.tlsConfidenceFullN++
+	case telemetry.TLSConfidencePartial:
+		s.tlsConfidencePartialN++
+	case telemetry.TLSConfidenceInferred:
+		s.tlsConfidenceInferredN++
+	default:
+		s.tlsConfidenceUnknownN++
+	}
 	s.addPolicyLocked(cl)
+}
+
+// tlsConfidenceCounts returns per-tier TLS confidence counters (full,
+// partial, inferred, unknown) for digest reporting.
+func (s *runStats) tlsConfidenceCounts() (full, partial, inferred, unknown int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.tlsConfidenceFullN, s.tlsConfidencePartialN, s.tlsConfidenceInferredN, s.tlsConfidenceUnknownN
 }
 
 func (s *runStats) setConnect4TupleUpdateFailures(n int) {

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -330,6 +330,9 @@ func writeFullKPITable(b *strings.Builder, in DigestInput) {
 
 	if tlsKPIVisible(in) {
 		fmt.Fprintf(b, "| **tls** | %d |\n", in.TLSTotal)
+		if in.TLSTotal > 0 {
+			fmt.Fprintf(b, "| **tls SNI confidence** | %s |\n", formatTLSConfidenceCell(in))
+		}
 		if in.TLSRingbufReserveFailures > 0 {
 			fmt.Fprintf(b, "| **tls_events ringbuf reserve failures** | %d |\n", in.TLSRingbufReserveFailures)
 		}

--- a/internal/report/digest_aggregation.go
+++ b/internal/report/digest_aggregation.go
@@ -181,6 +181,26 @@ func tlsKPIVisible(in DigestInput) bool {
 	return in.TLSSNIGate
 }
 
+// formatTLSConfidenceCell renders the per-tier TLS SNI confidence counters as
+// a compact `full=N partial=M unknown=K` cell. Inferred is only included when
+// non-zero (no enricher emits it today, so callers can keep the cell short).
+// Callers should gate the row on TLSTotal > 0; we still defend with the same
+// check so an accidental call with zero events does not show a misleading row.
+func formatTLSConfidenceCell(in DigestInput) string {
+	if in.TLSTotal == 0 {
+		return "—"
+	}
+	parts := []string{
+		fmt.Sprintf("full=%d", in.TLSConfidenceFull),
+		fmt.Sprintf("partial=%d", in.TLSConfidencePartial),
+	}
+	if in.TLSConfidenceInferred > 0 {
+		parts = append(parts, fmt.Sprintf("inferred=%d", in.TLSConfidenceInferred))
+	}
+	parts = append(parts, fmt.Sprintf("unknown=%d", in.TLSConfidenceUnknown))
+	return strings.Join(parts, " · ")
+}
+
 func fsKPIVisible(in DigestInput) bool {
 	return in.FSGate
 }

--- a/internal/report/digest_test.go
+++ b/internal/report/digest_test.go
@@ -259,6 +259,41 @@ func TestBuildDetectMarkdown_TLSKPIAndSection(t *testing.T) {
 	}
 }
 
+func TestBuildDetectMarkdown_TLSConfidenceKPIRow(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{
+		BPF:                  []telemetry.BPFStatus{{Name: "raw_tp/sys_enter (connect, sendto, http sniff, tls)", OK: true}},
+		TLSTotal:             3,
+		TLSConfidenceFull:    2,
+		TLSConfidencePartial: 1,
+		TLSConfidenceUnknown: 0,
+		TLSSNIGate:           true,
+		PolicyCounts:         map[string]int{"monitor": 3},
+		MaxRowsPerSection:    50,
+	})
+	for _, needle := range []string{
+		"| **tls SNI confidence** |",
+		"full=2",
+		"partial=1",
+		"unknown=0",
+	} {
+		if !strings.Contains(md, needle) {
+			t.Fatalf("missing %q in:\n%s", needle, md)
+		}
+	}
+}
+
+func TestBuildDetectMarkdown_TLSConfidenceRowHiddenWhenNoTLS(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{
+		BPF:               []telemetry.BPFStatus{{Name: "raw_tp/sys_enter (connect, sendto, http sniff, tls)", OK: true}},
+		TLSTotal:          0,
+		TLSSNIGate:        true,
+		MaxRowsPerSection: 50,
+	})
+	if strings.Contains(md, "tls SNI confidence") {
+		t.Fatalf("confidence row should be hidden when TLSTotal=0, got:\n%s", md)
+	}
+}
+
 func TestTruncateExeForDigest(t *testing.T) {
 	long := strings.Repeat("a", execExeDigestMaxBytes+20)
 	out := TruncateExeForDigest(long)

--- a/internal/report/digest_types.go
+++ b/internal/report/digest_types.go
@@ -108,7 +108,16 @@ type DigestInput struct {
 
 	ExecTotal, TCPTotal, UDPTotal, HTTPTotal, TLSTotal int
 	TLSSNIGate                                         bool
-	PolicyCounts                                       map[string]int
+	// TLSConfidenceFull / Partial / Inferred / Unknown count TLS events by the
+	// reliability of the captured SNI. The digest surfaces these as a
+	// `full=N partial=M unknown=K` row when at least one TLS event exists, so
+	// operators can weigh how trustworthy an SNI-based allow/deny match is on
+	// this run.
+	TLSConfidenceFull     int
+	TLSConfidencePartial  int
+	TLSConfidenceInferred int
+	TLSConfidenceUnknown  int
+	PolicyCounts          map[string]int
 
 	ExecRows  []ExecDigestRow
 	TCPRows   []TCPDigestRow

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -132,21 +132,71 @@ type HTTPEvent struct {
 	Sig      string `json:"sig,omitempty"`
 }
 
+// TLSConfidence indicates how reliably the SNI on a TLSEvent was captured.
+//
+//   - "full":     SNI present in ClientHello, length below the RFC 1035
+//     server-name boundary — best-effort but not truncated.
+//   - "partial":  SNI length hit the BPF/RFC capture boundary (TLSSNIMaxLen);
+//     the captured value may be a prefix of the real server name.
+//   - "inferred": SNI was inferred from rDNS or prior connection state
+//     (reserved for future enrichers; not yet emitted by the BPF path).
+//   - "unknown":  no usable SNI signal was captured.
+//
+// Operators reading the JSONL / digest can use the field to weigh how much to
+// trust an SNI-based allow/deny match.
+type TLSConfidence string
+
+const (
+	TLSConfidenceFull     TLSConfidence = "full"
+	TLSConfidencePartial  TLSConfidence = "partial"
+	TLSConfidenceInferred TLSConfidence = "inferred"
+	TLSConfidenceUnknown  TLSConfidence = "unknown"
+)
+
+// TLSSNIMaxLen is the maximum SNI host_name length the SNI parser accepts
+// (RFC 1035 §2.3.4 — labels add to 255 octets max). When the captured SNI
+// length is exactly TLSSNIMaxLen we cannot tell whether the real server name
+// was longer, so confidence drops to TLSConfidencePartial.
+const TLSSNIMaxLen = 255
+
+// ScoreTLSConfidence classifies the SNI captured for a TLS ClientHello event
+// using only the parsed SNI string. The function is intentionally a pure
+// helper so it is straightforward to unit-test and reuse from non-Linux
+// callers (replay, fuzz tooling).
+//
+// Inputs:
+//
+//   - sni: the host_name parsed out of the ClientHello (lower-cased,
+//     trimmed). Empty when no SNI was usable.
+//
+// The function does not consult rDNS or any prior connection state today;
+// TLSConfidenceInferred is reserved for a future enricher.
+func ScoreTLSConfidence(sni string) TLSConfidence {
+	if sni == "" {
+		return TLSConfidenceUnknown
+	}
+	if len(sni) >= TLSSNIMaxLen {
+		return TLSConfidencePartial
+	}
+	return TLSConfidenceFull
+}
+
 // TLSEvent is one JSONL record for TLS ClientHello SNI observed on egress (detect).
 type TLSEvent struct {
-	Type     string `json:"type"` // "tls"
-	TS       string `json:"ts"`
-	Seq      uint64 `json:"seq"`
-	PID      uint32 `json:"pid"`
-	TGID     uint32 `json:"tgid"`
-	ThreadID uint32 `json:"thread_id"`
-	Comm     string `json:"comm"`
-	SNI      string `json:"sni"`
-	Dst      string `json:"dst"`
-	Dport    uint16 `json:"dport"`
-	Policy   string `json:"policy"`
-	Note     string `json:"note,omitempty"`
-	Sig      string `json:"sig,omitempty"`
+	Type       string        `json:"type"` // "tls"
+	TS         string        `json:"ts"`
+	Seq        uint64        `json:"seq"`
+	PID        uint32        `json:"pid"`
+	TGID       uint32        `json:"tgid"`
+	ThreadID   uint32        `json:"thread_id"`
+	Comm       string        `json:"comm"`
+	SNI        string        `json:"sni"`
+	Confidence TLSConfidence `json:"confidence,omitempty"`
+	Dst        string        `json:"dst"`
+	Dport      uint16        `json:"dport"`
+	Policy     string        `json:"policy"`
+	Note       string        `json:"note,omitempty"`
+	Sig        string        `json:"sig,omitempty"`
 }
 
 // FSEvent is one JSONL record for a high-signal filesystem operation (detect, feature-gated).

--- a/internal/telemetry/tls_confidence_test.go
+++ b/internal/telemetry/tls_confidence_test.go
@@ -1,0 +1,57 @@
+package telemetry
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScoreTLSConfidence_Full(t *testing.T) {
+	got := ScoreTLSConfidence("example.com")
+	if got != TLSConfidenceFull {
+		t.Fatalf("ScoreTLSConfidence(\"example.com\") = %q, want %q", got, TLSConfidenceFull)
+	}
+}
+
+func TestScoreTLSConfidence_FullJustBelowBoundary(t *testing.T) {
+	// A 254-char hostname is one byte short of the RFC 1035 boundary; the parser
+	// would have accepted it intact, so confidence stays full.
+	sni := strings.Repeat("a", TLSSNIMaxLen-1)
+	got := ScoreTLSConfidence(sni)
+	if got != TLSConfidenceFull {
+		t.Fatalf("ScoreTLSConfidence(len=%d) = %q, want %q", len(sni), got, TLSConfidenceFull)
+	}
+}
+
+func TestScoreTLSConfidence_PartialAtBoundary(t *testing.T) {
+	// At exactly TLSSNIMaxLen (255) the SNI hit the parser's upper bound; we
+	// cannot tell whether the real server name was longer, so we report partial.
+	sni := strings.Repeat("a", TLSSNIMaxLen)
+	got := ScoreTLSConfidence(sni)
+	if got != TLSConfidencePartial {
+		t.Fatalf("ScoreTLSConfidence(len=%d) = %q, want %q", len(sni), got, TLSConfidencePartial)
+	}
+}
+
+func TestScoreTLSConfidence_Unknown(t *testing.T) {
+	got := ScoreTLSConfidence("")
+	if got != TLSConfidenceUnknown {
+		t.Fatalf("ScoreTLSConfidence(\"\") = %q, want %q", got, TLSConfidenceUnknown)
+	}
+}
+
+func TestTLSConfidenceConstants(t *testing.T) {
+	cases := []struct {
+		v    TLSConfidence
+		want string
+	}{
+		{TLSConfidenceFull, "full"},
+		{TLSConfidencePartial, "partial"},
+		{TLSConfidenceInferred, "inferred"},
+		{TLSConfidenceUnknown, "unknown"},
+	}
+	for _, c := range cases {
+		if string(c.v) != c.want {
+			t.Errorf("TLSConfidence string mismatch: got %q want %q", c.v, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `TLSConfidence` enum (`full` / `partial` / `inferred` / `unknown`) and a `Confidence` field on `telemetry.TLSEvent` so operators can weigh how trustworthy an SNI-based allow/deny match is on a given run. The detect digest gains a `tls SNI confidence` KPI row (`full=N · partial=M · unknown=K`) inside the Full KPI fold, gated on `TLSTotal > 0`.

## What changed

- **`internal/telemetry/event.go`** — new `TLSConfidence` type + constants, `TLSSNIMaxLen = 255` (RFC 1035 boundary), `ScoreTLSConfidence(sni string)` pure helper, and a `Confidence` field on `TLSEvent` (`omitempty`, so legacy consumers ignore it).
- **`internal/agent/agent_linux_ring_read.go`** — scores each TLS event after `ParseClientHelloSNI` and stamps `Confidence` on the JSONL record.
- **`internal/agent/agent_linux_state.go`** — `addTLS` now takes the confidence tier; per-tier counters land in `runStats` and are exposed via `tlsConfidenceCounts()`.
- **`internal/agent/agent_linux_digest.go`** — threads the four counters into `DigestInput`.
- **`internal/report/digest_types.go` / `digest_aggregation.go` / `digest.go`** — new `TLSConfidence*` fields on `DigestInput`, a `formatTLSConfidenceCell` helper, and a new KPI row.

## Scoring rules

Pure function of the parsed SNI string today (no rDNS yet — `inferred` is reserved for a future enricher):

- empty SNI → `unknown`
- `len(sni) >= TLSSNIMaxLen` (255) → `partial` (the captured value may be a prefix of the real server name)
- otherwise → `full`

## Tests

- `internal/telemetry/tls_confidence_test.go` covers `full` / boundary `partial` (255-byte SNI) / `full` just below the boundary (254-byte SNI) / `unknown` / the string values of the four constants.
- `internal/report/digest_test.go` gains two cases: the new KPI row renders with `full=2 · partial=1 · unknown=0` and is hidden when `TLSTotal=0`.

## Test plan

- [x] `gofmt -l` clean on every touched `.go` file
- [x] `go vet ./internal/telemetry/... ./internal/report/...` passes
- [x] `go test ./internal/telemetry/... ./internal/report/... -count=1` passes
- [x] `go build ./cmd/coldstep-action/... ./cmd/coldstep-report/...` succeeds
- [ ] CI: `coldstep-ci-runner.yml` unit + integration matrix (full BPF path)

## Backwards compatibility

`Confidence` is JSON-`omitempty` and the per-tier `DigestInput` fields default to zero, so older JSONL artifacts and report builders that don't know about confidence continue to work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)