### PR TITLE
P2-5: Reputation integration hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,10 @@ The agent's Linux entry (`internal/agent/agent_linux.go`) loads each program in 
 
 `internal/report/model/` defines the on-disk JSON model that `coldstep-report build-model` produces from JSONL. `internal/report/integrity/` scores it: `RequiredTypesForDetectProfile("enhanced")` expands required event types from `{meta, exec, tcp}` to `{meta, exec, tcp, udp, http, tls, proc_fork, fs_event}`. Detect workflows in CI run `assert-integrity` as an anti-blindness gate.
 
+### Reputation enrichment interface (`internal/reputation/`)
+
+Plug-in surface for IP reputation backends (OTX, VirusTotal, PassiveDNS, …). The public types — `reputation.Enricher`, `reputation.Result`, `reputation.Register`, `reputation.Registered`, `reputation.EnrichAll` — are considered stable once shipped; external integrators may build their own enrichers against them. Concrete backends live in subpackages (`internal/reputation/otx`, `internal/reputation/passivedns`); the env-driven assembly lives in `internal/reputation/loader` (kept in a subpackage to avoid an import cycle with the backends). Enrichment is **post-processing only** — `coldstep-report rdns-enrich` and `otx-enrich` invoke `loader.LoadFromEnv()` and then `reputation.EnrichAll(ctx, ip)`, never the agent's hot path. Backends are opt-in: `COLDSTEP_OTX_API_KEY`, `COLDSTEP_VIRUSTOTAL_API_KEY`, `COLDSTEP_PASSIVEDNS_SERVER`. When the env var is empty the loader returns a `NoOpEnricher` for that slot so the registry shape stays stable.
+
 ### Artifacts written to `$GITHUB_WORKSPACE`
 
 - `.coldstep-events.jsonl` — append-only event stream (source of truth).

--- a/README.md
+++ b/README.md
@@ -140,6 +140,16 @@ Detect workflows that build the **report model** can enrich indicators with **Al
 
 Enrichment walks indicators present in the report model when **`OTX_API_KEY`** is set (`coldstep-report otx-enrich`).
 
+### Pluggable reputation enrichment (OTX, VirusTotal, PassiveDNS)
+
+The post-processing step exposes a stable plug-in interface (`internal/reputation`) so additional reputation backends can be wired in without modifying core coldstep code. Enrichment is **opt-in** and runs only after JSONL is on disk — never on the agent's hot path. Configure backends via env on the post-run report step:
+
+- `COLDSTEP_OTX_API_KEY` — AlienVault OTX (new pluggable path; coexists with the legacy `OTX_API_KEY` flow above).
+- `COLDSTEP_VIRUSTOTAL_API_KEY` — VirusTotal (stub: key is accepted, wire protocol pending).
+- `COLDSTEP_PASSIVEDNS_SERVER` — CIRCL-compatible PassiveDNS endpoint (stub).
+
+When a backend's env var is empty, the loader installs a no-op enricher for that slot so the registry shape stays stable. Combined results land in the report model under `reputation_results` plus a `reputation` summary block.
+
 ---
 
 ## Limits (read before relying on signals)

--- a/cmd/coldstep-report/enrich.go
+++ b/cmd/coldstep-report/enrich.go
@@ -70,6 +70,9 @@ func rdnsEnrich(args []string) error {
 	}
 
 	m["dns_lookups"] = lookups
+	if err := applyReputationEnrichers(m); err != nil {
+		return err
+	}
 	if err := writeModelMap(inPath, m); err != nil {
 		return err
 	}
@@ -114,6 +117,9 @@ func otxEnrich(args []string) error {
 				"unidentified": 0,
 				"total":        0,
 			},
+		}
+		if err := applyReputationEnrichers(m); err != nil {
+			return err
 		}
 		return writeModelMap(inPath, m)
 	}
@@ -190,6 +196,9 @@ func otxEnrich(args []string) error {
 			"unidentified": unidentifiedCount,
 			"total":        maliciousCount + cleanCount + unidentifiedCount,
 		},
+	}
+	if err := applyReputationEnrichers(m); err != nil {
+		return err
 	}
 	return writeModelMap(inPath, m)
 }

--- a/cmd/coldstep-report/reputation.go
+++ b/cmd/coldstep-report/reputation.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/coldstep-io/coldstep/internal/reputation"
+	"github.com/coldstep-io/coldstep/internal/reputation/loader"
+)
+
+// reputationWallBudgetEnv bounds the total wall-clock time spent on the
+// new generic reputation pass. The legacy OTX path has its own budget
+// (COLDSTEP_OTX_WALL_BUDGET_MS); this knob covers the registry-driven
+// pass only.
+const reputationWallBudgetEnv = "COLDSTEP_REPUTATION_WALL_BUDGET_MS"
+
+// applyReputationEnrichers loads enrichers from the environment, runs
+// them over every IPv4 indicator in the model, and stores the combined
+// results under m["reputation_results"]. A summary block is written to
+// m["reputation"].
+//
+// This is the new plug-in path defined in internal/reputation. It runs
+// in addition to the legacy OTX-specific code in enrich.go so existing
+// reports keep producing the same fields; the new shape is additive.
+//
+// Returns nil even on partial enricher errors — those are recorded in
+// the per-IP "errors" field. A non-nil error here means we could not run
+// the pass at all (e.g. corrupt model).
+func applyReputationEnrichers(m map[string]any) error {
+	enrichers := loader.LoadFromEnv()
+	reputation.Reset()
+	for _, e := range enrichers {
+		reputation.Register(e)
+	}
+
+	active := make([]string, 0, len(enrichers))
+	for _, e := range enrichers {
+		if _, isNoOp := e.(reputation.NoOpEnricher); isNoOp {
+			continue
+		}
+		active = append(active, e.Name())
+	}
+
+	budgetMs := parseBudgetMillis(reputationWallBudgetEnv, 30000)
+	deadline := time.Now().Add(time.Duration(budgetMs) * time.Millisecond)
+	indicators := gatherModelIndicators(m)
+
+	rows := make([]map[string]any, 0)
+	queried := 0
+	partial := false
+
+	for _, ind := range indicators {
+		if !isIPv4(ind) {
+			continue
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			partial = true
+			break
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), remaining)
+		results, err := reputation.EnrichAll(ctx, ind)
+		cancel()
+		queried++
+
+		row := map[string]any{"ip": ind}
+		if err != nil {
+			row["errors"] = err.Error()
+		}
+		if len(results) == 0 {
+			continue
+		}
+		serialized := make([]map[string]any, 0, len(results))
+		for _, r := range results {
+			serialized = append(serialized, map[string]any{
+				"ip":           r.IP,
+				"enricher":     r.Enricher,
+				"score":        r.Score,
+				"tags":         r.Tags,
+				"country_code": r.CountryCode,
+				"asn":          r.ASN,
+			})
+		}
+		row["results"] = serialized
+		rows = append(rows, row)
+	}
+
+	if len(rows) > 0 {
+		m["reputation_results"] = rows
+	}
+	m["reputation"] = map[string]any{
+		"active_enrichers": active,
+		"queried":          queried,
+		"partial_results":  partial,
+		"wall_budget_ms":   budgetMs,
+		"queried_at":       time.Now().UTC().Format(time.RFC3339),
+	}
+	fmt.Fprintf(os.Stderr, "reputation: ran %d enricher(s) over %d indicator(s)\n", len(active), queried)
+	return nil
+}

--- a/internal/reputation/interface.go
+++ b/internal/reputation/interface.go
@@ -1,0 +1,62 @@
+// Package reputation defines the plug-in interface for IP/indicator
+// reputation enrichers (e.g. OTX, VirusTotal, PassiveDNS).
+//
+// Enrichment is post-processing only: callers run it after events are
+// written to JSONL, never on the agent's hot path. Implementations must be
+// safe for concurrent use because [EnrichAll] fans out to every registered
+// enricher in parallel.
+//
+// The public surface (Enricher, Result, Register, Registered, EnrichAll,
+// LoadFromEnv) is considered stable once shipped; external integrators may
+// build their own enrichers against it without depending on internal
+// coldstep details.
+package reputation
+
+import (
+	"context"
+	"time"
+)
+
+// Enricher enriches an IPv4 address with reputation data from a single
+// backend. Implementations must be safe for concurrent use.
+type Enricher interface {
+	// Name returns a stable identifier for this enricher
+	// (e.g. "otx", "virustotal", "passivedns"). Used as the
+	// Result.Enricher field and as a deduplication key.
+	Name() string
+
+	// Enrich queries reputation data for the given IPv4 address.
+	// Returning (nil, nil) means "no data available" and is not an
+	// error; callers should treat that case as a clean lookup.
+	Enrich(ctx context.Context, ip string) (*Result, error)
+}
+
+// Result holds reputation data for a single IP from one enricher.
+//
+// Score is a normalized 0–10 value where higher means more suspicious.
+// Raw is a passthrough of the backend's response for callers that want to
+// surface fields the normalized shape does not cover.
+type Result struct {
+	IP          string         `json:"ip"`
+	Enricher    string         `json:"enricher"`
+	Score       float64        `json:"score,omitempty"`
+	Tags        []string       `json:"tags,omitempty"`
+	CountryCode string         `json:"country_code,omitempty"`
+	ASN         string         `json:"asn,omitempty"`
+	Raw         map[string]any `json:"raw,omitempty"`
+	CachedAt    *time.Time     `json:"cached_at,omitempty"`
+}
+
+// NoOpEnricher satisfies [Enricher] but always returns (nil, nil). The
+// loader returns one of these for each backend that is not configured, so
+// callers can iterate the registry uniformly without nil checks.
+type NoOpEnricher struct{ name string }
+
+// NewNoOp constructs a NoOpEnricher with the given Name().
+func NewNoOp(name string) NoOpEnricher { return NoOpEnricher{name: name} }
+
+// Name reports the stable identifier supplied at construction.
+func (n NoOpEnricher) Name() string { return n.name }
+
+// Enrich always returns (nil, nil) — the backend is intentionally disabled.
+func (n NoOpEnricher) Enrich(_ context.Context, _ string) (*Result, error) { return nil, nil }

--- a/internal/reputation/loader/loader.go
+++ b/internal/reputation/loader/loader.go
@@ -1,0 +1,84 @@
+// Package loader assembles reputation enrichers from environment
+// variables.
+//
+// It lives in its own subpackage (rather than next to the interface in
+// internal/reputation) so the top-level package can stay leaf-only: the
+// concrete backends in internal/reputation/{otx,passivedns,...} import
+// the interface, and this loader imports both — that ordering avoids an
+// import cycle.
+package loader
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"github.com/coldstep-io/coldstep/internal/reputation"
+	"github.com/coldstep-io/coldstep/internal/reputation/otx"
+	"github.com/coldstep-io/coldstep/internal/reputation/passivedns"
+)
+
+// Env var names recognized by LoadFromEnv. Centralized here so callers
+// (and docs) reference a single source of truth.
+const (
+	EnvOTXAPIKey        = "COLDSTEP_OTX_API_KEY"
+	EnvVirusTotalAPIKey = "COLDSTEP_VIRUSTOTAL_API_KEY"
+	EnvPassiveDNSServer = "COLDSTEP_PASSIVEDNS_SERVER"
+)
+
+// LoadFromEnv inspects the environment and returns one Enricher per
+// supported backend, in deterministic order: otx, virustotal,
+// passivedns.
+//
+// When a backend's env var is empty, LoadFromEnv returns a NoOpEnricher
+// with that backend's Name(). This keeps the slice length and ordering
+// stable so callers can iterate uniformly and report which backends are
+// active without nil checks.
+//
+// LoadFromEnv does not call reputation.Register — that is the caller's
+// choice. Subcommands typically Reset() then Register() the returned
+// enrichers before invoking EnrichAll.
+func LoadFromEnv() []reputation.Enricher {
+	otxKey := strings.TrimSpace(os.Getenv(EnvOTXAPIKey))
+	vtKey := strings.TrimSpace(os.Getenv(EnvVirusTotalAPIKey))
+	pdnsServer := strings.TrimSpace(os.Getenv(EnvPassiveDNSServer))
+
+	out := make([]reputation.Enricher, 0, 3)
+
+	if otxKey != "" {
+		out = append(out, otx.New(otxKey))
+	} else {
+		out = append(out, reputation.NewNoOp("otx"))
+	}
+
+	if vtKey != "" {
+		out = append(out, &virusTotalEnricher{apiKey: vtKey})
+	} else {
+		out = append(out, reputation.NewNoOp("virustotal"))
+	}
+
+	if pdnsServer != "" {
+		out = append(out, passivedns.New(pdnsServer))
+	} else {
+		out = append(out, reputation.NewNoOp("passivedns"))
+	}
+
+	return out
+}
+
+// virusTotalEnricher is an in-package stub for the VirusTotal backend.
+// It lives here (rather than in its own subpackage) because the wire
+// protocol is not yet implemented and a dedicated package would mostly
+// be empty. Once a real client is built, move this to
+// internal/reputation/virustotal/.
+type virusTotalEnricher struct {
+	apiKey string
+}
+
+func (v *virusTotalEnricher) Name() string { return "virustotal" }
+
+func (v *virusTotalEnricher) Enrich(_ context.Context, _ string) (*reputation.Result, error) {
+	// Stub: keys are accepted (so LoadFromEnv can report the backend as
+	// "configured") but no HTTP call is made yet. Treat as no-data.
+	return nil, nil
+}

--- a/internal/reputation/otx/otx.go
+++ b/internal/reputation/otx/otx.go
@@ -1,0 +1,202 @@
+// Package otx provides an OTX (AlienVault Open Threat Exchange) backend
+// for the reputation enrichment interface.
+//
+// OTXEnricher implements reputation.Enricher by querying
+// https://otx.alienvault.com/api/v1/indicators/IPv4/{ip}/general with the
+// configured API key. If no API key is supplied, Enrich is a no-op and
+// returns (nil, nil).
+package otx
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/coldstep-io/coldstep/internal/reputation"
+)
+
+// Cap decoded JSON to prevent a pathological response from allocating
+// unbounded memory. Mirrors the bound used in cmd/coldstep-report.
+const maxResponseJSONBytes = 4 << 20
+
+// DefaultTimeout bounds a single OTX HTTP call. Callers can override by
+// passing a tighter deadline on the ctx supplied to Enrich.
+const DefaultTimeout = 10 * time.Second
+
+// OTXEnricher implements reputation.Enricher against the OTX general
+// indicators endpoint.
+type OTXEnricher struct {
+	APIKey  string
+	Client  *http.Client // optional; defaults to a 10s-timeout client
+	BaseURL string       // optional; defaults to https://otx.alienvault.com
+}
+
+// New constructs an OTXEnricher with the given API key. When apiKey is
+// empty, Enrich returns (nil, nil) — useful as a placeholder in the
+// registry when the user has not configured OTX.
+func New(apiKey string) *OTXEnricher {
+	return &OTXEnricher{
+		APIKey:  strings.TrimSpace(apiKey),
+		Client:  &http.Client{Timeout: DefaultTimeout},
+		BaseURL: "https://otx.alienvault.com",
+	}
+}
+
+// Name reports the stable identifier "otx".
+func (o *OTXEnricher) Name() string { return "otx" }
+
+// Enrich queries OTX for the given IPv4 address. Returns (nil, nil) when:
+//   - the API key is not configured, or
+//   - OTX has no pulse data for this indicator.
+//
+// HTTP and decode failures are surfaced as errors so the caller can
+// distinguish "no data" from "lookup failed".
+func (o *OTXEnricher) Enrich(ctx context.Context, ip string) (*reputation.Result, error) {
+	if o == nil || o.APIKey == "" {
+		return nil, nil
+	}
+	if strings.TrimSpace(ip) == "" {
+		return nil, nil
+	}
+
+	client := o.Client
+	if client == nil {
+		client = &http.Client{Timeout: DefaultTimeout}
+	}
+	base := o.BaseURL
+	if base == "" {
+		base = "https://otx.alienvault.com"
+	}
+	endpoint := fmt.Sprintf("%s/api/v1/indicators/IPv4/%s/general", strings.TrimRight(base, "/"), url.PathEscape(ip))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-OTX-API-KEY", o.APIKey)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxResponseJSONBytes))
+		_ = resp.Body.Close()
+	}()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// Fall through to decode below.
+	case http.StatusForbidden:
+		return nil, fmt.Errorf("otx: invalid api key")
+	case http.StatusTooManyRequests:
+		return nil, fmt.Errorf("otx: rate-limited")
+	default:
+		return nil, fmt.Errorf("otx: unexpected status %d", resp.StatusCode)
+	}
+
+	var body map[string]any
+	dec := json.NewDecoder(io.LimitReader(resp.Body, maxResponseJSONBytes))
+	if err := dec.Decode(&body); err != nil {
+		return nil, fmt.Errorf("otx: decode response: %w", err)
+	}
+
+	pulseCount := extractPulseCount(body)
+	if pulseCount == 0 {
+		// No OTX intel on this IP — that's "no data", not an error.
+		return nil, nil
+	}
+
+	now := time.Now().UTC()
+	result := &reputation.Result{
+		IP:       ip,
+		Enricher: o.Name(),
+		Score:    scoreFromPulseCount(pulseCount),
+		Tags:     extractTags(body),
+		CachedAt: &now,
+		Raw:      body,
+	}
+	if cc, ok := body["country_code"].(string); ok {
+		result.CountryCode = cc
+	}
+	if asn, ok := body["asn"].(string); ok {
+		result.ASN = asn
+	}
+	return result, nil
+}
+
+// scoreFromPulseCount maps OTX pulse counts onto the 0–10 reputation
+// scale. The mapping is intentionally simple — callers that need a
+// finer-grained model should inspect Result.Raw directly.
+func scoreFromPulseCount(n int) float64 {
+	switch {
+	case n <= 0:
+		return 0
+	case n >= 25:
+		return 10
+	default:
+		return float64(n) * 10.0 / 25.0
+	}
+}
+
+func extractPulseCount(body map[string]any) int {
+	pulseInfo, ok := body["pulse_info"].(map[string]any)
+	if !ok {
+		return 0
+	}
+	switch v := pulseInfo["count"].(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	}
+	if pulses, ok := pulseInfo["pulses"].([]any); ok {
+		return len(pulses)
+	}
+	return 0
+}
+
+func extractTags(body map[string]any) []string {
+	pulseInfo, ok := body["pulse_info"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	pulses, ok := pulseInfo["pulses"].([]any)
+	if !ok {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	var tags []string
+	for _, raw := range pulses {
+		pulse, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		rawTags, ok := pulse["tags"].([]any)
+		if !ok {
+			continue
+		}
+		for _, t := range rawTags {
+			s, ok := t.(string)
+			if !ok {
+				continue
+			}
+			s = strings.TrimSpace(s)
+			if s == "" {
+				continue
+			}
+			if _, dup := seen[s]; dup {
+				continue
+			}
+			seen[s] = struct{}{}
+			tags = append(tags, s)
+		}
+	}
+	return tags
+}

--- a/internal/reputation/otx/otx_test.go
+++ b/internal/reputation/otx/otx_test.go
@@ -1,0 +1,118 @@
+package otx
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestOTXEnricher_Disabled(t *testing.T) {
+	e := New("")
+	res, err := e.Enrich(context.Background(), "1.2.3.4")
+	if err != nil || res != nil {
+		t.Fatalf("disabled enricher should be no-op, got (%v, %v)", res, err)
+	}
+}
+
+func TestOTXEnricher_HTTP200WithPulses(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-OTX-API-KEY"); got != "secret" {
+			t.Fatalf("missing api key header, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"country_code": "US",
+			"asn": "AS15169",
+			"pulse_info": {
+				"count": 5,
+				"pulses": [
+					{"tags": ["malware", "scanner"]},
+					{"tags": ["scanner"]}
+				]
+			}
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	e := &OTXEnricher{APIKey: "secret", BaseURL: srv.URL, Client: srv.Client()}
+	res, err := e.Enrich(context.Background(), "1.2.3.4")
+	if err != nil {
+		t.Fatalf("Enrich error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("expected result, got nil")
+	}
+	if res.IP != "1.2.3.4" || res.Enricher != "otx" {
+		t.Fatalf("bad result fields: %#v", res)
+	}
+	if res.CountryCode != "US" || res.ASN != "AS15169" {
+		t.Fatalf("country/asn not populated: %#v", res)
+	}
+	if res.Score == 0 {
+		t.Fatalf("score should be > 0 for 5 pulses, got %v", res.Score)
+	}
+	tagSet := map[string]bool{}
+	for _, tg := range res.Tags {
+		tagSet[tg] = true
+	}
+	if !tagSet["malware"] || !tagSet["scanner"] {
+		t.Fatalf("tags missing: %v", res.Tags)
+	}
+}
+
+func TestOTXEnricher_HTTP200NoPulses_ReturnsNil(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"pulse_info":{"count":0}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	e := &OTXEnricher{APIKey: "secret", BaseURL: srv.URL, Client: srv.Client()}
+	res, err := e.Enrich(context.Background(), "1.2.3.4")
+	if err != nil || res != nil {
+		t.Fatalf("no pulses should be (nil, nil); got (%v, %v)", res, err)
+	}
+}
+
+func TestOTXEnricher_HTTPRateLimitedIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "rate limit", http.StatusTooManyRequests)
+	}))
+	t.Cleanup(srv.Close)
+
+	e := &OTXEnricher{APIKey: "secret", BaseURL: srv.URL, Client: srv.Client()}
+	_, err := e.Enrich(context.Background(), "1.2.3.4")
+	if err == nil {
+		t.Fatal("expected rate-limit error")
+	}
+}
+
+func TestOTXEnricher_HTTPForbiddenIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	t.Cleanup(srv.Close)
+
+	e := &OTXEnricher{APIKey: "secret", BaseURL: srv.URL, Client: srv.Client()}
+	_, err := e.Enrich(context.Background(), "1.2.3.4")
+	if err == nil {
+		t.Fatal("expected forbidden error")
+	}
+}
+
+func TestScoreFromPulseCount(t *testing.T) {
+	cases := []struct {
+		in   int
+		want float64
+	}{
+		{0, 0},
+		{1, 0.4},
+		{25, 10},
+		{100, 10},
+	}
+	for _, tc := range cases {
+		if got := scoreFromPulseCount(tc.in); got != tc.want {
+			t.Errorf("scoreFromPulseCount(%d) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/reputation/passivedns/passivedns.go
+++ b/internal/reputation/passivedns/passivedns.go
@@ -1,0 +1,52 @@
+// Package passivedns provides a PassiveDNS backend for the reputation
+// enrichment interface.
+//
+// The expected backend is CIRCL PassiveDNS or any compatible server
+// implementing the COF (Common Output Format) protocol:
+//
+//	GET https://{server}/query/{ip}
+//	Headers: Authorization: Bearer {token} (optional)
+//	Response: newline-delimited JSON, one record per historical resolution
+//
+// This file ships a stub implementation: Enrich always returns (nil, nil).
+// It exists so the registry surface and env loader are complete; the wire
+// protocol is left to a follow-up PR (or to external integrators who
+// embed coldstep and supply their own Enricher).
+package passivedns
+
+import (
+	"context"
+	"strings"
+
+	"github.com/coldstep-io/coldstep/internal/reputation"
+)
+
+// Enricher implements reputation.Enricher against a CIRCL PassiveDNS
+// compatible server. The Server field is the base URL of the PDNS
+// service; Token is the optional bearer token.
+type Enricher struct {
+	Server string
+	Token  string
+}
+
+// New constructs a PassiveDNS enricher pointing at server. When server is
+// empty, Enrich returns (nil, nil).
+func New(server string) *Enricher {
+	return &Enricher{Server: strings.TrimSpace(server)}
+}
+
+// Name reports the stable identifier "passivedns".
+func (e *Enricher) Name() string { return "passivedns" }
+
+// Enrich queries the configured PassiveDNS server for the given IP.
+//
+// This is a stub: it validates configuration and returns (nil, nil)
+// without making a network call. A real implementation would fetch
+// historical A/AAAA records, derive a reputation score from age/diversity
+// of resolutions, and surface the records in Result.Raw.
+func (e *Enricher) Enrich(_ context.Context, _ string) (*reputation.Result, error) {
+	if e == nil || e.Server == "" {
+		return nil, nil
+	}
+	return nil, nil
+}

--- a/internal/reputation/registry.go
+++ b/internal/reputation/registry.go
@@ -1,0 +1,147 @@
+package reputation
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+)
+
+var (
+	registryMu sync.RWMutex
+	registry   []Enricher
+)
+
+// Register adds e to the package-level registry. Re-registering an
+// enricher with the same Name() replaces the existing entry so callers may
+// safely call Register from init() in tests without leaking instances
+// across runs. A nil enricher is ignored.
+func Register(e Enricher) {
+	if e == nil {
+		return
+	}
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	name := e.Name()
+	for i, existing := range registry {
+		if existing.Name() == name {
+			registry[i] = e
+			return
+		}
+	}
+	registry = append(registry, e)
+}
+
+// Reset clears the registry. Exported for tests.
+func Reset() {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry = nil
+}
+
+// Registered returns a copy of the currently registered enrichers in
+// registration order. The returned slice is owned by the caller.
+func Registered() []Enricher {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	out := make([]Enricher, len(registry))
+	copy(out, registry)
+	return out
+}
+
+// EnrichAll fans out the lookup for ip to every registered enricher
+// concurrently and returns the non-nil results.
+//
+// Behaviour:
+//   - Each enricher is invoked with the supplied ctx. Slow or hung
+//     enrichers do not block others — EnrichAll only waits for the
+//     enrichers that respond (or for ctx cancellation).
+//   - Results are sorted by enricher name for deterministic output.
+//   - If one or more enrichers return an error, the errors are joined
+//     and returned alongside any successful results. Callers should not
+//     treat a partial error as fatal.
+func EnrichAll(ctx context.Context, ip string) ([]*Result, error) {
+	enrichers := Registered()
+	if len(enrichers) == 0 {
+		return nil, nil
+	}
+
+	type outcome struct {
+		res *Result
+		err error
+	}
+	resCh := make(chan outcome, len(enrichers))
+
+	var wg sync.WaitGroup
+	for _, e := range enrichers {
+		wg.Add(1)
+		go func(e Enricher) {
+			defer wg.Done()
+			defer func() {
+				// An enricher panic must not bring the report run down.
+				if r := recover(); r != nil {
+					resCh <- outcome{err: errors.New("reputation: enricher " + e.Name() + " panicked")}
+				}
+			}()
+			res, err := e.Enrich(ctx, ip)
+			resCh <- outcome{res: res, err: err}
+		}(e)
+	}
+
+	go func() {
+		wg.Wait()
+		close(resCh)
+	}()
+
+	var results []*Result
+	var errs []error
+	for {
+		select {
+		case <-ctx.Done():
+			// Drain whatever already arrived before the deadline; do not
+			// wait on the still-running enrichers. Their goroutines exit
+			// when they observe ctx (or, worst case, run to completion in
+			// the background and their sends are dropped because nobody is
+			// reading).
+			for {
+				select {
+				case o, ok := <-resCh:
+					if !ok {
+						return finalize(results, errs, ctx.Err())
+					}
+					if o.res != nil {
+						results = append(results, o.res)
+					}
+					if o.err != nil {
+						errs = append(errs, o.err)
+					}
+				default:
+					return finalize(results, errs, ctx.Err())
+				}
+			}
+		case o, ok := <-resCh:
+			if !ok {
+				return finalize(results, errs, nil)
+			}
+			if o.res != nil {
+				results = append(results, o.res)
+			}
+			if o.err != nil {
+				errs = append(errs, o.err)
+			}
+		}
+	}
+}
+
+func finalize(results []*Result, errs []error, ctxErr error) ([]*Result, error) {
+	sort.SliceStable(results, func(i, j int) bool {
+		return results[i].Enricher < results[j].Enricher
+	})
+	if ctxErr != nil {
+		errs = append(errs, ctxErr)
+	}
+	if len(errs) == 0 {
+		return results, nil
+	}
+	return results, errors.Join(errs...)
+}

--- a/internal/reputation/reputation_test.go
+++ b/internal/reputation/reputation_test.go
@@ -1,0 +1,329 @@
+package reputation_test
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/coldstep-io/coldstep/internal/reputation"
+	"github.com/coldstep-io/coldstep/internal/reputation/loader"
+)
+
+// fakeEnricher is a controllable test enricher.
+type fakeEnricher struct {
+	name   string
+	delay  time.Duration
+	result *reputation.Result
+	err    error
+}
+
+func (f *fakeEnricher) Name() string { return f.name }
+
+func (f *fakeEnricher) Enrich(ctx context.Context, ip string) (*reputation.Result, error) {
+	if f.delay > 0 {
+		select {
+		case <-time.After(f.delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.result == nil {
+		return nil, nil
+	}
+	clone := *f.result
+	clone.IP = ip
+	clone.Enricher = f.name
+	return &clone, nil
+}
+
+// hangEnricher never returns until ctx fires. Used to verify EnrichAll
+// does not block on a stuck backend.
+type hangEnricher struct{ name string }
+
+func (h *hangEnricher) Name() string { return h.name }
+func (h *hangEnricher) Enrich(ctx context.Context, _ string) (*reputation.Result, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func TestNoOpEnricher_SatisfiesInterface(t *testing.T) {
+	var _ reputation.Enricher = reputation.NoOpEnricher{}
+	n := reputation.NewNoOp("otx")
+	if got := n.Name(); got != "otx" {
+		t.Fatalf("Name() = %q, want otx", got)
+	}
+	res, err := n.Enrich(context.Background(), "1.2.3.4")
+	if res != nil || err != nil {
+		t.Fatalf("NoOp Enrich = (%v, %v), want (nil, nil)", res, err)
+	}
+}
+
+func TestRegister_Registered_RoundTrip(t *testing.T) {
+	reputation.Reset()
+	t.Cleanup(reputation.Reset)
+
+	a := &fakeEnricher{name: "alpha"}
+	b := &fakeEnricher{name: "beta"}
+	reputation.Register(a)
+	reputation.Register(b)
+	reputation.Register(nil) // ignored
+
+	got := reputation.Registered()
+	if len(got) != 2 {
+		t.Fatalf("Registered() len = %d, want 2", len(got))
+	}
+	if got[0].Name() != "alpha" || got[1].Name() != "beta" {
+		t.Fatalf("Registered() = [%s, %s], want [alpha, beta]", got[0].Name(), got[1].Name())
+	}
+
+	// Re-registering the same name should replace, not duplicate.
+	a2 := &fakeEnricher{name: "alpha", err: errors.New("replaced")}
+	reputation.Register(a2)
+	got = reputation.Registered()
+	if len(got) != 2 {
+		t.Fatalf("after replace, len = %d, want 2", len(got))
+	}
+	if got[0] != a2 {
+		t.Fatalf("alpha slot was not replaced")
+	}
+}
+
+func TestRegistered_ReturnsCopy(t *testing.T) {
+	reputation.Reset()
+	t.Cleanup(reputation.Reset)
+
+	reputation.Register(&fakeEnricher{name: "alpha"})
+	snap := reputation.Registered()
+	snap[0] = &fakeEnricher{name: "tampered"}
+
+	again := reputation.Registered()
+	if again[0].Name() != "alpha" {
+		t.Fatalf("internal slice was mutated through the returned copy")
+	}
+}
+
+func TestEnrichAll_CallsAllEnrichersAndCombines(t *testing.T) {
+	reputation.Reset()
+	t.Cleanup(reputation.Reset)
+
+	reputation.Register(&fakeEnricher{
+		name:   "alpha",
+		result: &reputation.Result{Score: 3.0, Tags: []string{"scanner"}},
+	})
+	reputation.Register(&fakeEnricher{
+		name:   "beta",
+		result: &reputation.Result{Score: 7.5, Tags: []string{"malware"}},
+	})
+
+	results, err := reputation.EnrichAll(context.Background(), "1.2.3.4")
+	if err != nil {
+		t.Fatalf("EnrichAll error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results len = %d, want 2", len(results))
+	}
+	// Sort-by-name ordering is part of the contract.
+	if results[0].Enricher != "alpha" || results[1].Enricher != "beta" {
+		t.Fatalf("results not sorted by enricher name: %v / %v", results[0].Enricher, results[1].Enricher)
+	}
+	if results[0].IP != "1.2.3.4" {
+		t.Fatalf("IP propagated incorrectly: %q", results[0].IP)
+	}
+}
+
+func TestEnrichAll_NilResultsAreSkipped(t *testing.T) {
+	reputation.Reset()
+	t.Cleanup(reputation.Reset)
+
+	reputation.Register(reputation.NewNoOp("disabled"))
+	reputation.Register(&fakeEnricher{
+		name:   "active",
+		result: &reputation.Result{Score: 1.0},
+	})
+
+	results, err := reputation.EnrichAll(context.Background(), "1.2.3.4")
+	if err != nil {
+		t.Fatalf("EnrichAll error: %v", err)
+	}
+	if len(results) != 1 || results[0].Enricher != "active" {
+		t.Fatalf("expected only 'active' result, got %#v", results)
+	}
+}
+
+func TestEnrichAll_EmptyRegistry(t *testing.T) {
+	reputation.Reset()
+	t.Cleanup(reputation.Reset)
+
+	results, err := reputation.EnrichAll(context.Background(), "1.2.3.4")
+	if err != nil || results != nil {
+		t.Fatalf("empty registry: got (%v, %v), want (nil, nil)", results, err)
+	}
+}
+
+func TestEnrichAll_HungEnricherDoesNotBlockOthers(t *testing.T) {
+	reputation.Reset()
+	t.Cleanup(reputation.Reset)
+
+	reputation.Register(&hangEnricher{name: "slow"})
+	reputation.Register(&fakeEnricher{
+		name:   "fast",
+		result: &reputation.Result{Score: 4.0},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	results, err := reputation.EnrichAll(ctx, "9.9.9.9")
+	elapsed := time.Since(start)
+
+	// We expect the fast enricher's result to be returned, and we expect
+	// EnrichAll to return well before any "long" timeout because once
+	// ctx fires it stops waiting on the hung enricher.
+	if elapsed > 2*time.Second {
+		t.Fatalf("EnrichAll waited too long (%v) — should bail out on ctx deadline", elapsed)
+	}
+	// err should reflect the context deadline.
+	if err == nil {
+		t.Fatalf("expected ctx error from EnrichAll, got nil")
+	}
+	foundFast := false
+	for _, r := range results {
+		if r.Enricher == "fast" {
+			foundFast = true
+		}
+	}
+	if !foundFast {
+		t.Fatalf("fast enricher's result missing despite hung neighbour: %#v", results)
+	}
+}
+
+func TestEnrichAll_PartialErrorsReturned(t *testing.T) {
+	reputation.Reset()
+	t.Cleanup(reputation.Reset)
+
+	reputation.Register(&fakeEnricher{name: "good", result: &reputation.Result{Score: 2}})
+	reputation.Register(&fakeEnricher{name: "bad", err: errors.New("backend exploded")})
+
+	results, err := reputation.EnrichAll(context.Background(), "1.1.1.1")
+	if err == nil || !contains(err.Error(), "backend exploded") {
+		t.Fatalf("expected backend error to be surfaced, got %v", err)
+	}
+	if len(results) != 1 || results[0].Enricher != "good" {
+		t.Fatalf("expected 'good' result alongside error, got %#v", results)
+	}
+}
+
+func TestLoadFromEnv_Table(t *testing.T) {
+	cases := []struct {
+		name      string
+		env       map[string]string
+		wantNames []string
+		wantNoOp  map[string]bool // backend -> is no-op
+	}{
+		{
+			name:      "all empty",
+			env:       map[string]string{},
+			wantNames: []string{"otx", "virustotal", "passivedns"},
+			wantNoOp:  map[string]bool{"otx": true, "virustotal": true, "passivedns": true},
+		},
+		{
+			name:      "otx only",
+			env:       map[string]string{loader.EnvOTXAPIKey: "abc"},
+			wantNames: []string{"otx", "virustotal", "passivedns"},
+			wantNoOp:  map[string]bool{"otx": false, "virustotal": true, "passivedns": true},
+		},
+		{
+			name: "all three",
+			env: map[string]string{
+				loader.EnvOTXAPIKey:        "abc",
+				loader.EnvVirusTotalAPIKey: "def",
+				loader.EnvPassiveDNSServer: "https://pdns.example/",
+			},
+			wantNames: []string{"otx", "virustotal", "passivedns"},
+			wantNoOp:  map[string]bool{"otx": false, "virustotal": false, "passivedns": false},
+		},
+		{
+			name:      "whitespace-only treated as empty",
+			env:       map[string]string{loader.EnvOTXAPIKey: "   "},
+			wantNames: []string{"otx", "virustotal", "passivedns"},
+			wantNoOp:  map[string]bool{"otx": true, "virustotal": true, "passivedns": true},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, k := range []string{loader.EnvOTXAPIKey, loader.EnvVirusTotalAPIKey, loader.EnvPassiveDNSServer} {
+				t.Setenv(k, "")
+			}
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			got := loader.LoadFromEnv()
+			names := make([]string, len(got))
+			for i, e := range got {
+				names[i] = e.Name()
+			}
+			if !equalStringSlice(names, tc.wantNames) {
+				t.Fatalf("names = %v, want %v", names, tc.wantNames)
+			}
+			for _, e := range got {
+				_, isNoOp := e.(reputation.NoOpEnricher)
+				if isNoOp != tc.wantNoOp[e.Name()] {
+					t.Fatalf("%s: NoOp=%v, want %v", e.Name(), isNoOp, tc.wantNoOp[e.Name()])
+				}
+			}
+		})
+	}
+}
+
+func TestEnrichAll_Deterministic(t *testing.T) {
+	reputation.Reset()
+	t.Cleanup(reputation.Reset)
+
+	for _, name := range []string{"zeta", "alpha", "mu"} {
+		reputation.Register(&fakeEnricher{name: name, result: &reputation.Result{Score: 1}})
+	}
+	results, err := reputation.EnrichAll(context.Background(), "8.8.8.8")
+	if err != nil {
+		t.Fatalf("EnrichAll: %v", err)
+	}
+	got := make([]string, len(results))
+	for i, r := range results {
+		got[i] = r.Enricher
+	}
+	want := []string{"alpha", "mu", "zeta"}
+	sort.Strings(want)
+	if !equalStringSlice(got, want) {
+		t.Fatalf("not sorted by enricher name: got %v, want %v", got, want)
+	}
+}
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && indexOf(s, substr) >= 0
+}
+
+func indexOf(s, substr string) int {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
## Summary

Implements **P2-5: Reputation integration hooks** — a stable, extensible plug-in interface for IP reputation enrichment backends (OTX, VirusTotal, PassiveDNS) under `internal/reputation`. External integrators can ship their own enrichers without modifying core coldstep code.

- `internal/reputation/{interface,registry}.go` — `Enricher` interface, `Result` struct, `NoOpEnricher`, `Register`/`Registered`/`EnrichAll`. `EnrichAll` fans out concurrently, sorts by enricher name for deterministic output, and does **not** block on hung backends past the ctx deadline.
- `internal/reputation/otx` — OTX backend hitting `https://otx.alienvault.com/api/v1/indicators/IPv4/{ip}/general` with `X-OTX-API-KEY`. 10s default timeout, 4 MiB JSON decode cap, 0–10 score derived from pulse count, tags collected from pulses.
- `internal/reputation/passivedns` — CIRCL PassiveDNS stub (interface satisfied; wire protocol left to a follow-up PR).
- `internal/reputation/loader` — env-driven assembly: `COLDSTEP_OTX_API_KEY`, `COLDSTEP_VIRUSTOTAL_API_KEY`, `COLDSTEP_PASSIVEDNS_SERVER`. Lives in its own subpackage so concrete backends can import the interface without an import cycle. When a backend's env var is empty the loader installs a `NoOpEnricher` for that slot so the returned `[]Enricher` shape stays stable.
- `cmd/coldstep-report` — `rdns-enrich` and `otx-enrich` now invoke `loader.LoadFromEnv()` → `reputation.Register(...)` → `reputation.EnrichAll(ctx, ip)` after their existing work, writing combined results into `m["reputation_results"]` plus an `m["reputation"]` summary. Coexists with the legacy `OTX_API_KEY` flow (different env var).

## Design constraints honored

- Enrichment is **post-processing only** — runs after JSONL is on disk, never on the agent's hot path.
- **Opt-in**: backends are inert until users configure the relevant env var.
- **No external network calls from core coldstep** by default.
- **Stable surface**: the public API (`Enricher`, `Result`, `Register`, `Registered`, `EnrichAll`, `LoadFromEnv`) is intended to remain backward-compatible once shipped.
- **Two modes only** preserved (detect / defend); no enforcement-flow changes.

## Tests

- `NoOpEnricher` satisfies the interface and is a clean no-op.
- `Register` + `Registered` round-trip, including replace-on-same-name and copy-on-return semantics.
- `EnrichAll` fans out to multiple enrichers, sorts results deterministically, and skips nil returns.
- **Hung-enricher safety**: a backend that never returns does not block its peers — `EnrichAll` bails out at the ctx deadline and still surfaces the fast enricher's result.
- Partial errors are returned alongside successful results via `errors.Join`.
- `LoadFromEnv` table test covers all-empty, otx-only, all-three, and whitespace-only env values.
- `internal/reputation/otx`: httptest-backed coverage for 200-with-pulses, 200-no-pulses (returns nil), 403, 429, and score mapping.

## Docs

- `CLAUDE.md` gets a new **Reputation enrichment interface** subsection under Architecture.
- `README.md` gets a **Pluggable reputation enrichment (OTX, VirusTotal, PassiveDNS)** block listing the opt-in env vars and the resulting model fields.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go vet ./internal/reputation/... ./cmd/coldstep-report/...` clean
- [x] `go test ./internal/reputation/... ./cmd/coldstep-report/... -count=1` passes
- [x] `scripts/check-gofmt.sh` and `scripts/check-encoding.sh` clean
- [ ] Linux CI: full `go vet ./...`, `staticcheck`, `go test ./... -count=1`
- [ ] Existing rdns-enrich / otx-enrich behavior unchanged when no `COLDSTEP_*` reputation env vars are set (new pass writes a summary with `active_enrichers: []` and no `reputation_results`).
- [ ] With `COLDSTEP_OTX_API_KEY` set, the new pass populates `reputation_results` alongside the legacy `m["otx"]` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
