### PR TITLE
feat(report): surface TLS SNI confidence reason codes in digest (P3-4)

### DIFF
--- a/.github/pr-bodies/pr-p3-4-tls-confidence-digest.md
+++ b/.github/pr-bodies/pr-p3-4-tls-confidence-digest.md
@@ -1,0 +1,32 @@
+## Summary
+
+- Surfaces TLS SNI **confidence reason codes** (`full`/`partial`/`inferred`/`unknown`) in the detect-mode Markdown digest so operators can tell at a glance how reliable each ClientHello SNI extraction is. (P3-4)
+- Adds the codes to JSONL `TLSEvent`s via a new `confidence` field and a new `ParseClientHelloSNIWithConfidence` helper that distinguishes a fully-captured ClientHello from one whose record extended past the BPF buffer.
+- KPI table gains a `tls SNI confidence` line (e.g. `5 names · 3 full · 1 partial · 1 inferred`), the recent-TLS table gains a `Confidence` column, and the **Technical details** fold gains a legend describing each tier.
+
+## What changed
+
+| Layer | File | Change |
+| :-- | :-- | :-- |
+| Telemetry | `internal/telemetry/event.go` | New `TLSSNIConfidence` constants; added `confidence` JSON field to `TLSEvent`. |
+| Telemetry | `internal/telemetry/tls_clienthello.go` | New `ParseClientHelloSNIWithConfidence` that returns `full` when the record/CH/extensions all fit, `partial` when truncation was reached. Legacy `ParseClientHelloSNI` kept as a thin wrapper. |
+| Agent | `internal/agent/agent_linux_state.go` | Per-tier counters on `runStats` (+ `tlsConfidenceCounts()` accessor) and updated `addTLS(cl, confidence)` signature. |
+| Agent | `internal/agent/agent_linux_ring_read.go` | Wires confidence from parser into row buffer, stats, and JSONL event. |
+| Agent | `internal/agent/agent_linux_digest.go` | Threads counts into `DigestInput`. |
+| Report | `internal/report/digest_types.go` | `TLSDigestRow.Confidence` + `DigestInput.TLSConfidence*` fields. |
+| Report | `internal/report/digest_aggregation.go` | `tlsConfidenceBreakdown` helper that emits the `"N names · X full · …"` line, omitting zero-count tiers. |
+| Report | `internal/report/digest.go` | KPI row, recent-TLS Confidence column, and tech-details legend describing all four tiers. |
+
+## Confidence semantics
+
+- `full` — complete ClientHello parsed in a single syscall buffer (no truncation reached).
+- `partial` — SNI found inside a buffer that the TLS record extended beyond; the name may be truncated.
+- `inferred` — SNI inferred from prior DNS / connect correlation (reserved; not currently emitted by the agent).
+- `unknown` — TLS framing detected but no SNI could be extracted (reserved; today such rows are suppressed).
+
+## Test plan
+
+- [x] `go test ./internal/telemetry/... ./internal/report/... -count=1` (Windows host) — passing locally
+- [ ] `coldstep-ci-runner.yml` matrix (gofmt, encoding, unit, unit-arm64, integration, action_bundle, detect-mode, defend-mode) on PR
+- [ ] Confirm Job Summary on `detect-mode` shows the new `tls SNI confidence` row + legend
+- [ ] Nightly (`coldstep-ci-nightly.yml`) once merged

--- a/internal/agent/agent_linux_digest.go
+++ b/internal/agent/agent_linux_digest.go
@@ -87,6 +87,7 @@ func buildDigestInput(
 	canarySnap canarySnapshot,
 ) report.DigestInput {
 	execN, tcpN, udpN, httpN, tlsN, fsN := stats.counts()
+	tlsConfFull, tlsConfPartial, tlsConfInferred, tlsConfUnknown := stats.tlsConfidenceCounts()
 	rawTPName := "raw_tp/sys_enter (connect, sendto, http sniff, tls)"
 	in := report.DigestInput{
 		DetectProfile:                  cfg.DetectProfile,
@@ -96,6 +97,10 @@ func buildDigestInput(
 		UDPTotal:                       udpN,
 		HTTPTotal:                      httpN,
 		TLSTotal:                       tlsN,
+		TLSConfidenceFull:              tlsConfFull,
+		TLSConfidencePartial:           tlsConfPartial,
+		TLSConfidenceInferred:          tlsConfInferred,
+		TLSConfidenceUnknown:           tlsConfUnknown,
 		TLSSNIGate:                     tlsSNIGate,
 		PolicyCounts:                   stats.snapshotPolicyCounts(),
 		ExecRows:                       execRows,

--- a/internal/agent/agent_linux_ring_read.go
+++ b/internal/agent/agent_linux_ring_read.go
@@ -371,20 +371,21 @@ func readTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, pol
 			continue
 		}
 		comm := string(bytes.TrimRight(commb[:], "\x00"))
-		sni, parsed := telemetry.ParseClientHelloSNI(rawPay)
+		sni, confidence, parsed := telemetry.ParseClientHelloSNIWithConfidence(rawPay)
 		if !parsed {
 			stats.addDropped("tls_sni_parse")
 			continue
 		}
 		cl := pol.Classify(sni, ip)
-		stats.addTLS(cl)
+		stats.addTLS(cl, confidence)
 
 		ts := time.Now().UTC().Format(time.RFC3339Nano)
 		rows.addTLS(report.TLSDigestRow{
 			TS: ts, PID: tgid, Comm: comm,
-			SNI:    sni,
-			Remote: fmt.Sprintf("`%s:%d`", ip.String(), port),
-			Policy: cl.Display(),
+			SNI:        sni,
+			Remote:     fmt.Sprintf("`%s:%d`", ip.String(), port),
+			Policy:     cl.Display(),
+			Confidence: confidence,
 		}, stats)
 
 		if cfg.EventsLogPath != "" {
@@ -395,8 +396,9 @@ func readTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, pol
 				PID: tgid, TGID: tgid, ThreadID: tid,
 				Comm: comm, SNI: sni,
 				Dst: ip.String(), Dport: port,
-				Policy: string(cl),
-				Note:   "ClientHello SNI from first write/writev/sendto buffer (best-effort); fragmented handshakes may be missed",
+				Policy:     string(cl),
+				Confidence: confidence,
+				Note:       "ClientHello SNI from first write/writev/sendto buffer (best-effort); fragmented handshakes may be missed",
 			}
 			err := telemetry.AppendJSONL(cfg.EventsLogPath, ev, signer)
 			jsonlMu.Unlock()

--- a/internal/agent/agent_linux_state.go
+++ b/internal/agent/agent_linux_state.go
@@ -33,6 +33,10 @@ type runStats struct {
 	udpN                            int
 	httpN                           int
 	tlsN                            int
+	tlsConfidenceFullN              int
+	tlsConfidencePartialN           int
+	tlsConfidenceInferredN          int
+	tlsConfidenceUnknownN           int
 	procForkN                       int
 	fsN                             int
 	connect4TupleUpdateFailuresN    int
@@ -137,11 +141,30 @@ func (s *runStats) addHTTP(cl policy.Class) {
 	s.addPolicyLocked(cl)
 }
 
-func (s *runStats) addTLS(cl policy.Class) {
+func (s *runStats) addTLS(cl policy.Class, confidence telemetry.TLSSNIConfidence) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.tlsN++
+	switch confidence {
+	case telemetry.TLSConfidenceFull:
+		s.tlsConfidenceFullN++
+	case telemetry.TLSConfidencePartial:
+		s.tlsConfidencePartialN++
+	case telemetry.TLSConfidenceInferred:
+		s.tlsConfidenceInferredN++
+	case telemetry.TLSConfidenceUnknown:
+		s.tlsConfidenceUnknownN++
+	default:
+		s.tlsConfidenceUnknownN++
+	}
 	s.addPolicyLocked(cl)
+}
+
+// tlsConfidenceCounts returns per-tier TLS-SNI confidence counts for the digest.
+func (s *runStats) tlsConfidenceCounts() (full, partial, inferred, unknown int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.tlsConfidenceFullN, s.tlsConfidencePartialN, s.tlsConfidenceInferredN, s.tlsConfidenceUnknownN
 }
 
 func (s *runStats) setConnect4TupleUpdateFailures(n int) {

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -282,6 +282,9 @@ func writeKPITable(b *strings.Builder, in DigestInput) {
 
 	if tlsKPIVisible(in) {
 		b.WriteString(fmt.Sprintf("| **tls** | %d |\n", in.TLSTotal))
+		if breakdown := tlsConfidenceBreakdown(in); breakdown != "" {
+			b.WriteString(fmt.Sprintf("| **tls SNI confidence** | %s |\n", breakdown))
+		}
 		if in.TLSRingbufReserveFailures > 0 {
 			b.WriteString(fmt.Sprintf("| **tls_events ringbuf reserve failures** | %d |\n", in.TLSRingbufReserveFailures))
 		}
@@ -450,6 +453,11 @@ func writeTechnicalDetails(b *strings.Builder, in DigestInput, max int) {
 	b.WriteString("- **HTTP KPI** counts cleartext HTTP/1 request bytes on `sendto` to destination port 80 only; HTTPS traffic appears as TCP connect events.\n")
 	if tlsKPIVisible(in) {
 		b.WriteString("- **tls KPI** counts ClientHello **SNI** parsed from the first cleartext handshake buffer on `write`/`writev`/`pwrite`/`pwritev`/`pwritev2`/`sendto` paths after an IPv4 `connect` when `COLDSTEP_FEATURE_GATES=tls_sni=1` (not decrypted TLS).\n")
+		b.WriteString("- **tls SNI confidence** reason codes (next to each row and rolled up in the KPI):\n")
+		b.WriteString("    - `full` — complete ClientHello parsed in a single syscall buffer.\n")
+		b.WriteString("    - `partial` — SNI found but the TLS record was fragmented past the captured buffer; the name may be truncated.\n")
+		b.WriteString("    - `inferred` — SNI inferred from prior DNS / connect correlation, not directly parsed from a ClientHello.\n")
+		b.WriteString("    - `unknown` — TLS framing was detected but no SNI could be extracted.\n")
 	}
 	if procForkKPIVisible(in) {
 		b.WriteString("- **proc_fork** counts `sched_process_fork` events (best-effort parent/child lineage).\n")
@@ -686,14 +694,19 @@ func BuildDetectMarkdown(in DigestInput) string {
 			return
 		}
 		b.WriteString("<details>\n<summary><strong>TLS ClientHello / SNI (recent)</strong></summary>\n\n")
-		b.WriteString("| Time (UTC) | PID | Comm | SNI | Remote | Policy |\n|:--|--:|:-|:-|:-|:-|\n")
+		b.WriteString("| Time (UTC) | PID | Comm | SNI | Remote | Policy | Confidence |\n|:--|--:|:-|:-|:-|:-|:-|\n")
 		if len(in.TLSRows) == 0 {
-			b.WriteString(fmt.Sprintf("| — | — | — | — | — | %s |\n", sanitizeCell(protocolEmptyReason(in.TLSDegradedHook, in.TLSReaderErrors))))
+			b.WriteString(fmt.Sprintf("| — | — | — | — | — | %s | — |\n", sanitizeCell(protocolEmptyReason(in.TLSDegradedHook, in.TLSReaderErrors))))
 		} else {
 			for _, r := range in.TLSRows {
-				b.WriteString(fmt.Sprintf("| %s | `%d` | `%s` | `%s` | %s | %s |\n",
+				conf := r.Confidence
+				if conf == "" {
+					conf = "unknown"
+				}
+				b.WriteString(fmt.Sprintf("| %s | `%d` | `%s` | `%s` | %s | %s | `%s` |\n",
 					sanitizeCell(r.TS), r.PID, sanitizeCell(r.Comm),
-					sanitizeCell(r.SNI), sanitizeCell(r.Remote), sanitizeCell(r.Policy)))
+					sanitizeCell(r.SNI), sanitizeCell(r.Remote), sanitizeCell(r.Policy),
+					sanitizeCell(conf)))
 			}
 		}
 		b.WriteString("\n</details>\n\n")

--- a/internal/report/digest_aggregation.go
+++ b/internal/report/digest_aggregation.go
@@ -144,6 +144,31 @@ func tlsKPIVisible(in DigestInput) bool {
 	return in.TLSSNIGate
 }
 
+// tlsConfidenceBreakdown renders the per-tier TLS SNI breakdown shown next to
+// the tls KPI total — e.g. `42 names · 38 full · 3 partial · 1 inferred`. It
+// returns an empty string when no rows or tier counters are present so that
+// the KPI table stays terse for runs without TLS visibility.
+func tlsConfidenceBreakdown(in DigestInput) string {
+	total := in.TLSConfidenceFull + in.TLSConfidencePartial + in.TLSConfidenceInferred + in.TLSConfidenceUnknown
+	if total == 0 {
+		return ""
+	}
+	parts := []string{fmt.Sprintf("%d names", total)}
+	if in.TLSConfidenceFull > 0 {
+		parts = append(parts, fmt.Sprintf("%d full", in.TLSConfidenceFull))
+	}
+	if in.TLSConfidencePartial > 0 {
+		parts = append(parts, fmt.Sprintf("%d partial", in.TLSConfidencePartial))
+	}
+	if in.TLSConfidenceInferred > 0 {
+		parts = append(parts, fmt.Sprintf("%d inferred", in.TLSConfidenceInferred))
+	}
+	if in.TLSConfidenceUnknown > 0 {
+		parts = append(parts, fmt.Sprintf("%d unknown", in.TLSConfidenceUnknown))
+	}
+	return strings.Join(parts, " · ")
+}
+
 func fsKPIVisible(in DigestInput) bool {
 	return in.FSGate
 }

--- a/internal/report/digest_test.go
+++ b/internal/report/digest_test.go
@@ -163,15 +163,17 @@ func TestBuildDetectMarkdown_KPIAndSections(t *testing.T) {
 
 func TestBuildDetectMarkdown_TLSKPIAndSection(t *testing.T) {
 	md := BuildDetectMarkdown(DigestInput{
-		BPF:          []telemetry.BPFStatus{{Name: "raw_tp/sys_enter (connect, sendto, http sniff, tls)", OK: true}},
-		ExecTotal:    0,
-		TCPTotal:     1,
-		TLSTotal:     1,
-		TLSSNIGate:   true,
-		PolicyCounts: map[string]int{"monitor": 1},
+		BPF:               []telemetry.BPFStatus{{Name: "raw_tp/sys_enter (connect, sendto, http sniff, tls)", OK: true}},
+		ExecTotal:         0,
+		TCPTotal:          1,
+		TLSTotal:          1,
+		TLSConfidenceFull: 1,
+		TLSSNIGate:        true,
+		PolicyCounts:      map[string]int{"monitor": 1},
 		TLSRows: []TLSDigestRow{{
 			TS: "t", PID: 42, Comm: "curl", SNI: "example.com",
 			Remote: "`93.184.216.34:443`", Policy: "monitor",
+			Confidence: telemetry.TLSConfidenceFull,
 		}},
 		JSONLPath:         "/tmp/x.jsonl",
 		SeqFirst:          1,
@@ -188,6 +190,72 @@ func TestBuildDetectMarkdown_TLSKPIAndSection(t *testing.T) {
 		if !strings.Contains(md, needle) {
 			t.Fatalf("missing %q in:\n%s", needle, md)
 		}
+	}
+}
+
+// TestBuildDetectMarkdown_TLSConfidenceBreakdown exercises the case where a
+// run produces SNI rows across multiple confidence tiers. It must surface:
+//   - the KPI breakdown row (e.g. "5 names · 3 full · 1 partial · 1 inferred"),
+//   - the Confidence column header + per-row reason codes in the recent table,
+//   - the technical-details legend describing each tier.
+func TestBuildDetectMarkdown_TLSConfidenceBreakdown(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{
+		BPF:                   []telemetry.BPFStatus{{Name: "raw_tp/sys_enter (connect, sendto, http sniff, tls)", OK: true}},
+		TCPTotal:              1,
+		TLSTotal:              5,
+		TLSConfidenceFull:     3,
+		TLSConfidencePartial:  1,
+		TLSConfidenceInferred: 1,
+		TLSSNIGate:            true,
+		PolicyCounts:          map[string]int{"monitor": 5},
+		TLSRows: []TLSDigestRow{
+			{TS: "t1", PID: 10, Comm: "curl", SNI: "a.example", Remote: "`1.1.1.1:443`", Policy: "monitor", Confidence: telemetry.TLSConfidenceFull},
+			{TS: "t2", PID: 11, Comm: "curl", SNI: "b.example", Remote: "`1.1.1.2:443`", Policy: "monitor", Confidence: telemetry.TLSConfidencePartial},
+			{TS: "t3", PID: 12, Comm: "curl", SNI: "c.example", Remote: "`1.1.1.3:443`", Policy: "monitor", Confidence: telemetry.TLSConfidenceInferred},
+		},
+		JSONLPath:         "/tmp/x.jsonl",
+		SeqFirst:          1,
+		SeqLast:           5,
+		MaxRowsPerSection: 50,
+	})
+	for _, needle := range []string{
+		"| **tls** | 5 |",
+		"| **tls SNI confidence** | 5 names · 3 full · 1 partial · 1 inferred |",
+		"| Time (UTC) | PID | Comm | SNI | Remote | Policy | Confidence |",
+		"`full`",
+		"`partial`",
+		"`inferred`",
+		"complete ClientHello parsed in a single syscall buffer",
+		"SNI found but the TLS record was fragmented",
+		"SNI inferred from prior DNS / connect correlation",
+		"TLS framing was detected but no SNI could be extracted",
+	} {
+		if !strings.Contains(md, needle) {
+			t.Fatalf("missing %q in:\n%s", needle, md)
+		}
+	}
+	// Tiers with zero counts should not appear in the breakdown row.
+	if strings.Contains(md, "0 unknown") {
+		t.Fatalf("zero-count tier leaked into KPI breakdown:\n%s", md)
+	}
+}
+
+func TestTLSConfidenceBreakdown_AllTiers(t *testing.T) {
+	got := tlsConfidenceBreakdown(DigestInput{
+		TLSConfidenceFull:     7,
+		TLSConfidencePartial:  2,
+		TLSConfidenceInferred: 1,
+		TLSConfidenceUnknown:  1,
+	})
+	want := "11 names · 7 full · 2 partial · 1 inferred · 1 unknown"
+	if got != want {
+		t.Fatalf("breakdown=%q want %q", got, want)
+	}
+}
+
+func TestTLSConfidenceBreakdown_Empty(t *testing.T) {
+	if got := tlsConfidenceBreakdown(DigestInput{}); got != "" {
+		t.Fatalf("expected empty breakdown, got %q", got)
 	}
 }
 

--- a/internal/report/digest_types.go
+++ b/internal/report/digest_types.go
@@ -65,12 +65,13 @@ type HTTPDigestRow struct {
 
 // TLSDigestRow is one TLS ClientHello / SNI line in the markdown digest.
 type TLSDigestRow struct {
-	TS     string
-	PID    uint32
-	Comm   string
-	SNI    string
-	Remote string
-	Policy string
+	TS         string
+	PID        uint32
+	Comm       string
+	SNI        string
+	Remote     string
+	Policy     string
+	Confidence telemetry.TLSSNIConfidence
 }
 
 // FSDigestRow is one filesystem event line in the markdown digest.
@@ -107,8 +108,15 @@ type DigestInput struct {
 	BPF           []telemetry.BPFStatus
 
 	ExecTotal, TCPTotal, UDPTotal, HTTPTotal, TLSTotal int
-	TLSSNIGate                                         bool
-	PolicyCounts                                       map[string]int
+	// TLSConfidence* counts the per-tier breakdown of TLS SNI rows
+	// emitted in this run. The fields sum to TLSTotal and feed the KPI
+	// row "TLS SNI | N names · X full · Y partial · Z inferred · W unknown".
+	TLSConfidenceFull     int
+	TLSConfidencePartial  int
+	TLSConfidenceInferred int
+	TLSConfidenceUnknown  int
+	TLSSNIGate            bool
+	PolicyCounts          map[string]int
 
 	ExecRows  []ExecDigestRow
 	TCPRows   []TCPDigestRow

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -125,21 +125,47 @@ type HTTPEvent struct {
 	Sig      string `json:"sig,omitempty"`
 }
 
+// TLSSNIConfidence is the reason code attached to each TLSEvent describing how
+// reliably the SNI value was recovered.
+//
+//   - TLSConfidenceFull     — complete ClientHello parsed inside a single
+//     syscall buffer (no truncation, SNI block fully bounded).
+//   - TLSConfidencePartial  — SNI was extracted but the TLS record extended
+//     past the captured buffer; the returned name may be truncated or come from
+//     a fragmented ClientHello.
+//   - TLSConfidenceInferred — SNI was not parsed directly from a ClientHello
+//     buffer; it was inferred from prior DNS / connect correlation. (Reserved
+//     for future correlation paths; not currently emitted by the agent.)
+//   - TLSConfidenceUnknown  — TLS framing was detected but no SNI could be
+//     extracted. (Reserved; the current agent suppresses these rows.)
+//
+// These four values are stable strings on the JSONL wire and are surfaced in
+// the Markdown digest's TLS KPI breakdown.
+type TLSSNIConfidence = string
+
+const (
+	TLSConfidenceFull     TLSSNIConfidence = "full"
+	TLSConfidencePartial  TLSSNIConfidence = "partial"
+	TLSConfidenceInferred TLSSNIConfidence = "inferred"
+	TLSConfidenceUnknown  TLSSNIConfidence = "unknown"
+)
+
 // TLSEvent is one JSONL record for TLS ClientHello SNI observed on egress (detect).
 type TLSEvent struct {
-	Type     string `json:"type"` // "tls"
-	TS       string `json:"ts"`
-	Seq      uint64 `json:"seq"`
-	PID      uint32 `json:"pid"`
-	TGID     uint32 `json:"tgid"`
-	ThreadID uint32 `json:"thread_id"`
-	Comm     string `json:"comm"`
-	SNI      string `json:"sni"`
-	Dst      string `json:"dst"`
-	Dport    uint16 `json:"dport"`
-	Policy   string `json:"policy"`
-	Note     string `json:"note,omitempty"`
-	Sig      string `json:"sig,omitempty"`
+	Type       string           `json:"type"` // "tls"
+	TS         string           `json:"ts"`
+	Seq        uint64           `json:"seq"`
+	PID        uint32           `json:"pid"`
+	TGID       uint32           `json:"tgid"`
+	ThreadID   uint32           `json:"thread_id"`
+	Comm       string           `json:"comm"`
+	SNI        string           `json:"sni"`
+	Dst        string           `json:"dst"`
+	Dport      uint16           `json:"dport"`
+	Policy     string           `json:"policy"`
+	Confidence TLSSNIConfidence `json:"confidence,omitempty"`
+	Note       string           `json:"note,omitempty"`
+	Sig        string           `json:"sig,omitempty"`
 }
 
 // FSEvent is one JSONL record for a high-signal filesystem operation (detect, feature-gated).

--- a/internal/telemetry/tls_clienthello.go
+++ b/internal/telemetry/tls_clienthello.go
@@ -9,81 +9,106 @@ import (
 // The buffer may be truncated (e.g. BPF captures only the first N bytes of a larger record); the
 // function parses as far as it can and returns false only when the SNI extension is unreachable.
 func ParseClientHelloSNI(b []byte) (sni string, ok bool) {
+	sni, _, ok = ParseClientHelloSNIWithConfidence(b)
+	return sni, ok
+}
+
+// ParseClientHelloSNIWithConfidence is the confidence-aware counterpart of
+// ParseClientHelloSNI. When ok is true, confidence is either TLSConfidenceFull
+// (the TLS record, ClientHello body, and SNI extension block all fit within the
+// provided buffer) or TLSConfidencePartial (the record extended past the
+// captured bytes — SNI was found within the truncated prefix but may be the
+// first of several names or be truncated itself). When ok is false, callers
+// should treat the buffer as opaque; the agent uses TLSConfidenceUnknown for
+// the reserved JSONL value in that case.
+func ParseClientHelloSNIWithConfidence(b []byte) (sni string, confidence TLSSNIConfidence, ok bool) {
 	if len(b) < 43 {
-		return "", false
+		return "", "", false
 	}
 	if b[0] != 0x16 {
-		return "", false
+		return "", "", false
 	}
 	ver := binary.BigEndian.Uint16(b[1:3])
 	if ver < 0x0301 || ver > 0x0304 {
-		return "", false
+		return "", "", false
 	}
 	recLen := int(binary.BigEndian.Uint16(b[3:5]))
 	if recLen < 38 {
-		return "", false
+		return "", "", false
 	}
+	truncated := false
 	// Use whatever bytes are available; a BPF capture may be shorter than the full record.
 	hsEnd := 5 + recLen
 	if hsEnd > len(b) {
 		hsEnd = len(b)
+		truncated = true
 	}
 	hs := b[5:hsEnd]
 	if len(hs) < 4 || hs[0] != 0x01 {
-		return "", false
+		return "", "", false
 	}
 	chLen := int(hs[1])<<16 | int(hs[2])<<8 | int(hs[3])
 	if chLen < 34 {
-		return "", false
+		return "", "", false
 	}
 	// ClientHello body may also be truncated; use available bytes.
 	chEnd := 4 + chLen
 	if chEnd > len(hs) {
 		chEnd = len(hs)
+		truncated = true
 	}
 	ch := hs[4:chEnd]
 	i := 34 // after version + random
 	if i >= len(ch) {
-		return "", false
+		return "", "", false
 	}
 	sidLen := int(ch[i])
 	i++
 	if i+sidLen > len(ch) {
-		return "", false
+		return "", "", false
 	}
 	i += sidLen
 	if i+2 > len(ch) {
-		return "", false
+		return "", "", false
 	}
 	csLen := int(binary.BigEndian.Uint16(ch[i : i+2]))
 	i += 2
 	if i+csLen > len(ch) {
-		return "", false
+		return "", "", false
 	}
 	i += csLen
 	if i >= len(ch) {
-		return "", false
+		return "", "", false
 	}
 	compLen := int(ch[i])
 	i++
 	if i+compLen > len(ch) {
-		return "", false
+		return "", "", false
 	}
 	i += compLen
 	if i+2 > len(ch) {
-		return "", false
+		return "", "", false
 	}
 	extLen := int(binary.BigEndian.Uint16(ch[i : i+2]))
 	i += 2
 	if extLen == 0 {
-		return "", false
+		return "", "", false
 	}
 	// The extensions block may also be truncated; scan whatever bytes are available.
 	extEnd := i + extLen
 	if extEnd > len(ch) {
 		extEnd = len(ch)
+		truncated = true
 	}
-	return scanServerNameList(ch[i:extEnd])
+	name, found := scanServerNameList(ch[i:extEnd])
+	if !found {
+		return "", "", false
+	}
+	conf := TLSConfidenceFull
+	if truncated {
+		conf = TLSConfidencePartial
+	}
+	return name, conf, true
 }
 
 func scanServerNameList(ext []byte) (string, bool) {

--- a/internal/telemetry/tls_clienthello_test.go
+++ b/internal/telemetry/tls_clienthello_test.go
@@ -92,6 +92,56 @@ func TestParseClientHelloSNI_TruncatedRecord(t *testing.T) {
 	}
 }
 
+func TestParseClientHelloSNIWithConfidence_FullWhenBufferComplete(t *testing.T) {
+	ch := buildSyntheticClientHelloWithSNI("full.example")
+	if ch == nil {
+		t.Fatal("nil hello")
+	}
+	sni, conf, ok := ParseClientHelloSNIWithConfidence(ch)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if sni != "full.example" {
+		t.Fatalf("sni=%q", sni)
+	}
+	if conf != TLSConfidenceFull {
+		t.Fatalf("confidence=%q want %q", conf, TLSConfidenceFull)
+	}
+}
+
+func TestParseClientHelloSNIWithConfidence_PartialWhenRecordTruncated(t *testing.T) {
+	full := buildSyntheticClientHelloWithSNI("partial.example")
+	if full == nil {
+		t.Fatal("nil hello")
+	}
+	// Stretch the record length so the captured buffer is shorter than the
+	// declared TLS record — the parser should still pick the SNI out of the
+	// prefix but mark confidence as partial because of the truncation.
+	extPad := make([]byte, 200)
+	for i := range extPad {
+		extPad[i] = 0xab
+	}
+	raw := make([]byte, len(full)+len(extPad))
+	copy(raw, full)
+	copy(raw[len(full):], extPad)
+	newRecLen := int(binary.BigEndian.Uint16(raw[3:5])) + len(extPad)
+	binary.BigEndian.PutUint16(raw[3:5], uint16(newRecLen))
+	truncated := raw
+	if len(truncated) > 256 {
+		truncated = raw[:256]
+	}
+	sni, conf, ok := ParseClientHelloSNIWithConfidence(truncated)
+	if !ok {
+		t.Fatalf("expected SNI, got ok=false (len=%d, recLen=%d)", len(truncated), newRecLen)
+	}
+	if sni != "partial.example" {
+		t.Fatalf("sni=%q", sni)
+	}
+	if conf != TLSConfidencePartial {
+		t.Fatalf("confidence=%q want %q", conf, TLSConfidencePartial)
+	}
+}
+
 func TestParseClientHelloSNI_RejectsApplicationDataRecord(t *testing.T) {
 	// TLS application data record (type 0x17), long enough to pass initial length gates
 	// but handshake type is not ClientHello.


### PR DESCRIPTION
## Summary

- Surfaces TLS SNI **confidence reason codes** (`full`/`partial`/`inferred`/`unknown`) in the detect-mode Markdown digest so operators can tell at a glance how reliable each ClientHello SNI extraction is. (P3-4)
- Adds the codes to JSONL `TLSEvent`s via a new `confidence` field and a new `ParseClientHelloSNIWithConfidence` helper that distinguishes a fully-captured ClientHello from one whose record extended past the BPF buffer.
- KPI table gains a `tls SNI confidence` line (e.g. `5 names · 3 full · 1 partial · 1 inferred`), the recent-TLS table gains a `Confidence` column, and the **Technical details** fold gains a legend describing each tier.

## What changed

| Layer | File | Change |
| :-- | :-- | :-- |
| Telemetry | `internal/telemetry/event.go` | New `TLSSNIConfidence` constants; added `confidence` JSON field to `TLSEvent`. |
| Telemetry | `internal/telemetry/tls_clienthello.go` | New `ParseClientHelloSNIWithConfidence` that returns `full` when the record/CH/extensions all fit, `partial` when truncation was reached. Legacy `ParseClientHelloSNI` kept as a thin wrapper. |
| Agent | `internal/agent/agent_linux_state.go` | Per-tier counters on `runStats` (+ `tlsConfidenceCounts()` accessor) and updated `addTLS(cl, confidence)` signature. |
| Agent | `internal/agent/agent_linux_ring_read.go` | Wires confidence from parser into row buffer, stats, and JSONL event. |
| Agent | `internal/agent/agent_linux_digest.go` | Threads counts into `DigestInput`. |
| Report | `internal/report/digest_types.go` | `TLSDigestRow.Confidence` + `DigestInput.TLSConfidence*` fields. |
| Report | `internal/report/digest_aggregation.go` | `tlsConfidenceBreakdown` helper that emits the `"N names · X full · …"` line, omitting zero-count tiers. |
| Report | `internal/report/digest.go` | KPI row, recent-TLS Confidence column, and tech-details legend describing all four tiers. |

## Confidence semantics

- `full` — complete ClientHello parsed in a single syscall buffer (no truncation reached).
- `partial` — SNI found inside a buffer that the TLS record extended beyond; the name may be truncated.
- `inferred` — SNI inferred from prior DNS / connect correlation (reserved; not currently emitted by the agent).
- `unknown` — TLS framing detected but no SNI could be extracted (reserved; today such rows are suppressed).

## Test plan

- [x] `go test ./internal/telemetry/... ./internal/report/... -count=1` (Windows host) — passing locally
- [ ] `coldstep-ci-runner.yml` matrix (gofmt, encoding, unit, unit-arm64, integration, action_bundle, detect-mode, defend-mode) on PR
- [ ] Confirm Job Summary on `detect-mode` shows the new `tls SNI confidence` row + legend
- [ ] Nightly (`coldstep-ci-nightly.yml`) once merged
