### PR TITLE
P2-2: QUIC/HTTP3 observation heuristic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,8 @@ Shared C headers live in `bpf/` (notably `coldstep_pure.h`, `deny_event.h`, `def
 
 The agent's Linux entry (`internal/agent/agent_linux.go`) loads each program in a fixed order, captures BPF status into `telemetry.BPFStatus` rows used by the digest, and drains ringbufs through `agent_linux_ring_read.go`. Feature gates `proc_tree`, `tls_sni`, `fs_events` (parsed in `internal/config/featuregates.go`) toggle optional event streams; `COLDSTEP_DETECT_PROFILE=enhanced` flips defaults on if a key is unset. Set the same profile env on the post-run `coldstep-report build-model` step so integrity scoring matches.
 
+**QUIC / HTTP3 visibility note (P2-2).** QUIC payloads are encrypted at the transport layer and cannot be inspected by the BPF probes, so coldstep treats UDP/443 egress to non-loopback IPv4 as a *likely* QUIC/HTTP3 flow and emits a synthetic `quic_candidate` JSONL line alongside the underlying `udp` event (see `IsQUICCandidate` in `internal/agent/quic_candidate.go` and the `QUIC (port-443 UDP)` KPI row in the digest). This is a userspace heuristic — no BPF/clang work involved — and surfaces the visibility gap explicitly rather than letting QUIC traffic look like silent UDP.
+
 ### Config + policy compilation
 
 `internal/config.LoadFromEnv` reads `CI_GUARD_MODE` and `COLDSTEP_*` env (set by `coldstep-action` from action inputs):

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Enrichment walks indicators present in the report model when **`OTX_API_KEY`** i
 
 - **TCP** rows reflect **`connect(2)` at syscall enter**, not guaranteed established sockets.
 - **HTTP** events are cleartext **HTTP/1 on port 80**; **HTTPS** is not decrypted. Optional **`tls_sni`** surfaces **ClientHello SNI** from the first cleartext handshake buffer seen on **`write(2)`/`writev`/`pwrite(2)`/`pwritev`/`pwritev2`/`sendto`** paths after IPv4 **`connect`** (best-effort); explicit-address TCP **`sendto`** is included when the tuple matches the syscall destination.
+- **QUIC / HTTP3** flows are detected via a **UDP-443 heuristic** (non-loopback IPv4): each match is recorded as a `quic_candidate` JSONL line alongside the underlying `udp` event, and the digest surfaces a **`QUIC (port-443 UDP)`** KPI row. **Payload content is not inspected** — QUIC is encrypted at the transport layer, so coldstep names the visibility gap rather than hiding it.
 - **Shared runners**: attribution is **PID / `comm`**-class; not a perfect global process tree.
 - Prefer **JSONL** over the Summary for forensics; the Summary is **capped** (GitHub limit ~1 MiB per step).
 - **Agent env (advanced):** the Go agent enables **verbose BPF verifier logging** for the large `traceconnect` program only when **`COLDSTEP_BPF_VERBOSE_VERIFY`** is set in the job environment. Leave it unset on GitHub-hosted runners (default) so `LoadTraceconnectObjects` stays fast; set it when debugging verifier rejections locally or in a dedicated job.

--- a/internal/agent/agent_linux_digest.go
+++ b/internal/agent/agent_linux_digest.go
@@ -156,6 +156,7 @@ func buildDigestInput(
 		CanaryFailCount:                canarySnap.failCount,
 		TCPDNSResponsesObserved:        stats.tcpDNSResponsesObserved(),
 		TCPDNSSkippedShortRead:         stats.tcpDNSSkippedShortRead(),
+		QUICCandidateCount:             stats.quicCandidateTotal(),
 		BPFAuditTotal:                  stats.bpfAuditTotal(),
 		BPFMapIntegrityFailures:        stats.bpfMapIntegrityFailures(),
 		BPFAuditRingbufReserveFailures: stats.bpfAuditRingbufReserveFailures(),

--- a/internal/agent/agent_linux_ring_read.go
+++ b/internal/agent/agent_linux_ring_read.go
@@ -474,13 +474,14 @@ func readUDPRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, dns
 			Policy:   cl.Display(),
 		}, stats)
 
+		ipStr := ip.String()
 		if cfg.EventsLogPath != "" {
 			jsonlMu.Lock()
 			n := seq.Next()
 			ev := telemetry.UDPEvent{
 				Type: "udp", TS: ts, Seq: n,
 				PID: tgid, TGID: tgid, ThreadID: tid,
-				Comm: comm, Dst: ip.String(), Dport: port,
+				Comm: comm, Dst: ipStr, Dport: port,
 				DatagramLen: dgramLen, FQDN: fqdn, FQDNProvenance: fqdnProv,
 				Direction: "egress",
 				Policy:    string(cl),
@@ -490,6 +491,28 @@ func readUDPRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, dns
 			if err != nil {
 				stats.addDropped("udp_jsonl")
 				slog.Warn("events jsonl", "err", err)
+			}
+		}
+
+		// QUIC/HTTP3 visibility-gap event (P2-2). Emitted alongside the UDP row
+		// when the egress is a likely QUIC flow; payload content is not inspected.
+		if IsQUICCandidate(ipStr, port) {
+			stats.addQUICCandidate()
+			if cfg.EventsLogPath != "" {
+				jsonlMu.Lock()
+				n := seq.Next()
+				qev := telemetry.QUICCandidateEvent{
+					Type: telemetry.EventTypeQUICCandidate, TS: ts, Seq: n,
+					PID: tgid, TGID: tgid, Comm: comm,
+					DstIP: ipStr, DstPort: port,
+					Note: "UDP/443 to non-loopback IPv4; payload encrypted (QUIC) — not inspected",
+				}
+				err := telemetry.AppendJSONL(cfg.EventsLogPath, qev, signer)
+				jsonlMu.Unlock()
+				if err != nil {
+					stats.addDropped("quic_candidate_jsonl")
+					slog.Warn("events jsonl (quic_candidate)", "err", err)
+				}
 			}
 		}
 	}

--- a/internal/agent/agent_linux_state.go
+++ b/internal/agent/agent_linux_state.go
@@ -62,6 +62,7 @@ type runStats struct {
 	ioUringSetupObservedN           int
 	tcpDNSResponsesObservedN        int
 	tcpDNSSkippedShortReadN         int
+	quicCandidateN                  int
 	bpfAuditN                       int
 	bpfMapIntegrityFailuresN        int
 	bpfDNSCacheUpdateFailuresN      int
@@ -451,6 +452,21 @@ func (s *runStats) tcpDNSSkippedShortRead() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.tcpDNSSkippedShortReadN
+}
+
+// addQUICCandidate bumps the per-run counter for UDP/443 non-loopback egress
+// classified as a likely QUIC/HTTP3 flow (payload not inspected). See
+// IsQUICCandidate for the predicate.
+func (s *runStats) addQUICCandidate() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.quicCandidateN++
+}
+
+func (s *runStats) quicCandidateTotal() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.quicCandidateN
 }
 
 func (s *runStats) addBPFHeartbeatFailure() {

--- a/internal/agent/quic_candidate.go
+++ b/internal/agent/quic_candidate.go
@@ -1,0 +1,37 @@
+// Package agent — QUIC/HTTP3 observation heuristic (P2-2).
+//
+// BPF probes cannot inspect UDP payloads (QUIC is encrypted at the transport
+// layer), so coldstep treats UDP egress to port 443 on a non-loopback IPv4
+// destination as a *likely* QUIC/HTTP3 flow. The heuristic runs in userspace
+// alongside the regular UDP ring reader, so no BPF or clang work is required.
+//
+// IsQUICCandidate is intentionally cross-platform (no build tag) so the rule
+// can be unit-tested on any host. It centralizes the "what counts as QUIC"
+// predicate so the agent and the report builder agree.
+package agent
+
+import "net"
+
+// IsQUICCandidate returns true when an observed UDP egress is a likely
+// QUIC/HTTP3 flow worth surfacing as a visibility-gap event. The rule is:
+//
+//   - destination port equals 443, AND
+//   - destination IP parses as a non-loopback IPv4 address.
+//
+// Loopback (127.0.0.0/8) is excluded because runner-local UDP/443 traffic is
+// almost never QUIC egress to the public internet. IPv6 is not considered;
+// coldstep's BPF probes are IPv4-only by design.
+func IsQUICCandidate(dstIP string, dstPort uint16) bool {
+	if dstPort != 443 {
+		return false
+	}
+	ip := net.ParseIP(dstIP)
+	if ip == nil {
+		return false
+	}
+	v4 := ip.To4()
+	if v4 == nil {
+		return false
+	}
+	return !v4.IsLoopback()
+}

--- a/internal/agent/quic_candidate_test.go
+++ b/internal/agent/quic_candidate_test.go
@@ -1,0 +1,38 @@
+package agent
+
+import "testing"
+
+// TestIsQUICCandidate exercises the cross-platform UDP/443 → QUIC predicate
+// (P2-2). The agent's UDP ring reader uses this to decide whether to emit a
+// synthetic quic_candidate JSONL line alongside the regular udp event; the
+// rule must not fire on loopback (runner-local traffic) or non-443 ports.
+func TestIsQUICCandidate(t *testing.T) {
+	cases := []struct {
+		name string
+		ip   string
+		port uint16
+		want bool
+	}{
+		{"public ipv4 port 443", "1.2.3.4", 443, true},
+		{"cloudflare port 443", "104.16.0.1", 443, true},
+
+		{"loopback port 443", "127.0.0.1", 443, false},
+		{"loopback 127.0.0.2 port 443", "127.0.0.2", 443, false},
+		{"loopback higher in /8 port 443", "127.255.255.254", 443, false},
+
+		{"public ipv4 port 80", "1.2.3.4", 80, false},
+		{"public ipv4 port 53", "8.8.8.8", 53, false},
+		{"public ipv4 port 0", "1.2.3.4", 0, false},
+		{"public ipv4 port 4433", "1.2.3.4", 4433, false},
+
+		{"empty ip port 443", "", 443, false},
+		{"garbage ip port 443", "not-an-ip", 443, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsQUICCandidate(tc.ip, tc.port); got != tc.want {
+				t.Fatalf("IsQUICCandidate(%q, %d) = %v, want %v", tc.ip, tc.port, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -363,6 +363,9 @@ func writeFullKPITable(b *strings.Builder, in DigestInput) {
 	if in.SendmmsgUnobservedExtra > 0 {
 		fmt.Fprintf(b, "| **sendmmsg extra messages dropped past unroll bound (vlen>8)** | %d |\n", in.SendmmsgUnobservedExtra)
 	}
+	if in.QUICCandidateCount > 0 {
+		fmt.Fprintf(b, "| **QUIC (port-443 UDP)** | %d flows · payload not inspected |\n", in.QUICCandidateCount)
+	}
 
 	fmt.Fprintf(b, "| **http** | %d |\n", in.HTTPTotal)
 	if in.HTTPRingbufReserveFailures > 0 {
@@ -823,6 +826,9 @@ func writeKPISemantics(b *strings.Builder, in DigestInput, max int) {
 	}
 	if in.SendmmsgMultiMessage > 0 {
 		b.WriteString("- **sendmmsg multi-message** counts `sendmmsg(2)` calls with `vlen>1` (multi-message batch); only the first `mmsghdr` is introspected today.\n")
+	}
+	if in.QUICCandidateCount > 0 {
+		b.WriteString("- **QUIC (port-443 UDP)** counts UDP egress to non-loopback IPv4 on port 443 — a heuristic for QUIC/HTTP3 flows. Payload content is encrypted at the transport layer and **not inspected** by the BPF probes; the JSONL `quic_candidate` event records pid, comm, and destination only. Use this to gauge how much of the run is invisible to HTTP/TLS sniff paths.\n")
 	}
 	if in.SendfileObserved > 0 || in.SpliceObserved > 0 || in.SendmmsgFirstOnly > 0 {
 		b.WriteString("- **sendfile / splice / sendmmsg partial-observe** counters (BG-01) name the IPv4-egress paths that emit destination/length telemetry but no HTTP/TLS payload sniff: `sendfile`/`splice` correlate destination via the cached `(tgid,fd)→tuple` map, and `sendmmsg` introspects only the first `mmsghdr` (messages 2..N are dropped). Per-path counts let operators see which arm drove the gap. Under **defend**, cgroup/LSM hooks may still apply to the underlying socket; under **detect**, this is visibility-only.\n")

--- a/internal/report/digest_test.go
+++ b/internal/report/digest_test.go
@@ -594,6 +594,40 @@ func TestBuildDetectMarkdown_RingbufReserveRollup(t *testing.T) {
 	}
 }
 
+func TestBuildDetectMarkdown_QUICCandidateKPI(t *testing.T) {
+	t.Parallel()
+	md := BuildDetectMarkdown(DigestInput{
+		UDPTotal:           5,
+		QUICCandidateCount: 3,
+	})
+	for _, needle := range []string{
+		"| **QUIC (port-443 UDP)** | 3 flows · payload not inspected |",
+		"**QUIC (port-443 UDP)** counts UDP egress to non-loopback IPv4 on port 443",
+		"Payload content is encrypted",
+		"not inspected",
+	} {
+		if !strings.Contains(md, needle) {
+			t.Fatalf("missing %q in:\n%s", needle, md)
+		}
+	}
+}
+
+func TestBuildDetectMarkdown_QUICCandidateKPI_Hidden_WhenZero(t *testing.T) {
+	t.Parallel()
+	md := BuildDetectMarkdown(DigestInput{
+		UDPTotal:           5,
+		QUICCandidateCount: 0,
+	})
+	for _, unexpected := range []string{
+		"QUIC (port-443 UDP)",
+		"payload not inspected",
+	} {
+		if strings.Contains(md, unexpected) {
+			t.Fatalf("unexpected QUIC row when count=0:\n%s", md)
+		}
+	}
+}
+
 func TestBuildDetectMarkdown_DroppedEventCounters(t *testing.T) {
 	md := BuildDetectMarkdown(DigestInput{
 		DroppedCounts: map[string]int{

--- a/internal/report/digest_types.go
+++ b/internal/report/digest_types.go
@@ -235,6 +235,10 @@ type DigestInput struct {
 	// the BPF ringbuf pipeline may be compromised (suppression, exhaustion).
 	CanaryPipelineOK bool
 	CanaryFailCount  int
+	// QUICCandidateCount counts UDP/443 egress to non-loopback IPv4 observed in
+	// this run, classified as likely QUIC/HTTP3 flows. The payload is encrypted
+	// and not inspected — non-zero surfaces the visibility gap in the KPI table.
+	QUICCandidateCount int
 	// TCPDNSResponsesObserved counts TCP DNS length-framed replies where the BPF
 	// path could inspect the QR bit (trace_dns.bpf.c read/recvfrom sys_exit).
 	TCPDNSResponsesObserved int

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -8,6 +8,10 @@ import (
 // SchemaVersion is bumped when JSONL field shapes change incompatibly.
 const SchemaVersion = 2
 
+// EventTypeQUICCandidate is the JSONL "type" value for synthetic QUIC/HTTP3
+// candidate events derived from UDP egress on port 443 to non-loopback IPv4.
+const EventTypeQUICCandidate = "quic_candidate"
+
 // BPFStatus records attach outcome for forensics (meta + shutdown summary).
 type BPFStatus struct {
 	Name   string `json:"name"`
@@ -197,6 +201,25 @@ type TLSEvent struct {
 	Policy     string        `json:"policy"`
 	Note       string        `json:"note,omitempty"`
 	Sig        string        `json:"sig,omitempty"`
+}
+
+// QUICCandidateEvent is emitted when a UDP egress to port 443 on a non-loopback
+// IPv4 address is observed. QUIC payloads are encrypted at the transport layer
+// and cannot be inspected by the BPF probes — this event signals a *likely*
+// QUIC/HTTP3 flow so operators can see the visibility gap without scanning
+// raw UDP JSONL. It is a userspace-derived heuristic emitted alongside the
+// underlying UDPEvent, not a separate BPF ringbuf source.
+type QUICCandidateEvent struct {
+	Type    string `json:"type"` // "quic_candidate"
+	TS      string `json:"ts"`
+	Seq     uint64 `json:"seq"`
+	PID     uint32 `json:"pid"` // tgid (compat field name)
+	TGID    uint32 `json:"tgid"`
+	Comm    string `json:"comm"`
+	DstIP   string `json:"dst_ip"`
+	DstPort uint16 `json:"dst_port"` // always 443
+	Note    string `json:"note,omitempty"`
+	Sig     string `json:"sig,omitempty"`
 }
 
 // FSEvent is one JSONL record for a high-signal filesystem operation (detect, feature-gated).


### PR DESCRIPTION
## Summary

**P2-2: QUIC/HTTP3 observation heuristic.** QUIC traffic was previously a silent visibility gap — UDP/443 egress showed up as plain `udp` events in the digest with no signal that an entire HTTPS-equivalent path was unobservable to the BPF probes (QUIC encrypts at the transport layer, so payload sniff is not possible). This PR names the gap rather than hiding it.

### What changed

- **New telemetry type** `telemetry.QUICCandidateEvent` (constant `telemetry.EventTypeQUICCandidate = "quic_candidate"`) — JSONL line emitted alongside the underlying `udp` event when the heuristic matches.
- **Userspace heuristic** in `internal/agent/quic_candidate.go` (`IsQUICCandidate(dstIP, dstPort)`): fires when `dstPort == 443` AND `dstIP` parses as **non-loopback IPv4**. Loopback (`127.0.0.0/8`) is excluded because runner-local UDP/443 is virtually never QUIC egress to the public internet. IPv6 is not considered (coldstep is IPv4-only by design).
- **UDP ring reader** (`internal/agent/agent_linux_ring_read.go`): after writing each `udp` event, runs `IsQUICCandidate` and emits a synthetic `quic_candidate` JSONL line plus bumps a per-run counter. No BPF / clang work involved — pure userspace.
- **Digest KPI** (`internal/report/digest.go` + `digest_types.go`): new `QUICCandidateCount` field on `DigestInput`; a `QUIC (port-443 UDP)` KPI row renders only when non-zero with explicit `N flows · payload not inspected` wording, plus a Technical-details bullet explaining the encryption gap.
- **Docs**: `CLAUDE.md` gains a QUIC visibility note in the agent-wiring section; `README.md`'s "Limits" section names the heuristic and the inspection gap.

### What did *not* change

- No BPF C source, no `go generate`, no clang dependency added.
- No `telemetry.Summary` field, no `action.yml` input, no public API.
- Loopback UDP/443 still produces a `udp` event; only the synthetic `quic_candidate` line is suppressed for loopback.

## Test plan

- [x] `go test ./internal/agent/... ./internal/report/... ./internal/telemetry/... -count=1` — all pass on Windows.
- [x] `go vet ./internal/agent/... ./internal/report/... ./internal/telemetry/... ./internal/config/... ./internal/policy/... ./cmd/...` — clean.
- [x] `gofmt -l` — clean for touched files.
- [x] `bash scripts/check-encoding.sh` — clean (mojibake + U+FFFD scan).
- [x] `TestIsQUICCandidate` cross-platform predicate tests: public IPv4/443 → true, loopback/443 → false, non-443 ports → false, garbage/empty IP → false.
- [x] `TestBuildDetectMarkdown_QUICCandidateKPI` and `TestBuildDetectMarkdown_QUICCandidateKPI_Hidden_WhenZero` digest tests.
- [ ] CI: `coldstep-ci.yml` matrix (`unit`, `unit-arm64`, `integration`, `detect-mode`, `defend-mode`) — verified by CI on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
