### PR TITLE
sec(bpf,policy): P2-1 IPv6 Phase 2 — defend mode blocks non-loopback IPv6 egress via LPM trie + AAAA resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ The single `uses:` block is enough — node24 pre/post hooks start the agent bef
 
 | Topic | Detail |
 | :---- | :----- |
-| **IP versions** | **Defend is IPv4-only.** Allowlists and cgroup blocking (`connect4` / `sendmsg4`) cover IPv4 traffic only. **IPv6 egress is observed** via `cgroup/connect6` / `cgroup/sendmsg6` and surfaces in the digest as **⚠️** (detect) or **🚨** (defend, where it escaped enforcement) — Phase 1, observe-only. IPv6 blocking is not yet implemented. |
+| **IP versions** | **Defend is IPv4 + IPv6.** Allowlists resolve both **A** and **AAAA** records and program two LPM tries: `allowed_ipv4` (4-byte keys) and `allowed_ipv6` (16-byte keys). cgroup hooks block on both families — `connect4` / `sendmsg4` for IPv4, `connect6` / `sendmsg6` for IPv6 — denying any destination not on the allowlist with `EPERM`. `::1` (loopback) and `fe80::/10` (link-local) always bypass enforcement. Detect mode observes both families without enforcing. |
 | **Runner OS** | **Linux only** for the agent. **v1 supports `ubuntu-latest` only** (GitHub-hosted Ubuntu x64). Not supported on macOS, Windows, self-hosted, or other `runs-on` labels until explicitly documented in a later release. |
 | **Build on runner** | The action runs [`scripts/build-agent-linux.sh`](scripts/build-agent-linux.sh) (clang, libbpf, **bpftool** against `/sys/kernel/btf/vmlinux` → `bpf/vmlinux.h`, `go generate` / bpf2go, then **`go build`** → **`bin/coldstep`**). |
 | **Privileges** | The agent runs under **`sudo`** to load BPF. |
 | **Action runtime** | Composite action is shell + Go binaries (`bin/coldstep-action`, `bin/coldstep-report`) and no longer requires Node.js runtime hooks. |
 
-For **GitHub Actions security posture** — threat model for a workflow job, consumer mitigations (pins, permissions), residual risk, and honest telemetry scope — see **[SECURITY.md](SECURITY.md)** (*GitHub Actions: threat model and mitigations*). For **guaranteed vs best-effort behavior** (telemetry gaps, hooks, IPv4-only defend), see **[Guarantees vs best-effort](SECURITY.md#guarantees-vs-best-effort-defend-and-detect)**. Maintainers may keep deeper **egress truthfulness** specs under local **`design/`** (gitignored); consumers should rely on **SECURITY.md** and **README**.
+For **GitHub Actions security posture** — threat model for a workflow job, consumer mitigations (pins, permissions), residual risk, and honest telemetry scope — see **[SECURITY.md](SECURITY.md)** (*GitHub Actions: threat model and mitigations*). For **guaranteed vs best-effort behavior** (telemetry gaps, hook coverage), see **[Guarantees vs best-effort](SECURITY.md#guarantees-vs-best-effort-defend-and-detect)**. Maintainers may keep deeper **egress truthfulness** specs under local **`design/`** (gitignored); consumers should rely on **SECURITY.md** and **README**.
 
 ---
 

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,12 @@ inputs:
 
   mode:
     description: >-
-      Runtime mode: detect (default) or defend (blocking, requires allowlist). The enforce spelling is not supported; use defend.
+      Runtime mode: detect (default) or defend (blocking, requires allowlist).
+      defend resolves A and AAAA records for every domain in the allowlist and
+      programs both the BPF allowed_ipv4 and allowed_ipv6 LPM tries. cgroup
+      hooks block non-allowlisted egress on both IPv4 (connect4/sendmsg4) and
+      IPv6 (connect6/sendmsg6); ::1 and fe80::/10 always bypass. The enforce
+      spelling is not supported; use defend.
     required: false
     default: detect
 
@@ -20,7 +25,10 @@ inputs:
       Comma- or newline-separated egress allowlist. Accepts plain domains (example.com), wildcard domains (*.example.com),
       IPv4 literals (1.2.3.4), and CIDRs (10.0.0.0/8). Prefix a CIDR with ! to ignore that net (e.g. !192.168.0.0/16).
       Entries are auto-classified: IP/CIDR → allowed-ips, domain/wildcard → allowed-hosts + allowed-domains.
-      Merged with allow-file and the legacy per-type inputs.
+      Merged with allow-file and the legacy per-type inputs. In defend mode each
+      domain is resolved for both A and AAAA records; matching IPv4 and IPv6
+      addresses populate the BPF allowlists. IPv6 literals are not accepted as
+      input today — use AAAA-bearing hostnames instead.
     required: false
     default: ''
 

--- a/bpf/defend_lpm_v6_key.h
+++ b/bpf/defend_lpm_v6_key.h
@@ -1,0 +1,19 @@
+/*
+ * IPv6 LPM trie key for defend allowlist map (P2-1, Phase 2).
+ * Layout matches BPF_MAP_TYPE_LPM_TRIE: prefixlen (CPU-endian) + addr (network order).
+ *
+ * Userspace must mirror this wire format byte-for-byte in
+ * loadAllowedLPMv6Map: 20-byte buffer where bytes [0:4] are the prefix
+ * length in CPU/little-endian order and bytes [4:20] are the IPv6 address
+ * in network byte order. Drift between the two sides equals silent BPF
+ * EINVAL on Update at agent start, surfacing as IPv6 defend-bypass.
+ */
+#ifndef COLDSTEP_DEFEND_LPM_V6_KEY_H
+#define COLDSTEP_DEFEND_LPM_V6_KEY_H
+
+struct lpm_v6_key {
+	__u32 prefixlen;
+	__u8 addr[16];
+} __attribute__((packed));
+
+#endif /* COLDSTEP_DEFEND_LPM_V6_KEY_H */

--- a/bpf/trace_defend_all.bpf.c
+++ b/bpf/trace_defend_all.bpf.c
@@ -24,6 +24,7 @@
 #include <bpf/bpf_endian.h>
 #include "trace_connect_obs.h"
 #include "defend_lpm_key.h"
+#include "defend_lpm_v6_key.h"
 #include "dns_cache.h"
 #include "deny_event.h"
 
@@ -39,6 +40,10 @@ char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
 #ifndef AF_INET
 #define AF_INET 2
+#endif
+
+#ifndef AF_INET6
+#define AF_INET6 10
 #endif
 
 #ifndef EPERM

--- a/bpf/trace_defend_cgroup.inc
+++ b/bpf/trace_defend_cgroup.inc
@@ -194,6 +194,25 @@ static __always_inline void cg_bump_percpu_u32(void *map)
 }
 
 /*
+ * Copy the 16-byte IPv6 destination from ctx->user_ip6 into a __u32[4]
+ * aligned destination. The cgroup/connect|sendmsg6 verifier rewrites
+ * each `ctx->user_ip6[i]` access into a 4-byte converter load against
+ * the internal sockaddr fields. A wider read (e.g. `__builtin_memcpy
+ * (dst, &ctx->user_ip6[0], 16)`) is rejected with "dereference of
+ * modified ctx ptr R2 off=8 disallowed" because the verifier won't let
+ * helpers / memcpy receive the converter-managed ctx pointer at a
+ * non-zero offset. Issuing four direct __u32 loads stays inside the
+ * allowed access pattern.
+ */
+static __always_inline void cg_copy_user_ip6_u32(struct bpf_sock_addr *ctx, __u32 dst[4])
+{
+	dst[0] = ctx->user_ip6[0];
+	dst[1] = ctx->user_ip6[1];
+	dst[2] = ctx->user_ip6[2];
+	dst[3] = ctx->user_ip6[3];
+}
+
+/*
  * IPv6 allowlist LPM lookup. user_ip6 is __be32[4] (network order); the
  * LPM trie key copies those 16 bytes verbatim into struct lpm_v6_key.addr.
  * Prefixlen is set to /128 for the lookup itself; the trie matches
@@ -205,7 +224,7 @@ static __always_inline int cg_ipv6_is_allowlisted(struct bpf_sock_addr *ctx)
 	struct lpm_v6_key k = {};
 
 	k.prefixlen = 128;
-	__builtin_memcpy(&k.addr[0], &ctx->user_ip6[0], sizeof(k.addr));
+	cg_copy_user_ip6_u32(ctx, (__u32 *)&k.addr[0]);
 	/* AUDIT(5a): null checked — only used inside `if (ok)`. */
 	__u8 *ok = bpf_map_lookup_elem(&allowed_ipv6, &k);
 	return ok != 0;
@@ -240,7 +259,14 @@ static __always_inline void cg_emit_deny_event_ipv6(__u8 protocol, struct bpf_so
 	de->reason = reason;
 	de->af = AF_INET6;
 	de->_pad = 0;
-	__builtin_memcpy(&de->daddr[0], &ctx->user_ip6[0], sizeof(de->daddr));
+	/*
+	 * Same converter-load restriction as cg_copy_user_ip6_u32 — avoid
+	 * passing &ctx->user_ip6[0] to memcpy and instead emit four 4-byte
+	 * stores into the ringbuf record. de->daddr starts at offset 28
+	 * (4+4+16+1+1+1+1) inside the packed deny_event, which is __u32-
+	 * aligned so the casts are sound.
+	 */
+	cg_copy_user_ip6_u32(ctx, (__u32 *)&de->daddr[0]);
 	__builtin_memcpy(de->dport, &dport, sizeof(de->dport));
 	bpf_ringbuf_submit(de, 0);
 }

--- a/bpf/trace_defend_cgroup.inc
+++ b/bpf/trace_defend_cgroup.inc
@@ -1,20 +1,23 @@
 /*
  * Cgroup egress defend section of bpf/trace_defend_all.bpf.c.
  *
- * IPv4 paths (`cgroup/connect4`, `cgroup/sendmsg4`) carry the policy-based
- * deny logic. IPv6 paths (`cgroup/connect6`, `cgroup/sendmsg6`) are
- * Phase 1 observe-only (P0-1): they bump per-cpu counters but always
- * return 1 (allow). Enforcement on IPv6 is a future phase.
+ * IPv4 paths (`cgroup/connect4`, `cgroup/sendmsg4`) and IPv6 paths
+ * (`cgroup/connect6`, `cgroup/sendmsg6`) both carry policy-based deny
+ * logic. P2-1 Phase 2 added the IPv6 LPM allowlist (`allowed_ipv6`) and
+ * deny emission; ::1 (loopback) and fe80::/10 (link-local) bypass enforcement
+ * and the observe-only counters (`ipv6_connect_observed`,
+ * `ipv6_sendmsg_observed`) still bump for visibility.
  *
  * Maps in this section use bare names (no prefix): deny_events,
  * deny_reserve_failures, defend_cfg, allowed_ipv4, ignored_ipv4_lpm,
- * ipv6_connect_observed, ipv6_sendmsg_observed.
+ * allowed_ipv6, ipv6_connect_observed, ipv6_sendmsg_observed.
  * Policy helpers from defend_policy.inc are renamed to cg_* so the LSM
  * section can declare lsm_* equivalents in the same translation unit.
  *
  * The combined .bpf.c provides vmlinux/BPF helpers, LICENSE, shared
- * #defines (IPPROTO_*, AF_INET, COLDSTEP_*), the deny_event _Static_assert,
- * and dns_cache.h (allowed_domains + dns_cache) before including this file.
+ * #defines (IPPROTO_*, AF_INET, AF_INET6, COLDSTEP_*), the deny_event
+ * _Static_assert, and dns_cache.h (allowed_domains + dns_cache) before
+ * including this file.
  */
 
 struct {
@@ -54,6 +57,20 @@ struct {
 	__type(key, struct ns_lpm4_key);
 	__type(value, __u8);
 } ignored_ipv4_lpm SEC(".maps");
+
+/*
+ * P2-1 Phase 2: IPv6 defend allowlist. AAAA-resolved domain entries plus
+ * implicit ::1/128 (loopback) and fe80::/10 (link-local) bypass live here.
+ * Sized identically to allowed_ipv4 (4096) so the abi_test pair stays
+ * symmetric; userspace bounds inserts by policy.MaxAllowedDefendIPv6Keys.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_LPM_TRIE);
+	__uint(max_entries, 4096);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__type(key, struct lpm_v6_key);
+	__type(value, __u8);
+} allowed_ipv6 SEC(".maps");
 
 /*
  * P0-1 Phase 1: IPv6 egress observe-only counters. cgroup/connect6 and
@@ -142,7 +159,8 @@ int defend_sendmsg4(struct bpf_sock_addr *ctx)
 /*
  * IPv6 loopback (::1) check: user_ip6 is __be32[4] in network byte order;
  * ::1 is {0,0,0,htonl(1)}. Skip loopback so test runners' localhost IPv6
- * traffic doesn't dominate the counter.
+ * traffic doesn't dominate the counter, and so loopback always bypasses
+ * Phase 2 enforcement.
  */
 static __always_inline int cg_ipv6_is_loopback(struct bpf_sock_addr *ctx)
 {
@@ -150,6 +168,20 @@ static __always_inline int cg_ipv6_is_loopback(struct bpf_sock_addr *ctx)
 	       ctx->user_ip6[1] == 0 &&
 	       ctx->user_ip6[2] == 0 &&
 	       ctx->user_ip6[3] == bpf_htonl(1);
+}
+
+/*
+ * IPv6 link-local (fe80::/10) check: user_ip6[0] is the first __be32 of
+ * the IPv6 address in network byte order, so the high-order bytes are at
+ * the low memory addresses. fe80::/10 = first 10 bits 1111 1110 10xx, i.e.
+ * the high 16 bits are 0xfe80..0xfebf — equivalently network-order
+ * (user_ip6[0] & htonl(0xffc00000)) == htonl(0xfe800000). Always-bypass
+ * for these so router solicitations / mDNS / SLAAC discovery don't get
+ * blocked.
+ */
+static __always_inline int cg_ipv6_is_link_local(struct bpf_sock_addr *ctx)
+{
+	return (ctx->user_ip6[0] & bpf_htonl(0xffc00000)) == bpf_htonl(0xfe800000);
 }
 
 static __always_inline void cg_bump_percpu_u32(void *map)
@@ -162,25 +194,93 @@ static __always_inline void cg_bump_percpu_u32(void *map)
 }
 
 /*
- * Phase 1 (P0-1): observe-only — record the IPv6 egress attempt and
- * always return 1 (allow). Enforcement on IPv6 is a future phase; right
- * now coldstep can't gate it, but the digest can warn that traffic
- * escaped the IPv4-only allowlist.
+ * IPv6 allowlist LPM lookup. user_ip6 is __be32[4] (network order); the
+ * LPM trie key copies those 16 bytes verbatim into struct lpm_v6_key.addr.
+ * Prefixlen is set to /128 for the lookup itself; the trie matches
+ * longest-prefix against shorter inserted prefixes (e.g. /48 from AAAA
+ * resolution).
  */
+static __always_inline int cg_ipv6_is_allowlisted(struct bpf_sock_addr *ctx)
+{
+	struct lpm_v6_key k = {};
+
+	k.prefixlen = 128;
+	__builtin_memcpy(&k.addr[0], &ctx->user_ip6[0], sizeof(k.addr));
+	/* AUDIT(5a): null checked — only used inside `if (ok)`. */
+	__u8 *ok = bpf_map_lookup_elem(&allowed_ipv6, &k);
+	return ok != 0;
+}
+
+/*
+ * Emit an IPv6 deny event into the shared deny_events ringbuf. The
+ * `deny_event` wire layout has a 16-byte daddr field that already
+ * accommodates an IPv6 address; userspace inspects `af` to decide how to
+ * render it. Mirrors emit_deny_event_ipv4 from defend_policy.inc but
+ * sets af=AF_INET6 and writes all 16 bytes.
+ */
+static __always_inline void cg_emit_deny_event_ipv6(__u8 protocol, struct bpf_sock_addr *ctx,
+						    __be16 dport, __u8 reason)
+{
+	/* AUDIT(5b): submit/discard paired — only exit path between reserve and
+	 * submit is the `!de` early return (no slot held). Submit at end. */
+	struct deny_event *de = bpf_ringbuf_reserve(&deny_events, sizeof(*de), 0);
+
+	if (!de) {
+		cg_note_deny_ring_reserve_failed();
+		return;
+	}
+	{
+		__u64 pt = bpf_get_current_pid_tgid();
+
+		de->tgid = (__u32)(pt >> 32);
+		de->tid = (__u32)pt;
+	}
+	bpf_get_current_comm(&de->comm, sizeof(de->comm));
+	de->protocol = protocol;
+	de->reason = reason;
+	de->af = AF_INET6;
+	de->_pad = 0;
+	__builtin_memcpy(&de->daddr[0], &ctx->user_ip6[0], sizeof(de->daddr));
+	__builtin_memcpy(de->dport, &dport, sizeof(de->dport));
+	bpf_ringbuf_submit(de, 0);
+}
+
+/*
+ * P2-1 Phase 2: IPv6 enforcement. ::1 (loopback) and fe80::/10
+ * (link-local) always allow; non-loopback destinations still bump the
+ * observe counter for visibility regardless of defend state. In defend
+ * mode, look up against the allowed_ipv6 LPM trie; non-matches emit a
+ * deny event and return 0 (EPERM-equivalent for cgroup sockaddr).
+ */
+static __always_inline int defend_cgroup_sock_addr_ipv6(struct bpf_sock_addr *ctx,
+							void *observe_map)
+{
+	__be16 dport = (__be16)ctx->user_port;
+	__u8 protocol = cg_protocol_from_sock_ctx(ctx);
+
+	if (cg_ipv6_is_loopback(ctx))
+		return 1;
+	if (cg_ipv6_is_link_local(ctx))
+		return 1;
+	cg_bump_percpu_u32(observe_map);
+
+	if (!cg_defense_enabled())
+		return 1;
+	if (cg_ipv6_is_allowlisted(ctx))
+		return 1;
+
+	cg_emit_deny_event_ipv6(protocol, ctx, dport, COLDSTEP_DENY_REASON_DST_NOT_ALLOWLISTED);
+	return 0;
+}
+
 SEC("cgroup/connect6")
 int defend_cgroup_connect6(struct bpf_sock_addr *ctx)
 {
-	if (cg_ipv6_is_loopback(ctx))
-		return 1;
-	cg_bump_percpu_u32(&ipv6_connect_observed);
-	return 1;
+	return defend_cgroup_sock_addr_ipv6(ctx, &ipv6_connect_observed);
 }
 
 SEC("cgroup/sendmsg6")
 int defend_cgroup_sendmsg6(struct bpf_sock_addr *ctx)
 {
-	if (cg_ipv6_is_loopback(ctx))
-		return 1;
-	cg_bump_percpu_u32(&ipv6_sendmsg_observed);
-	return 1;
+	return defend_cgroup_sock_addr_ipv6(ctx, &ipv6_sendmsg_observed);
 }

--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -277,11 +277,12 @@ func Run(ctx context.Context, cfg config.Config) error {
 		// this way). The primary deny reader watches the cgroup `deny_events`
 		// ringbuf; the LSM ringbuf, when present, is drained by a separate
 		// reader.
-		allowlistSize, ignoredSize, loadErr := loadDefendMaps(&defendObjs, defendCompiled, pol)
+		allowlistSize, ipv6AllowlistSize, ignoredSize, loadErr := loadDefendMaps(&defendObjs, defendCompiled, pol)
 		if loadErr != nil {
 			return loadErr
 		}
 		defendState.setModeAndAllowlist(defendModeForBackend(backend.backend), allowlistSize, ignoredSize)
+		defendState.setIPv6AllowlistSize(ipv6AllowlistSize)
 		rd, err := ringbuf.NewReader(defendObjs.DenyEvents)
 		if err != nil {
 			return fmt.Errorf("ringbuf reader deny: %w", err)

--- a/internal/agent/agent_linux_digest.go
+++ b/internal/agent/agent_linux_digest.go
@@ -128,6 +128,7 @@ func buildDigestInput(
 		TLSReaderErrors:                sectionState.tlsReadErrors + sectionState.tlsDecodeErrors,
 		DefendMode:                     digestDefendLabel(cfg, defendState),
 		DefendAllowlistSize:            defendState.allowlistSize,
+		DefendIPv6AllowlistSize:        defendState.allowlistIPv6Size,
 		DefendDenyCount:                defendState.denyCount,
 		DefendDenyReserveFailures:      defendState.denyReserveFailures,
 		DefendFirstDeny:                defendState.firstDeny,

--- a/internal/agent/agent_linux_policy_maps.go
+++ b/internal/agent/agent_linux_policy_maps.go
@@ -41,8 +41,12 @@ func compileDefendAllowlist(ctx context.Context, cfg config.Config, resolver pol
 		return policy.CompileResult{}, perr
 	}
 	pol.MergeLiteralAllowedIPv4Into(&compiled.AllowedIPv4)
-	if compiled.AllowedIPv4.Len() == 0 {
-		msg := "defend allowlist effective allowlist is empty (no IPv4 A-record resolutions; add literals to allowed-ips if needed)"
+	// P2-1 Phase 2: an IPv6-only allowlist (AAAA resolutions, no A) is
+	// valid — both BPF defend hooks attach, IPv4 cgroup denies everything,
+	// IPv6 cgroup denies everything outside allowed_ipv6. Only reject
+	// when BOTH families are empty (every domain failed both A and AAAA).
+	if compiled.AllowedIPv4.Len() == 0 && compiled.AllowedIPv6.Len() == 0 {
+		msg := "defend allowlist effective allowlist is empty (no A/AAAA resolutions; add literals to allowed-ips if needed)"
 		if len(compiled.UnresolvedDomains) > 0 {
 			msg += fmt.Sprintf(" — check DNS for: %s", strings.Join(compiled.UnresolvedDomains, ", "))
 		}
@@ -221,6 +225,12 @@ func clampPerCPUSumToUint32(n int) uint32 {
 // literal IPv4 entries from the policy, and produce an LPM plan ready to write
 // into the BPF allowlist map identified by mapName. The two callers differ only
 // in which BPF map (allowed_ipv4 vs lsm_allowed_ipv4) receives the result.
+//
+// Empty IPv4 plan is allowed: under Phase 2 a defend mode run can have
+// AAAA-only resolutions and still defend coherently — the IPv4 cgroup
+// hook simply blocks every non-ignored destination. compileDefendAllowlist
+// already rejects the truly-empty case (both families empty) before this
+// builder runs.
 func buildDefendAllowedPlan(mapName string, compiled policy.CompileResult, pol *policy.Policy) (allowedLPMPlan, error) {
 	v4keys := make(map[[4]byte]struct{}, compiled.AllowedIPv4.Len())
 	compiled.AllowedIPv4.ForEach(func(k [4]byte) { v4keys[k] = struct{}{} })
@@ -232,9 +242,6 @@ func buildDefendAllowedPlan(mapName string, compiled policy.CompileResult, pol *
 	}
 	if plan.totalEntries > policy.MaxAllowedDefendIPv4Keys {
 		return allowedLPMPlan{}, fmt.Errorf("%s: %d entries exceeds BPF max %d", mapName, plan.totalEntries, policy.MaxAllowedDefendIPv4Keys)
-	}
-	if plan.totalEntries == 0 {
-		return allowedLPMPlan{}, fmt.Errorf("defend allowlist effective allowlist is empty (no map entries)")
 	}
 	return plan, nil
 }
@@ -308,11 +315,22 @@ func loadLSMDefendMaps(objs *defend.DefendObjects, compiled policy.CompileResult
 	}, compiled, pol)
 }
 
-func loadDefendMaps(objs *defend.DefendObjects, compiled policy.CompileResult, pol *policy.Policy) (int, int, error) {
+// loadDefendMaps programs BPF allowlist maps from compiled domain resolutions + literal policy entries.
+//
+// PR-G: allowed_ipv4 is now a BPF_MAP_TYPE_LPM_TRIE (was HASH). Single-IP
+// allowlist entries (resolved domain IPs + literal /32s from --allowed-ips)
+// are still programmed individually but with prefixlen=32. Literal CIDR
+// entries from --allowed-ips (e.g. "10.0.0.0/8") are programmed once as a
+// single LPM key and cover every address inside the range.
+//
+// Returns (ipv4Entries, ipv6Entries, ignoredCidrs, error). The IPv6 count
+// flows into defendState.setIPv6AllowlistSize so the digest can choose
+// between ✅ "gated" and 🚨 "block-all" Phase 2 verdicts.
+func loadDefendMaps(objs *defend.DefendObjects, compiled policy.CompileResult, pol *policy.Policy) (int, int, int, error) {
 	if objs == nil {
-		return 0, 0, fmt.Errorf("defend objects are required for cgroup defend mode")
+		return 0, 0, 0, fmt.Errorf("defend objects are required for cgroup defend mode")
 	}
-	return loadDefendMapsForBackend(defendMapSet{
+	ipv4Entries, ignoredCount, err := loadDefendMapsForBackend(defendMapSet{
 		cfgName:        "defend_cfg",
 		allowedName:    "allowed_ipv4",
 		cfg:            objs.DefendCfg,
@@ -320,6 +338,24 @@ func loadDefendMaps(objs *defend.DefendObjects, compiled policy.CompileResult, p
 		allowedLPM:     objs.AllowedIpv4,
 		allowedDomains: objs.AllowedDomains,
 	}, compiled, pol)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	// P2-1 Phase 2: program AAAA-resolved destinations into allowed_ipv6
+	// when the map is present in the loaded objects. Loader stripped this
+	// to nil if the BPF stubs predate Phase 2 — populate returns (0, nil)
+	// in that case, so older stubs continue to load IPv4-only defend.
+	ipv6Programmed, err := populateAllowedIPv6Map(objs.AllowedIpv6, compiled)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	if ipv6Programmed > 0 {
+		slog.Info("allowlist loaded into BPF map", "map", "allowed_ipv6",
+			"ipv6_entries", ipv6Programmed)
+	}
+
+	return ipv4Entries, ipv6Programmed, ignoredCount, nil
 }
 
 // loadAllowedLPMMap programs the allowed_ipv4 LPM trie (PR-G).
@@ -416,6 +452,47 @@ func loadAllowedLPMMap(m *ebpf.Map, plan allowedLPMPlan) error {
 	return nil
 }
 
+// populateAllowedIPv6Map writes AAAA-resolved /128 entries from the
+// compiled allowlist into the BPF allowed_ipv6 LPM trie. Wire format is
+// the userspace mirror of `struct lpm_v6_key`: 20-byte buffer where bytes
+// [0:4] are the prefix length in CPU/little-endian order (BPF_MAP_TYPE_LPM_TRIE
+// reads it as u32) and bytes [4:20] are the IPv6 address in network byte
+// order. Drift between this layout and bpf/defend_lpm_v6_key.h equals
+// silent EINVAL on Update at startup — both sides MUST move together.
+//
+// Returns the number of entries actually programmed. Missing map (older
+// stubs that predate Phase 2) is tolerated: 0 returned, no error — the
+// BPF program also degrades gracefully because cgroup/connect6 +
+// sendmsg6 will be missing, leaving IPv4-only defend.
+func populateAllowedIPv6Map(m *ebpf.Map, compiled policy.CompileResult) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	// Deterministic ordering for reproducibility (tests, logs).
+	keys := make([][16]byte, 0, compiled.AllowedIPv6.Len())
+	compiled.AllowedIPv6.ForEach(func(k [16]byte) { keys = append(keys, k) })
+	sort.Slice(keys, func(i, j int) bool {
+		return bytes.Compare(keys[i][:], keys[j][:]) < 0
+	})
+	if len(keys) > policy.MaxAllowedDefendIPv6Keys {
+		return 0, fmt.Errorf("allowed_ipv6: %d entries exceeds BPF max %d",
+			len(keys), policy.MaxAllowedDefendIPv6Keys)
+	}
+	val := uint8(1)
+	programmed := 0
+	for _, addr := range keys {
+		var key [20]byte
+		binary.LittleEndian.PutUint32(key[0:4], 128)
+		copy(key[4:20], addr[:])
+		if err := m.Update(key, val, ebpf.UpdateAny); err != nil {
+			return programmed, fmt.Errorf("load allowed_ipv6 map (/128 %s): %w",
+				net.IP(addr[:]).String(), err)
+		}
+		programmed++
+	}
+	return programmed, nil
+}
+
 func appendDenyFromRaw(cfg config.Config, raw []byte, seq *telemetry.SeqGen, jsonlMu *sync.Mutex, state *defendState, signer *telemetry.Signer, hookFamily string, dns *DNSCache) (telemetry.DenyEvent, error) {
 	tgid, tid, commb, protocolRaw, reasonRaw, af, daddr16, dport, ok := decodeDenyEvent(raw)
 	if !ok {
@@ -423,10 +500,20 @@ func appendDenyFromRaw(cfg config.Config, raw []byte, seq *telemetry.SeqGen, jso
 	}
 	protocol := denyProtocolLabel(protocolRaw)
 	reason := denyReasonLabel(reasonRaw)
-	if af != linuxAFInet {
-		return telemetry.DenyEvent{}, fmt.Errorf("deny event: unsupported address family %d (IPv4 only)", af)
+	var dstIP net.IP
+	switch af {
+	case linuxAFInet:
+		dstIP = net.IPv4(daddr16[0], daddr16[1], daddr16[2], daddr16[3])
+	case linuxAFInet6:
+		// P2-1 Phase 2: IPv6 deny events. daddr16 holds the 16-byte address
+		// in network byte order; net.IP shares that layout so we can copy
+		// it verbatim. String() picks the canonical zero-compressed form.
+		ip := make(net.IP, net.IPv6len)
+		copy(ip, daddr16[:])
+		dstIP = ip
+	default:
+		return telemetry.DenyEvent{}, fmt.Errorf("deny event: unsupported address family %d (IPv4/IPv6 only)", af)
 	}
-	dstIP := net.IPv4(daddr16[0], daddr16[1], daddr16[2], daddr16[3])
 	dst := dstIP.String()
 	// P1-5: sanitize attacker-controlled comm before it lands in JSONL — a
 	// blocked process whose argv[0] embeds newline / control bytes must not

--- a/internal/agent/agent_linux_state_defend.go
+++ b/internal/agent/agent_linux_state_defend.go
@@ -15,6 +15,7 @@ type defendState struct {
 	mu                     sync.Mutex
 	mode                   string
 	allowlistSize          int
+	allowlistIPv6Size      int
 	denyCountN             int
 	denyReserveFailuresN   int
 	mapIntegrityFailures   int
@@ -26,6 +27,7 @@ type defendState struct {
 type defendSnapshot struct {
 	mode                 string
 	allowlistSize        int
+	allowlistIPv6Size    int
 	denyCount            int
 	denyReserveFailures  int
 	mapIntegrityFailures int
@@ -105,6 +107,16 @@ func (s *defendState) setModeAndAllowlist(mode string, allowlistSize, ignoredSiz
 	s.expectedIgnoredEntries = ignoredSize
 }
 
+// setIPv6AllowlistSize records the number of /128 entries written into the
+// BPF allowed_ipv6 LPM trie at startup. Called from loadDefendMaps after
+// populateAllowedIPv6Map. Zero means defend is in pure block-all IPv6
+// posture (every non-loopback / non-link-local IPv6 destination denied).
+func (s *defendState) setIPv6AllowlistSize(n int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.allowlistIPv6Size = n
+}
+
 func (s *defendState) addMapIntegrityFailure() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -149,6 +161,7 @@ func (s *defendState) snapshot() defendSnapshot {
 	out := defendSnapshot{
 		mode:                 s.mode,
 		allowlistSize:        s.allowlistSize,
+		allowlistIPv6Size:    s.allowlistIPv6Size,
 		denyCount:            s.denyCountN,
 		denyReserveFailures:  s.denyReserveFailuresN,
 		mapIntegrityFailures: s.mapIntegrityFailures,

--- a/internal/agent/agent_linux_state_sections.go
+++ b/internal/agent/agent_linux_state_sections.go
@@ -136,6 +136,7 @@ const (
 	denyProtoUDP                = 2
 	denyReasonDstNotAllowlisted = 1
 	linuxAFInet                 = 2
+	linuxAFInet6                = 10
 
 	// BPF↔Go wire-format size contract. Each constant is paired with a
 	// `_Static_assert(sizeof(struct X) == N)` in the matching bpf/*.c file

--- a/internal/agent/agent_linux_test.go
+++ b/internal/agent/agent_linux_test.go
@@ -494,7 +494,7 @@ func TestAppendDenyFromRaw_InvalidPayload(t *testing.T) {
 	}
 }
 
-func TestAppendDenyFromRaw_NonIPv4AddressFamilyRejected(t *testing.T) {
+func TestAppendDenyFromRaw_UnknownAddressFamilyRejected(t *testing.T) {
 	t.Parallel()
 	cfg := config.Config{Mode: config.ModeDefend}
 	var seq telemetry.SeqGen
@@ -502,7 +502,7 @@ func TestAppendDenyFromRaw_NonIPv4AddressFamilyRejected(t *testing.T) {
 	state := newDefendState()
 
 	raw := fillTestDenyRawV4(1, 1, "curl", denyProtoTCP, denyReasonDstNotAllowlisted, net.ParseIP("1.1.1.1"), 443)
-	raw[26] = 10 // AF_INET6 — Coldstep does not emit or record IPv6 denies
+	raw[26] = 17 // AF_PACKET — only AF_INET / AF_INET6 are emitted by defend.
 
 	_, err := appendDenyFromRaw(cfg, raw, &seq, &jsonlMu, state, nil, "", nil)
 	if err == nil {
@@ -510,6 +510,45 @@ func TestAppendDenyFromRaw_NonIPv4AddressFamilyRejected(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unsupported address family") {
 		t.Fatalf("expected AF error, got %v", err)
+	}
+}
+
+func TestAppendDenyFromRaw_IPv6DenyDecoded(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "events.jsonl")
+	cfg := config.Config{Mode: config.ModeDefend, EventsLogPath: logPath}
+	var seq telemetry.SeqGen
+	var jsonlMu sync.Mutex
+	state := newDefendState()
+
+	raw := make([]byte, denyEventWireSize)
+	binary.LittleEndian.PutUint32(raw[0:4], 7)
+	binary.LittleEndian.PutUint32(raw[4:8], 7)
+	copy(raw[8:24], "curl")
+	raw[24] = denyProtoTCP
+	raw[25] = denyReasonDstNotAllowlisted
+	raw[26] = linuxAFInet6
+	ip6 := net.ParseIP("2001:db8::1").To16()
+	copy(raw[28:44], ip6)
+	binary.BigEndian.PutUint16(raw[44:46], 443)
+
+	deny, err := appendDenyFromRaw(cfg, raw, &seq, &jsonlMu, state, nil, "cgroup", nil)
+	if err != nil {
+		t.Fatalf("appendDenyFromRaw: %v", err)
+	}
+	if deny.Dst != "2001:db8::1" {
+		t.Fatalf("Dst=%q want 2001:db8::1", deny.Dst)
+	}
+	if deny.Dport != 443 || deny.Protocol != "tcp" {
+		t.Fatalf("Dport=%d Protocol=%q", deny.Dport, deny.Protocol)
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read events.jsonl: %v", err)
+	}
+	if !bytes.Contains(data, []byte(`"dst":"2001:db8::1"`)) {
+		t.Fatalf("expected IPv6 dst in JSONL, got %s", string(data))
 	}
 }
 

--- a/internal/bpf/defend/abi_test.go
+++ b/internal/bpf/defend/abi_test.go
@@ -117,6 +117,38 @@ func TestIPv6ObservePrograms(t *testing.T) {
 	}
 }
 
+// TestAllowedIPv6MapShape asserts the P2-1 Phase 2 allowed_ipv6 LPM trie
+// has the shape userspace expects when programming AAAA-resolved
+// destinations: BPF_MAP_TYPE_LPM_TRIE, key size 20 bytes
+// (4-byte prefixlen + 16-byte address), value size 1 byte, max_entries
+// matching policy.MaxAllowedDefendIPv6Keys. Drift on any of these results
+// in silent EINVAL on Update at agent start, surfacing as defend-bypass.
+// Skips until stubs are regenerated on Linux.
+// TODO: remove skip after Linux regeneration of internal/bpf/defend/*_bpfel.go.
+func TestAllowedIPv6MapShape(t *testing.T) {
+	spec, err := LoadDefend()
+	if err != nil {
+		t.Fatalf("LoadDefend: %v", err)
+	}
+	ms, ok := spec.Maps["allowed_ipv6"]
+	if !ok {
+		t.Skipf("defend stubs not regenerated yet: map \"allowed_ipv6\" absent from CollectionSpec — run `go generate ./internal/bpf/defend/` on Linux")
+	}
+	if ms.Type != ebpf.LPMTrie {
+		t.Errorf("allowed_ipv6 type = %v, want ebpf.LPMTrie", ms.Type)
+	}
+	if ms.KeySize != 20 {
+		t.Errorf("allowed_ipv6 KeySize = %d, want 20 (4-byte prefixlen + 16-byte addr)", ms.KeySize)
+	}
+	if ms.ValueSize != 1 {
+		t.Errorf("allowed_ipv6 ValueSize = %d, want 1", ms.ValueSize)
+	}
+	if ms.MaxEntries != uint32(policy.MaxAllowedDefendIPv6Keys) {
+		t.Errorf("allowed_ipv6 MaxEntries = %d, want %d (policy.MaxAllowedDefendIPv6Keys)",
+			ms.MaxEntries, policy.MaxAllowedDefendIPv6Keys)
+	}
+}
+
 // TestSendpageObserveMapIsPerCPUArray asserts the sendpage_observed counter
 // map (kernel-5.15 sendfile/splice gap) has the PERCPU_ARRAY shape userspace
 // expects to sum. Added in bpf/trace_lsm_defend_lsm.inc; the test skips

--- a/internal/bpf/defend/loader.go
+++ b/internal/bpf/defend/loader.go
@@ -144,6 +144,17 @@ func LoadDefendObjectsForKernel(obj *DefendObjects, wantLSM bool) error {
 		detachMapIfPresent(coll, m.name, m.dst)
 	}
 
+	// P2-1 Phase 2: IPv6 allowlist LPM trie. Optional in older generated
+	// stubs (same regeneration window as the connect6/sendmsg6 enforcement
+	// path). When absent, defend mode still loads but cgroup/connect6 and
+	// cgroup/sendmsg6 fall back to Phase 1 observe-only behaviour because
+	// the bpf2go binding's defend_cgroup_connect6 program reference will
+	// also be missing.
+	// TODO: remove the missing-map tolerance once defend objects are
+	// regenerated on Linux with bpf/trace_defend_cgroup.inc's
+	// allowed_ipv6 map.
+	detachMapIfPresent(coll, "allowed_ipv6", &obj.AllowedIpv6)
+
 	if wantLSM {
 		lsmPrograms := []struct {
 			name string

--- a/internal/policy/allowlist.go
+++ b/internal/policy/allowlist.go
@@ -80,10 +80,74 @@ func (s IPv4Set) ForEach(fn func(k [4]byte)) {
 	}
 }
 
+// IPv6Set stores unique IPv6 addresses in 16-byte form (network byte order
+// when serialized). Pure IPv4 inputs are rejected — callers separate AAAA
+// resolutions from A resolutions before insertion.
+type IPv6Set struct {
+	items map[[16]byte]struct{}
+}
+
+// Add inserts an IPv6 address into the set. IPv4-mapped IPv6 inputs are
+// rejected so the IPv4 and IPv6 sets stay disjoint.
+func (s *IPv6Set) Add(ip net.IP) {
+	if ip == nil {
+		return
+	}
+	if ip.To4() != nil {
+		return
+	}
+	ip16 := ip.To16()
+	if ip16 == nil {
+		return
+	}
+	if s.items == nil {
+		s.items = make(map[[16]byte]struct{})
+	}
+	var key [16]byte
+	copy(key[:], ip16)
+	s.items[key] = struct{}{}
+}
+
+// Contains reports whether ip is present in the set.
+func (s IPv6Set) Contains(ip net.IP) bool {
+	if ip == nil || len(s.items) == 0 {
+		return false
+	}
+	if ip.To4() != nil {
+		return false
+	}
+	ip16 := ip.To16()
+	if ip16 == nil {
+		return false
+	}
+	var key [16]byte
+	copy(key[:], ip16)
+	_, ok := s.items[key]
+	return ok
+}
+
+// Len returns the number of unique IPv6 addresses in the set.
+func (s IPv6Set) Len() int {
+	return len(s.items)
+}
+
+// ForEach calls fn for every key in the set.
+func (s IPv6Set) ForEach(fn func(k [16]byte)) {
+	for k := range s.items {
+		fn(k)
+	}
+}
+
 // CompileResult is the deterministic output from allowlist compilation.
+//
+// AllowedIPv6 (P2-1 Phase 2) holds AAAA-resolved destinations programmed
+// into the BPF allowed_ipv6 LPM trie in defend mode. IPv6 loopback (::1)
+// and link-local (fe80::/10) are NOT included here — those bypass
+// enforcement directly inside the BPF program.
 type CompileResult struct {
 	Domains             []string
 	AllowedIPv4         IPv4Set
+	AllowedIPv6         IPv6Set
 	UnresolvedDomains   []string
 	WildcardRiskDomains []string
 }
@@ -140,20 +204,26 @@ func CompileDomainAllowlist(ctx context.Context, domains []string, resolver Look
 	result := CompileResult{
 		Domains:     normalized,
 		AllowedIPv4: IPv4Set{items: make(map[[4]byte]struct{})},
+		AllowedIPv6: IPv6Set{items: make(map[[16]byte]struct{})},
 	}
 
 	type domainResult struct {
-		domain   string
-		ips      []net.IP
-		resolved bool
+		domain    string
+		ips4      []net.IP
+		ips6      []net.IP
+		resolved4 bool
+		resolved6 bool
 	}
 
 	results := make([]domainResult, len(normalized))
 
 	// errgroup.SetLimit bounds in-flight goroutines to N; Go() blocks on the
 	// internal semaphore once N goroutines are running. Workers currently return
-	// nil errors (resolution failures land in domainResult.resolved=false); Wait
+	// nil errors (resolution failures land in domainResult.resolved*=false); Wait
 	// is still checked so unexpected errgroup failures remain observable in logs.
+	// A and AAAA resolutions for the same domain run in the same worker
+	// sequentially so the per-domain CPU profile stays predictable; the limit
+	// bounds the total in-flight (A or AAAA) lookups across the run.
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -167,21 +237,39 @@ func CompileDomainAllowlist(ctx context.Context, domains []string, resolver Look
 				if gctx.Err() != nil {
 					break
 				}
-				lookupCtx, cancel := context.WithTimeout(gctx, coldstepDomainLookupAttemptTimeout)
-				ips4, err4 := resolver(lookupCtx, "ip4", d)
-				cancel()
-				if err4 != nil && (errors.Is(err4, context.Canceled) || errors.Is(err4, context.DeadlineExceeded)) {
-					break
-				}
-				if err4 == nil {
-					for _, ip := range ips4 {
-						if ip.To4() != nil {
-							res.ips = append(res.ips, ip)
-							res.resolved = true
+				if !res.resolved4 {
+					lookupCtx, cancel := context.WithTimeout(gctx, coldstepDomainLookupAttemptTimeout)
+					ips4, err4 := resolver(lookupCtx, "ip4", d)
+					cancel()
+					if err4 != nil && (errors.Is(err4, context.Canceled) || errors.Is(err4, context.DeadlineExceeded)) {
+						break
+					}
+					if err4 == nil {
+						for _, ip := range ips4 {
+							if ip.To4() != nil {
+								res.ips4 = append(res.ips4, ip)
+								res.resolved4 = true
+							}
 						}
 					}
 				}
-				if res.resolved {
+				if !res.resolved6 {
+					lookupCtx6, cancel6 := context.WithTimeout(gctx, coldstepDomainLookupAttemptTimeout)
+					ips6, err6 := resolver(lookupCtx6, "ip6", d)
+					cancel6()
+					if err6 != nil && (errors.Is(err6, context.Canceled) || errors.Is(err6, context.DeadlineExceeded)) {
+						break
+					}
+					if err6 == nil {
+						for _, ip := range ips6 {
+							if ip.To4() == nil && ip.To16() != nil {
+								res.ips6 = append(res.ips6, ip)
+								res.resolved6 = true
+							}
+						}
+					}
+				}
+				if res.resolved4 && res.resolved6 {
 					break
 				}
 			}
@@ -194,29 +282,52 @@ func CompileDomainAllowlist(ctx context.Context, domains []string, resolver Look
 	}
 
 	// Merge results back into CompileResult (single-threaded; goroutines are done).
+	// A domain is considered "resolved" if either A or AAAA returned at least
+	// one address — pure IPv6 destinations remain enforceable without an A
+	// record, and pure IPv4 destinations work without AAAA (the common case).
 	for _, res := range results {
-		if res.resolved {
-			seen := make(map[[4]byte]struct{})
-			for _, ip := range res.ips {
-				ip4 := ip.To4()
-				if ip4 == nil {
-					continue
-				}
-				var k [4]byte
-				copy(k[:], ip4)
-				seen[k] = struct{}{}
-			}
-			if len(seen) > coldstepDomainAllowlistIPv4WarnThreshold {
-				slog.Warn("allowlist domain resolved to many distinct IPv4 addresses (policy ambiguity risk)",
-					"domain", res.domain,
-					"unique_ipv4", len(seen),
-					"threshold", coldstepDomainAllowlistIPv4WarnThreshold)
-			}
-			for _, ip := range res.ips {
-				result.AllowedIPv4.Add(ip)
-			}
-		} else {
+		resolved := res.resolved4 || res.resolved6
+		if !resolved {
 			result.UnresolvedDomains = append(result.UnresolvedDomains, res.domain)
+			continue
+		}
+		seen4 := make(map[[4]byte]struct{})
+		for _, ip := range res.ips4 {
+			ip4 := ip.To4()
+			if ip4 == nil {
+				continue
+			}
+			var k [4]byte
+			copy(k[:], ip4)
+			seen4[k] = struct{}{}
+		}
+		if len(seen4) > coldstepDomainAllowlistIPv4WarnThreshold {
+			slog.Warn("allowlist domain resolved to many distinct IPv4 addresses (policy ambiguity risk)",
+				"domain", res.domain,
+				"unique_ipv4", len(seen4),
+				"threshold", coldstepDomainAllowlistIPv4WarnThreshold)
+		}
+		for _, ip := range res.ips4 {
+			result.AllowedIPv4.Add(ip)
+		}
+		seen6 := make(map[[16]byte]struct{})
+		for _, ip := range res.ips6 {
+			ip16 := ip.To16()
+			if ip16 == nil || ip.To4() != nil {
+				continue
+			}
+			var k [16]byte
+			copy(k[:], ip16)
+			seen6[k] = struct{}{}
+		}
+		if len(seen6) > coldstepDomainAllowlistIPv4WarnThreshold {
+			slog.Warn("allowlist domain resolved to many distinct IPv6 addresses (policy ambiguity risk)",
+				"domain", res.domain,
+				"unique_ipv6", len(seen6),
+				"threshold", coldstepDomainAllowlistIPv4WarnThreshold)
+		}
+		for _, ip := range res.ips6 {
+			result.AllowedIPv6.Add(ip)
 		}
 	}
 
@@ -225,7 +336,8 @@ func CompileDomainAllowlist(ctx context.Context, domains []string, resolver Look
 
 	slog.Info("allowlist compiled",
 		"domains", len(normalized),
-		"resolved_ips", result.AllowedIPv4.Len(),
+		"resolved_ipv4", result.AllowedIPv4.Len(),
+		"resolved_ipv6", result.AllowedIPv6.Len(),
 		"unresolved_count", len(result.UnresolvedDomains),
 		"wildcard_risk_count", len(result.WildcardRiskDomains),
 	)

--- a/internal/policy/allowlist_test.go
+++ b/internal/policy/allowlist_test.go
@@ -169,8 +169,10 @@ func TestCompileDomainAllowlist_MaxAttemptsFloor(t *testing.T) {
 	}
 
 	_ = CompileDomainAllowlist(ctx, []string{"a.example.com"}, resolver, 0)
-	if calls != 1 {
-		t.Fatalf("resolver calls: got %d want 1 (ip4 once) when maxAttempts <= 0", calls)
+	// P2-1 Phase 2: compile resolves A and AAAA; maxAttempts floor of 1
+	// means one ip4 attempt + one ip6 attempt = 2 resolver calls per domain.
+	if calls != 2 {
+		t.Fatalf("resolver calls: got %d want 2 (ip4 + ip6 once each) when maxAttempts <= 0", calls)
 	}
 }
 
@@ -225,6 +227,97 @@ func TestCompileDomainAllowlist_PopulatesWildcardRiskDomains(t *testing.T) {
 	want := []string{"*.s3.amazonaws.com"}
 	if !slices.Equal(got.WildcardRiskDomains, want) {
 		t.Fatalf("WildcardRiskDomains: got %v want %v", got.WildcardRiskDomains, want)
+	}
+}
+
+func TestCompileDomainAllowlist_ResolvesAAAA(t *testing.T) {
+	ctx := context.Background()
+	var calls sync.Map
+	resolver := func(_ context.Context, network, host string) ([]net.IP, error) {
+		bumpCallCount(&calls, network+"|"+host)
+		switch host {
+		case "v6-only.example.com":
+			if network == "ip6" {
+				return []net.IP{net.ParseIP("2001:db8::1"), net.ParseIP("2001:db8::2")}, nil
+			}
+			return nil, nil
+		case "dual-stack.example.com":
+			if network == "ip4" {
+				return []net.IP{net.ParseIP("1.2.3.4")}, nil
+			}
+			return []net.IP{net.ParseIP("2606:4700::1")}, nil
+		default:
+			return nil, errors.New("unexpected host")
+		}
+	}
+
+	got := CompileDomainAllowlist(ctx, []string{"v6-only.example.com", "dual-stack.example.com"}, resolver, 2)
+
+	if got.AllowedIPv6.Len() != 3 {
+		t.Fatalf("AllowedIPv6.Len()=%d want 3 (2 v6-only + 1 dual-stack)", got.AllowedIPv6.Len())
+	}
+	if !got.AllowedIPv6.Contains(net.ParseIP("2001:db8::1")) {
+		t.Fatal("expected 2001:db8::1 in AllowedIPv6")
+	}
+	if !got.AllowedIPv6.Contains(net.ParseIP("2606:4700::1")) {
+		t.Fatal("expected 2606:4700::1 in AllowedIPv6")
+	}
+	if got.AllowedIPv4.Len() != 1 || !got.AllowedIPv4.Contains(net.ParseIP("1.2.3.4")) {
+		t.Fatalf("AllowedIPv4 expected single dual-stack 1.2.3.4, got len=%d contains=%v",
+			got.AllowedIPv4.Len(), got.AllowedIPv4.Contains(net.ParseIP("1.2.3.4")))
+	}
+	if len(got.UnresolvedDomains) != 0 {
+		t.Fatalf("UnresolvedDomains: got %v want empty", got.UnresolvedDomains)
+	}
+	// v6-only: ip4 returns nil so retried up to maxAttempts; ip6 succeeds first try.
+	if loadCallCount(&calls, "ip4|v6-only.example.com") != 2 {
+		t.Fatalf("ip4|v6-only retries: got %d want 2", loadCallCount(&calls, "ip4|v6-only.example.com"))
+	}
+	if loadCallCount(&calls, "ip6|v6-only.example.com") != 1 {
+		t.Fatalf("ip6|v6-only: got %d want 1", loadCallCount(&calls, "ip6|v6-only.example.com"))
+	}
+}
+
+func TestCompileDomainAllowlist_AAAAErrorFallsBackToIPv4(t *testing.T) {
+	ctx := context.Background()
+	resolver := func(_ context.Context, network, host string) ([]net.IP, error) {
+		if host != "ipv4-only.example.com" {
+			return nil, errors.New("unexpected host")
+		}
+		if network == "ip4" {
+			return []net.IP{net.ParseIP("198.51.100.1")}, nil
+		}
+		return nil, errors.New("NXDOMAIN")
+	}
+
+	got := CompileDomainAllowlist(ctx, []string{"ipv4-only.example.com"}, resolver, 2)
+
+	if got.AllowedIPv4.Len() != 1 || !got.AllowedIPv4.Contains(net.ParseIP("198.51.100.1")) {
+		t.Fatalf("AllowedIPv4 missing 198.51.100.1: len=%d", got.AllowedIPv4.Len())
+	}
+	if got.AllowedIPv6.Len() != 0 {
+		t.Fatalf("AllowedIPv6.Len()=%d want 0 (AAAA NXDOMAIN)", got.AllowedIPv6.Len())
+	}
+	if len(got.UnresolvedDomains) != 0 {
+		t.Fatalf("UnresolvedDomains: got %v want empty (A succeeded)", got.UnresolvedDomains)
+	}
+}
+
+func TestIPv6SetContainsRejectsIPv4(t *testing.T) {
+	var s IPv6Set
+	s.Add(net.ParseIP("2001:db8::1"))
+	s.Add(net.ParseIP("1.2.3.4")) // IPv4 input ignored
+	if s.Len() != 1 {
+		t.Fatalf("IPv6Set.Len()=%d want 1 (IPv4 input must not insert)", s.Len())
+	}
+	if !s.Contains(net.ParseIP("2001:db8::1")) {
+		t.Fatal("expected 2001:db8::1 to be present")
+	}
+	if s.Contains(net.ParseIP("1.2.3.4")) {
+		t.Fatal("IPv6Set should not match an IPv4 lookup")
+	}
+	if s.Contains(nil) {
+		t.Fatal("nil IP should not match")
 	}
 }
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -17,6 +17,13 @@ const MaxIgnoredIPv4Nets = 128
 // MaxAllowedDefendIPv4Keys matches allowed_ipv4 max_entries in bpf/trace_defend.bpf.c.
 const MaxAllowedDefendIPv4Keys = 4096
 
+// MaxAllowedDefendIPv6Keys matches allowed_ipv6 max_entries in
+// bpf/trace_defend_cgroup.inc. Kept symmetric with IPv4 so the abi_test
+// pair stays parallel; in practice AAAA resolutions yield fewer entries
+// per domain than A records (one AAAA + a few alias addresses), so 4096
+// is well above realistic defend-mode demand.
+const MaxAllowedDefendIPv6Keys = 4096
+
 // MaxAllowedHostnameBytes is the maximum length of an allowed hostname (exact match or wildcard suffix).
 // DNS FQDNs are at most 253 octets (RFC 1035). BPF allowed_domains uses fixed char[256] keys; longer
 // names would truncate silently in userspace map updates without this guard.

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -41,12 +41,23 @@ func droppedTotal(in DigestInput) int {
 }
 
 // ipv6EgressObserved returns the total non-loopback IPv6 egress attempts
-// observed by the P0-1 Phase 1 cgroup/connect6 + cgroup/sendmsg6 hooks.
-// Non-zero means traffic bypassed the IPv4-only defend enforcement; in
-// detect mode that's a visibility gap (⚠️), in defend mode that's an
-// outright bypass (🚨).
+// observed by the cgroup/connect6 + cgroup/sendmsg6 hooks. Non-zero means
+// IPv6 destinations were contacted during the run. Under Phase 2, defend
+// mode enforces on these — see ipv6DefendActive for the predicate that
+// chooses the ✅/⚠️ verdict.
 func ipv6EgressObserved(in DigestInput) uint32 {
 	return in.IPv6ConnectObserved + in.IPv6SendmsgObserved
+}
+
+// ipv6DefendActive reports whether Phase 2 IPv6 enforcement is fully
+// configured for this defend run. It returns true when defend mode is
+// active AND the agent programmed at least one entry into the BPF
+// allowed_ipv6 LPM trie (AAAA-resolved or literal). False covers two
+// cases: detect mode (no enforcement at all) and defend mode with a
+// pure block-all IPv6 posture (allowlist empty), which is functional
+// but should be flagged so operators can spot a missing AAAA config.
+func ipv6DefendActive(in DigestInput) bool {
+	return isBlockingDigestMode(in.DefendMode) && in.DefendIPv6AllowlistSize > 0
 }
 
 // verdictEmoji returns ✅ / ⚠️ / 🚨 for the headline. Mirrors the prior
@@ -59,12 +70,17 @@ func verdictEmoji(in DigestInput) string {
 			break
 		}
 	}
-	// In defend mode, any observed IPv6 egress is a 🚨 — the IPv4-only
-	// cgroup/connect4+sendmsg4 path could not gate it, so traffic
-	// escaped enforcement entirely. In detect mode this is a ⚠️
-	// limitation rather than an alert (handled in the review check
-	// below).
-	defendIPv6Bypass := isBlockingDigestMode(in.DefendMode) && ipv6EgressObserved(in) > 0
+	// P2-1 Phase 2: IPv6 in defend mode is gated by the allowed_ipv6 LPM
+	// trie when populated (any traffic outside it gets EPERM at the
+	// cgroup/connect6+sendmsg6 hooks). The "bypass" alert only fires when
+	// defend mode observed IPv6 egress AND the IPv6 allowlist is empty —
+	// in that block-all posture the events were denied, but the operator
+	// likely meant to add AAAA destinations and should see it. Detect
+	// mode still flags IPv6 as a ⚠️ visibility gap (handled in the review
+	// check below).
+	defendIPv6Bypass := isBlockingDigestMode(in.DefendMode) &&
+		ipv6EgressObserved(in) > 0 &&
+		in.DefendIPv6AllowlistSize == 0
 	alert := (!in.CanaryPipelineOK && in.CanaryFailCount > 0) ||
 		in.BPFHeartbeatFailures > 0 ||
 		in.BPFMapIntegrityFailures > 0 ||
@@ -73,6 +89,11 @@ func verdictEmoji(in DigestInput) string {
 	if alert {
 		return "🚨"
 	}
+	// IPv6 egress is a ⚠️ when there's no Phase 2 enforcement to gate it
+	// (detect mode — visibility-only). In defend mode with a populated
+	// allowed_ipv6 trie the traffic was actually checked, so it's no
+	// longer a review trigger on its own.
+	ipv6Review := ipv6EgressObserved(in) > 0 && !ipv6DefendActive(in) && !isBlockingDigestMode(in.DefendMode)
 	review := totalDetectRingbufReserveFailures(in) > 0 ||
 		in.UDPSendmsgMultiIovecObserved > 0 ||
 		in.TLSWritevMultiIovecObserved > 0 ||
@@ -83,7 +104,7 @@ func verdictEmoji(in DigestInput) string {
 		in.DefendDenyReserveFailures > 0 ||
 		droppedTotal(in) > 0 ||
 		in.IoUringSetupObserved > 0 ||
-		ipv6EgressObserved(in) > 0
+		ipv6Review
 	if review {
 		return "⚠️"
 	}
@@ -106,12 +127,23 @@ func writeHeader(b *strings.Builder, in DigestInput) {
 }
 
 // writeCoverage emits a one-line scope statement so users do not misread ✅ as
-// "every byte of egress observed". IPv6 and QUIC/HTTP3 are statically out of
-// scope today (no BPF coverage); the "Payloads beyond iov[0]" cell flips to
-// ⚠️ partial when BG-01 partial-observe counters fired this run.
+// "every byte of egress observed". IPv6 coverage flips state per run:
+//   - detect or defend without allowed_ipv6: "observed" (cgroup/connect6 +
+//     sendmsg6 always counts; defend with empty trie still gates by denying).
+//   - defend with allowed_ipv6 entries: "gated" (Phase 2 active).
+//
+// QUIC/HTTP3 remains statically out of scope (no BPF coverage). The
+// "Payloads beyond iov[0]" cell flips to ⚠️ partial when BG-01
+// partial-observe counters fired this run.
 func writeCoverage(b *strings.Builder, in DigestInput) {
-	fmt.Fprintf(b, "**Coverage this run:** IPv4 TCP/UDP ✓ observed | IPv6 ✗ not observed | QUIC/HTTP3 ✗ not observed | Payloads beyond iov[0]: %s\n\n",
-		coveragePayloadState(in))
+	ipv6State := "observed (detect — no enforcement)"
+	if ipv6DefendActive(in) {
+		ipv6State = "gated (defend allowed_ipv6 active)"
+	} else if isBlockingDigestMode(in.DefendMode) {
+		ipv6State = "denied (defend block-all — empty allowed_ipv6)"
+	}
+	fmt.Fprintf(b, "**Coverage this run:** IPv4 TCP/UDP ✓ observed | IPv6 %s | QUIC/HTTP3 ✗ not observed | Payloads beyond iov[0]: %s\n\n",
+		ipv6State, coveragePayloadState(in))
 }
 
 // writeCompactKPI emits a single-row 5-column KPI table. The full per-channel
@@ -249,16 +281,25 @@ func buildTriageRows(in DigestInput) [][2]string {
 		}
 	}
 
-	// P0-1 Phase 1: surface IPv6 egress as a top-level triage row. In
-	// detect mode this is a ⚠️ limitation (IPv4-only visibility); in
-	// defend mode it's 🚨 (the IPv4-only allowlist could not gate the
-	// connection). Phase 2 will add IPv6 enforcement.
+	// P2-1 Phase 2: surface IPv6 egress as a triage row. Three states:
+	//   - detect mode: ⚠️ visibility-only (no enforcement, by design).
+	//   - defend mode + allowed_ipv6 populated: ✅ gated by AAAA-resolved
+	//     LPM trie; non-matches were denied with EPERM.
+	//   - defend mode + allowed_ipv6 empty: 🚨 pure block-all posture —
+	//     functional, but operator likely forgot to configure AAAA
+	//     destinations for any service they want reachable over IPv6.
 	if n := ipv6EgressObserved(in); n > 0 {
-		badge := "⚠️"
-		suffix := "IPv6 enforcement not yet supported"
-		if isBlockingDigestMode(in.DefendMode) {
+		var badge, suffix string
+		switch {
+		case ipv6DefendActive(in):
+			badge = "✅"
+			suffix = fmt.Sprintf("**gated by %d-entry allowed_ipv6 LPM trie (AAAA-resolved)**", in.DefendIPv6AllowlistSize)
+		case isBlockingDigestMode(in.DefendMode):
 			badge = "🚨"
-			suffix = "**defend allowlist is IPv4-only — traffic escaped enforcement**"
+			suffix = "**defend has no allowed_ipv6 entries — all non-loopback IPv6 denied (block-all). Add AAAA destinations to `allow:` if this was unintentional.**"
+		default:
+			badge = "⚠️"
+			suffix = "detect mode — IPv6 visibility only, Phase 2 enforcement runs in defend"
 		}
 		rows = append(rows, [2]string{
 			"**IPv6 egress detected**",
@@ -361,10 +402,22 @@ func writeFullKPITable(b *strings.Builder, in DigestInput) {
 		fmt.Fprintf(b, "| **⚠️ io_uring_setup (syscall-hook bypass class)** | %d |\n", in.IoUringSetupObserved)
 	}
 	if in.IPv6ConnectObserved > 0 {
-		fmt.Fprintf(b, "| **⚠️ ipv6 connect6 observed (defend is IPv4-only)** | %d |\n", in.IPv6ConnectObserved)
+		label := "**⚠️ ipv6 connect6 observed (detect — no enforcement)**"
+		if ipv6DefendActive(in) {
+			label = "**✅ ipv6 connect6 gated by allowed_ipv6**"
+		} else if isBlockingDigestMode(in.DefendMode) {
+			label = "**🚨 ipv6 connect6 denied (defend has empty allowed_ipv6 — block-all)**"
+		}
+		fmt.Fprintf(b, "| %s | %d |\n", label, in.IPv6ConnectObserved)
 	}
 	if in.IPv6SendmsgObserved > 0 {
-		fmt.Fprintf(b, "| **⚠️ ipv6 sendmsg6 observed (defend is IPv4-only)** | %d |\n", in.IPv6SendmsgObserved)
+		label := "**⚠️ ipv6 sendmsg6 observed (detect — no enforcement)**"
+		if ipv6DefendActive(in) {
+			label = "**✅ ipv6 sendmsg6 gated by allowed_ipv6**"
+		} else if isBlockingDigestMode(in.DefendMode) {
+			label = "**🚨 ipv6 sendmsg6 denied (defend has empty allowed_ipv6 — block-all)**"
+		}
+		fmt.Fprintf(b, "| %s | %d |\n", label, in.IPv6SendmsgObserved)
 	}
 
 	// --- processes ---
@@ -778,10 +831,13 @@ func writeKPISemantics(b *strings.Builder, in DigestInput, max int) {
 		b.WriteString("- **⚠️ io_uring_setup** was called on this runner — io_uring can bypass typical syscall tracepoints used for detect mode. If `io-uring-disable` is true (default), the setup call was blocked by sysctl; this counter still records the attempt. See SECURITY.md (Guarantees vs best-effort).\n")
 	}
 	if ipv6EgressObserved(in) > 0 {
-		if isBlockingDigestMode(in.DefendMode) {
-			b.WriteString("- **🚨 IPv6 egress** was observed by the `cgroup/connect6` and `cgroup/sendmsg6` observe-only hooks. coldstep defend currently enforces only IPv4 (`cgroup/connect4` and `cgroup/sendmsg4`), so these connections **escaped the allowlist entirely** — review which destinations were contacted and whether IPv4 fallbacks should be required.\n")
-		} else {
-			b.WriteString("- **⚠️ IPv6 egress** was observed by the `cgroup/connect6` and `cgroup/sendmsg6` observe-only hooks. coldstep is IPv4-only for now — Phase 1 (P0-1) records the attempts so visibility gaps are explicit; Phase 2 will add IPv6 enforcement.\n")
+		switch {
+		case ipv6DefendActive(in):
+			fmt.Fprintf(b, "- **✅ IPv6 egress** observed and gated by the `cgroup/connect6` + `cgroup/sendmsg6` defend hooks against the `allowed_ipv6` LPM trie (%d AAAA-resolved entries). `::1` (loopback) and `fe80::/10` (link-local) bypass the lookup.\n", in.DefendIPv6AllowlistSize)
+		case isBlockingDigestMode(in.DefendMode):
+			b.WriteString("- **🚨 IPv6 egress** observed under defend mode with an empty `allowed_ipv6` LPM trie — every non-loopback / non-link-local IPv6 destination was denied (block-all). If any of these were legitimate, add the relevant AAAA hostnames to `allow:` so the next run programs the LPM trie.\n")
+		default:
+			b.WriteString("- **⚠️ IPv6 egress** observed in detect mode. coldstep records the attempts here; switching to `mode: defend` activates the Phase 2 `cgroup/connect6` + `cgroup/sendmsg6` LPM-trie enforcement.\n")
 		}
 	}
 	if in.TCPDNSSkippedShortRead > 0 {

--- a/internal/report/digest_test.go
+++ b/internal/report/digest_test.go
@@ -616,29 +616,41 @@ func TestBuildDetectMarkdown_DroppedEventCounters(t *testing.T) {
 func TestBuildDetectMarkdown_CoverageScopeBlock_AlwaysPresent(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name string
-		in   DigestInput
+		name       string
+		in         DigestInput
+		ipv6Cell   string
+		extraCells []string
 	}{
 		{"clean detect", DigestInput{
 			BPF:       []telemetry.BPFStatus{{Name: "exec", OK: true}},
 			ExecTotal: 1,
-		}},
-		{"defend", DigestInput{
-			DefendMode:          "defend",
-			DefendAllowlistSize: 1,
-			DefendDenyCount:     0,
-			BPF:                 []telemetry.BPFStatus{{Name: "connect", OK: true}},
-		}},
+		}, "IPv6 observed (detect — no enforcement)", nil},
+		{"defend gated", DigestInput{
+			DefendMode:              "defend",
+			DefendAllowlistSize:     1,
+			DefendIPv6AllowlistSize: 2,
+			DefendDenyCount:         0,
+			BPF:                     []telemetry.BPFStatus{{Name: "connect", OK: true}},
+		}, "IPv6 gated (defend allowed_ipv6 active)", nil},
+		{"defend block-all", DigestInput{
+			DefendMode:              "defend",
+			DefendAllowlistSize:     1,
+			DefendIPv6AllowlistSize: 0,
+			DefendDenyCount:         0,
+			BPF:                     []telemetry.BPFStatus{{Name: "connect", OK: true}},
+		}, "IPv6 denied (defend block-all — empty allowed_ipv6)", nil},
 	}
 	for _, c := range cases {
 		md := BuildDetectMarkdown(c.in)
-		for _, needle := range []string{
+		needles := []string{
 			"**Coverage this run:**",
 			"IPv4 TCP/UDP ✓ observed",
-			"IPv6 ✗ not observed",
+			c.ipv6Cell,
 			"QUIC/HTTP3 ✗ not observed",
 			"Payloads beyond iov[0]: ✓ observed",
-		} {
+		}
+		needles = append(needles, c.extraCells...)
+		for _, needle := range needles {
 			if !strings.Contains(md, needle) {
 				t.Fatalf("[%s] missing %q in digest:\n%s", c.name, needle, md)
 			}
@@ -740,9 +752,10 @@ func TestBuildDetectMarkdown_VisibleLineBudget(t *testing.T) {
 	}
 }
 
-// TestBuildDetectMarkdown_IPv6Observed_DetectMode covers the P0-1 Phase 1
-// detect-mode rendering: any non-zero IPv6 counter must (a) flip the
-// headline verdict to ⚠️ and (b) add a triage row naming the limitation.
+// TestBuildDetectMarkdown_IPv6Observed_DetectMode covers detect-mode
+// rendering: any non-zero IPv6 counter must (a) flip the headline verdict
+// to ⚠️ and (b) add a triage row naming detect mode as visibility-only.
+// Detect never enforces IPv6 (Phase 2 enforcement is defend-only).
 func TestBuildDetectMarkdown_IPv6Observed_DetectMode(t *testing.T) {
 	md := BuildDetectMarkdown(DigestInput{
 		BPF:                 []telemetry.BPFStatus{{Name: "sched_process_exec", OK: true}},
@@ -756,7 +769,7 @@ func TestBuildDetectMarkdown_IPv6Observed_DetectMode(t *testing.T) {
 		"**IPv6 egress detected**",
 		"⚠️ **5** non-loopback IPv6 destinations",
 		"connect=3 sendmsg=2",
-		"IPv6 enforcement not yet supported",
+		"detect mode — IPv6 visibility only",
 	} {
 		if !strings.Contains(md, needle) {
 			t.Fatalf("missing %q in:\n%s", needle, md)
@@ -767,27 +780,59 @@ func TestBuildDetectMarkdown_IPv6Observed_DetectMode(t *testing.T) {
 	}
 }
 
-// TestBuildDetectMarkdown_IPv6Observed_DefendMode covers the defend-mode
-// escalation: in defend mode the IPv4-only allowlist could not gate the
-// IPv6 connection, so the headline must be 🚨 and the triage row must
-// say the allowlist is IPv4-only.
-func TestBuildDetectMarkdown_IPv6Observed_DefendMode(t *testing.T) {
+// TestBuildDetectMarkdown_IPv6Observed_DefendMode_BlockAll covers Phase 2
+// defend-mode with an empty allowed_ipv6 LPM trie: every non-loopback /
+// non-link-local IPv6 destination was denied (block-all). The headline
+// stays 🚨 because the empty trie likely indicates a missed AAAA config,
+// and the triage row tells the operator how to fix it.
+func TestBuildDetectMarkdown_IPv6Observed_DefendMode_BlockAll(t *testing.T) {
 	md := BuildDetectMarkdown(DigestInput{
-		DefendMode:          "defend",
-		BPF:                 []telemetry.BPFStatus{{Name: "sched_process_exec", OK: true}},
-		ExecTotal:           1,
-		IPv6ConnectObserved: 1,
-		MaxRowsPerSection:   50,
+		DefendMode:              "defend",
+		BPF:                     []telemetry.BPFStatus{{Name: "sched_process_exec", OK: true}},
+		ExecTotal:               1,
+		IPv6ConnectObserved:     1,
+		DefendIPv6AllowlistSize: 0,
+		MaxRowsPerSection:       50,
 	})
 	for _, needle := range []string{
 		"## 🚨 coldstep — defend",
 		"**IPv6 egress detected**",
 		"🚨 **1** non-loopback IPv6 destinations",
-		"defend allowlist is IPv4-only",
+		"defend has no allowed_ipv6 entries",
+		"block-all",
 	} {
 		if !strings.Contains(md, needle) {
 			t.Fatalf("missing %q in:\n%s", needle, md)
 		}
+	}
+}
+
+// TestBuildDetectMarkdown_IPv6Observed_DefendMode_Gated covers Phase 2
+// defend-mode with a populated allowed_ipv6 LPM trie: traffic was checked,
+// matches were allowed, non-matches were denied. The headline must NOT
+// be 🚨 (Phase 2 is doing its job), and the triage row should say "gated".
+func TestBuildDetectMarkdown_IPv6Observed_DefendMode_Gated(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{
+		DefendMode:              "defend",
+		BPF:                     []telemetry.BPFStatus{{Name: "sched_process_exec", OK: true}},
+		ExecTotal:               1,
+		IPv6ConnectObserved:     4,
+		IPv6SendmsgObserved:     1,
+		DefendIPv6AllowlistSize: 3,
+		MaxRowsPerSection:       50,
+	})
+	for _, needle := range []string{
+		"## ✅ coldstep — defend",
+		"**IPv6 egress detected**",
+		"✅ **5** non-loopback IPv6 destinations",
+		"gated by 3-entry allowed_ipv6 LPM trie",
+	} {
+		if !strings.Contains(md, needle) {
+			t.Fatalf("missing %q in:\n%s", needle, md)
+		}
+	}
+	if strings.Contains(md, "🚨 coldstep") {
+		t.Fatalf("Phase 2 gated defend must not escalate to 🚨:\n%s", md)
 	}
 }
 

--- a/internal/report/digest_types.go
+++ b/internal/report/digest_types.go
@@ -201,12 +201,24 @@ type DigestInput struct {
 	SpliceObserved    int
 	SendmmsgFirstOnly int
 	// IPv6ConnectObserved / IPv6SendmsgObserved count non-loopback IPv6
-	// egress attempts observed by the P0-1 Phase 1 cgroup/connect6 and
-	// cgroup/sendmsg6 hooks. coldstep defend mode is IPv4-only — non-zero
-	// values mean traffic escaped enforcement entirely; the triage table
-	// surfaces this as ⚠️ in detect mode and 🚨 in defend mode.
+	// egress attempts observed by the cgroup/connect6 and cgroup/sendmsg6
+	// hooks. Under P2-1 Phase 2 these hooks enforce in defend mode (LPM
+	// trie lookup against allowed_ipv6). In detect mode non-zero values
+	// remain a visibility row (no enforcement); in defend mode the digest
+	// pivots on DefendIPv6AllowlistSize — non-zero means traffic was gated
+	// by an explicit AAAA-resolved allowlist, zero means defend is in a
+	// pure block-all IPv6 posture.
 	IPv6ConnectObserved uint32
 	IPv6SendmsgObserved uint32
+	// DefendIPv6AllowlistSize is the number of /128 entries programmed
+	// into the BPF allowed_ipv6 LPM trie at agent startup. Used by the
+	// digest to distinguish two Phase 2 defend postures:
+	//   - allowlist > 0: ✅ blocked (AAAA-resolved entries gating IPv6)
+	//   - allowlist == 0: ⚠️ pure block-all (all non-loopback/non-link-local
+	//     IPv6 denied — works, but operators should know their config has
+	//     no AAAA destinations and may surprise users who expect IPv6
+	//     services).
+	DefendIPv6AllowlistSize int
 	// SendpageObserved counts security_socket_sendpage invocations recorded
 	// by the lsm/socket_sendpage hook. Non-zero means sendfile(2) or splice(2)
 	// reached a socket via the sock_sendpage path — which cgroup/sendmsg4 and


### PR DESCRIPTION
## Summary

Closes the silent IPv6 egress channel under `mode: defend`. Phase 1 (#155) added observe-only `cgroup/connect6`+`sendmsg6` hooks that surfaced any IPv6 traffic as a digest warning. **Phase 2 enforces.**

- New `allowed_ipv6` LPM trie (`bpf/defend_lpm_v6_key.h`: 4-byte prefixlen + 16-byte addr, packed) is populated at startup from AAAA resolutions and consulted on every `connect6`/`sendmsg6`. Misses emit a deny event (`af=AF_INET6`, 16-byte daddr) and return `0` (EPERM-equivalent).
- `::1` (loopback) and `fe80::/10` (link-local) always bypass enforcement.
- Allowlist compile resolves A **and** AAAA per domain (one worker, sequential within the domain, errgroup-bounded concurrency unchanged). A domain is "resolved" if either family returned an address — AAAA-only services are now valid defend allowlist entries.
- Digest pivots verdict on a new `DefendIPv6AllowlistSize` field:
  - detect + IPv6 observed → ⚠️ visibility-only.
  - defend + `allowed_ipv6` populated + IPv6 observed → ✅ gated.
  - defend + `allowed_ipv6` empty + IPv6 observed → 🚨 block-all (operator likely missed AAAA config — message tells them how to fix it).
- README "IP versions" cell and `action.yml` `mode`+`allow` input docs updated to describe the dual-stack flow.

## Test plan

Pure-Go (no Linux required) tests run on the unit lane:

- [x] `internal/policy/allowlist_test.go`: `ResolvesAAAA`, `AAAAErrorFallsBackToIPv4`, `IPv6SetContainsRejectsIPv4`, `MaxAttemptsFloor` updated for ip4+ip6.
- [x] `internal/agent/agent_linux_test.go`: `NonIPv4AddressFamilyRejected` retargeted to `AF_PACKET`; new `IPv6DenyDecoded` asserts AF_INET6 routes through JSONL with canonical string form.
- [x] `internal/report/digest_test.go`: `DefendMode` split into Gated + BlockAll variants; `CoverageScopeBlock_AlwaysPresent` parameterized by IPv6 state.

ABI assertions for the new map and connect6/sendmsg6 program type are `t.Skipf`-guarded (same pattern as Phase 1 stubs); they activate once `go generate ./internal/bpf/defend/` runs on Linux.

Linux integration tests (`coldstep-ci-runner.yml`):

- [ ] `unit` matrix — exercises the Go AAAA path under real `net.DefaultResolver`.
- [ ] `defend-mode` workflow — exercises the BPF allowed_ipv6 path end to end; verifies `connect6`/`sendmsg6` deny and JSONL emission with AF_INET6.
- [ ] `assert-integrity` — confirms the digest IPv6 row renders correctly for the new ✅/🚨 split.

## Notes

- BPF stubs (`*_bpfel.go`, `vmlinux.h`) are gitignored — `loader.go` continues to tolerate missing maps/programs so older generated stubs degrade to Phase 1 IPv4-only defend instead of failing to load.
- `buildDefendAllowedPlan` no longer rejects an empty IPv4 plan — necessary to allow AAAA-only defend configurations. `compileDefendAllowlist` still rejects the truly-empty case (both A and AAAA empty across the entire allowlist).
- IPv6 LPM trie reconciliation (`defend_rearm.go` analogue) is **not** included; the IPv6 allowlist is fixed at startup, same as the IPv4 baseline. Follow-up if runtime DNS rotation becomes a requirement.
