### PR TITLE
fix: gosec G101 nolint on env var name in reputation loader

### DIFF
--- a/internal/reputation/loader/loader.go
+++ b/internal/reputation/loader/loader.go
@@ -21,7 +21,7 @@ import (
 // Env var names recognized by LoadFromEnv. Centralized here so callers
 // (and docs) reference a single source of truth.
 const (
-	EnvOTXAPIKey        = "COLDSTEP_OTX_API_KEY"
+	EnvOTXAPIKey        = "COLDSTEP_OTX_API_KEY" // #nosec G101 -- env var name, not a credential value
 	EnvVirusTotalAPIKey = "COLDSTEP_VIRUSTOTAL_API_KEY"
 	EnvPassiveDNSServer = "COLDSTEP_PASSIVEDNS_SERVER"
 )


### PR DESCRIPTION
Suppresses false-positive gosec G101 on the literal string COLDSTEP_OTX_API_KEY, which is an environment variable name, not a credential.