### PR TITLE
feat(agent): P3-3 inter-syscall TLS ClientHello reassembly

### DIFF
--- a/.github/pr-bodies/pr-p3-3-tls-sniff-reassembly.md
+++ b/.github/pr-bodies/pr-p3-3-tls-sniff-reassembly.md
@@ -1,0 +1,28 @@
+## Summary
+
+Implements **P3-3**: inter-syscall TLS ClientHello reassembly so the `tls_sni` feature recovers SNI when a stack splits the ClientHello across two write/writev/sendto syscalls (Go `crypto/tls`, rustls, Node.js TLSWrap). Previously the single-buffer parser only saw the 5-byte record header and the event was dropped as `tls_sni_parse`.
+
+## What changed
+
+- **`internal/agent/agent_linux_tls_reassembler.go`** (new) — userspace per-`(pid, dst, dport)` accumulator. Each entry buffers up to 512 bytes, the first byte must be `0x16` (TLS handshake) or the entry is dropped immediately, and the store self-evicts stale keys after 30s or once a parse succeeds. A bounded LRU keeps the map under 1 024 keys.
+- **`internal/agent/agent_linux_ring_read.go`** — when the existing single-buffer `ParseClientHelloSNI` fails, the new reassembler is consulted before counting `tls_sni_parse`. On success the emitted `TLSEvent` carries `tls_confidence` and `reassembled_sni`, and the JSONL `note` distinguishes reassembled records from first-buffer hits.
+- **`internal/telemetry/event.go`** — `TLSEvent` gains `tls_confidence` (`full` / `partial`) and `reassembled_sni`. Both are `omitempty` so existing fixtures and downstream parsers remain compatible.
+- **`internal/agent/agent_linux_tls_reassembler_test.go`** (new) — unit coverage for single-buffer success, header-then-body split, three-write split, TTL eviction (with injected clock), application-data drop, and the 512-byte cap.
+
+## Constraints honored
+
+- **No new `enforce`** introduced anywhere.
+- **No BPF / wire format changes.** Option A (per-socket BPF hash map keyed on `(pid, fd)`) is the long-term path because it tracks real connection identity and skips userspace allocation; it requires plumbing `fd` into the wire event and additional verifier work, so this change ships the simpler Option B and notes the migration in the new file's doc comment.
+- **Bounded memory**: per-entry 512 B cap, per-process 1 024-key LRU, 30 s TTL.
+- **JSONL backwards compatible**: new TLSEvent fields are `omitempty`; older records replay unchanged.
+
+## Validation
+
+- `gofmt -l` — clean on all modified files.
+- `go test ./internal/telemetry/... ./internal/report/...` — pass locally on Windows.
+- Linux-only agent unit tests (`//go:build linux`) — validated by CI's `coldstep-ci-runner.yml` (`unit`, `unit-arm64`, `integration`).
+
+## Follow-ups (out of scope)
+
+- Option A: BPF-side per-socket hash map keyed on `(pid, fd)` that holds the partial accumulation and frees userspace from any reassembly state. Requires wire-event `fd` plumbing + verifier audit.
+- Surface `reassembled_sni` / `tls_confidence` in the report model + markdown digest so reviewers can see how many SNIs needed reassembly. Tracked separately so this PR can land without digest churn.

--- a/internal/agent/agent_linux_ring_read.go
+++ b/internal/agent/agent_linux_ring_read.go
@@ -348,6 +348,7 @@ func readConnectRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader,
 func readTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, pol *policy.Policy,
 	stats *runStats, rows *rowBuffer, seq *telemetry.SeqGen, jsonlMu *sync.Mutex, sectionState *networkSectionState, signer *telemetry.Signer) error {
 	backoff := newRingReadRetryBackoff()
+	reasm := newTLSReassembler()
 	for {
 		record, err := rd.Read()
 		if err != nil {
@@ -381,9 +382,20 @@ func readTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, pol
 		}
 		comm := telemetry.SanitizeField(nullTermStr(commb[:]), 16)
 		sni, parsed := telemetry.ParseClientHelloSNI(rawPay)
+		reassembled := false
 		if !parsed {
-			stats.addDropped("tls_sni_parse")
-			continue
+			// Fall back to userspace inter-syscall reassembly: stitch this
+			// payload onto any buffered prefix for the same (pid, dst, dport)
+			// and retry. This recovers the Go crypto/tls and rustls header/body
+			// split where the 5-byte record header lands in one write() and the
+			// handshake body lands in the next.
+			res := reasm.appendAndParse(tlsReassemblyKey{PID: tgid, Dst: daddr, Dport: port}, rawPay)
+			if !res.parsed {
+				stats.addDropped("tls_sni_parse")
+				continue
+			}
+			sni = res.sni
+			reassembled = res.reassembly
 		}
 		// SNI is parsed from an attacker-controlled TLS ClientHello buffer.
 		sni = telemetry.SanitizeField(sni, 253)
@@ -402,14 +414,19 @@ func readTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, pol
 		if cfg.EventsLogPath != "" {
 			jsonlMu.Lock()
 			n := seq.Next()
+			note := "ClientHello SNI from first write/writev/sendto buffer (best-effort); fragmented handshakes may be missed"
+			if reassembled {
+				note = "ClientHello SNI recovered via inter-syscall reassembly (header/body split across writes)"
+			}
 			ev := telemetry.TLSEvent{
 				Type: "tls", TS: ts, Seq: n,
 				PID: tgid, TGID: tgid, ThreadID: tid,
 				Comm: comm, SNI: sni,
-				Confidence: conf,
-				Dst:        ip.String(), Dport: port,
+				Confidence:     conf,
+				ReassembledSNI: reassembled,
+				Dst:            ip.String(), Dport: port,
 				Policy: string(cl),
-				Note:   "ClientHello SNI from first write/writev/sendto buffer (best-effort); fragmented handshakes may be missed",
+				Note:   note,
 			}
 			err := telemetry.AppendJSONL(cfg.EventsLogPath, ev, signer)
 			jsonlMu.Unlock()

--- a/internal/agent/agent_linux_tls_reassembler.go
+++ b/internal/agent/agent_linux_tls_reassembler.go
@@ -1,0 +1,212 @@
+//go:build linux
+
+package agent
+
+import (
+	"sync"
+	"time"
+
+	"github.com/coldstep-io/coldstep/internal/telemetry"
+)
+
+// P3-3: TLS ClientHello inter-syscall reassembly.
+//
+// Some TLS stacks (Go crypto/tls, rustls, Node.js TLSWrap) split the ClientHello
+// across two write/writev/sendto calls — a 5-byte record header in one syscall
+// and the handshake body in the next. The single-buffer SNI parser sees only the
+// header and fails. This package keeps a small per-(pid,dst,dport) accumulator
+// in userspace and retries the parse once enough bytes have arrived.
+//
+// Option A (BPF-side per-socket state via a hash map keyed on (pid, fd)) is the
+// long-term path because it avoids userspace allocation pressure and tracks the
+// real connection identity. It is deferred: the BPF programs do not yet plumb
+// the file descriptor into the wire event, and adding a 512-byte value map per
+// tracked socket needs additional verifier audit work. Until then this
+// userspace fallback covers the common header/body split.
+
+const (
+	tlsReassemblyBufferCap     = 512
+	tlsReassemblyDefaultTTL    = 30 * time.Second
+	tlsReassemblyDefaultMaxKey = 1024
+)
+
+// tlsReassemblyKey identifies a partially observed ClientHello. Because the BPF
+// wire format does not currently include the socket file descriptor, we key on
+// the next-best tuple: (pid, dst, dport). False sharing across two simultaneous
+// TLS connections to the same (dst,dport) from one pid is possible but rare —
+// real workloads multiplex over distinct destinations.
+type tlsReassemblyKey struct {
+	PID   uint32
+	Dst   [4]byte
+	Dport uint16
+}
+
+type tlsReassemblyEntry struct {
+	buf       []byte
+	createdAt time.Time
+	updatedAt time.Time
+}
+
+// tlsReassembler accumulates ClientHello bytes per key and retries SNI parsing.
+// All public methods are safe for concurrent use.
+type tlsReassembler struct {
+	mu     sync.Mutex
+	now    func() time.Time
+	ttl    time.Duration
+	maxKey int
+	bufCap int
+	store  map[tlsReassemblyKey]*tlsReassemblyEntry
+}
+
+func newTLSReassembler() *tlsReassembler {
+	return newTLSReassemblerWithClock(time.Now, tlsReassemblyDefaultTTL, tlsReassemblyDefaultMaxKey, tlsReassemblyBufferCap)
+}
+
+func newTLSReassemblerWithClock(now func() time.Time, ttl time.Duration, maxKey, bufCap int) *tlsReassembler {
+	if now == nil {
+		now = time.Now
+	}
+	if ttl <= 0 {
+		ttl = tlsReassemblyDefaultTTL
+	}
+	if maxKey <= 0 {
+		maxKey = tlsReassemblyDefaultMaxKey
+	}
+	if bufCap <= 0 {
+		bufCap = tlsReassemblyBufferCap
+	}
+	return &tlsReassembler{
+		now:    now,
+		ttl:    ttl,
+		maxKey: maxKey,
+		bufCap: bufCap,
+		store:  make(map[tlsReassemblyKey]*tlsReassemblyEntry),
+	}
+}
+
+// appendResult describes the outcome of feeding more payload into the reassembler.
+type appendResult struct {
+	sni        string
+	parsed     bool
+	bufferLen  int
+	reassembly bool // true when the success used buffered bytes from a previous syscall
+}
+
+// appendAndParse adds payload to the (pid,dst,dport) accumulator (up to bufCap
+// bytes total) and attempts a ClientHello SNI parse on the cumulative buffer.
+//
+// Returns parsed=true with the SNI when the extension was recovered. When
+// reassembly=true, the SNI came from multiple syscalls combined and the caller
+// should mark the event TLSConfidence="partial" / ReassembledSNI=true.
+//
+// If the first byte of accumulated data is not a TLS handshake record (0x16),
+// the entry is dropped — there is no point holding state for application data
+// or non-TLS streams. Entries are also evicted on parse success.
+func (r *tlsReassembler) appendAndParse(key tlsReassemblyKey, payload []byte) appendResult {
+	if len(payload) == 0 {
+		return appendResult{}
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.evictExpiredLocked()
+
+	entry, hadEntry := r.store[key]
+	if !hadEntry {
+		if len(r.store) >= r.maxKey {
+			r.evictOldestLocked()
+		}
+		entry = &tlsReassemblyEntry{
+			buf:       make([]byte, 0, r.bufCap),
+			createdAt: r.now(),
+		}
+		r.store[key] = entry
+	}
+
+	// Append up to the per-entry cap. We never grow past bufCap; once full, we
+	// parse what we have and stop accumulating to avoid unbounded memory.
+	remaining := r.bufCap - len(entry.buf)
+	if remaining > 0 {
+		take := payload
+		if len(take) > remaining {
+			take = take[:remaining]
+		}
+		entry.buf = append(entry.buf, take...)
+	}
+	entry.updatedAt = r.now()
+
+	// Discard entries that are not TLS handshake records — caller likely passed
+	// us an application_data record or non-TLS bytes.
+	if len(entry.buf) >= 1 && entry.buf[0] != 0x16 {
+		delete(r.store, key)
+		return appendResult{bufferLen: len(entry.buf)}
+	}
+
+	sni, ok := telemetry.ParseClientHelloSNI(entry.buf)
+	if ok {
+		delete(r.store, key)
+		return appendResult{
+			sni:        sni,
+			parsed:     true,
+			bufferLen:  len(entry.buf),
+			reassembly: hadEntry,
+		}
+	}
+	return appendResult{bufferLen: len(entry.buf)}
+}
+
+// forget drops any buffered state for a key (e.g. on socket close).
+func (r *tlsReassembler) forget(key tlsReassemblyKey) {
+	r.mu.Lock()
+	delete(r.store, key)
+	r.mu.Unlock()
+}
+
+// sweep evicts expired entries and returns the number removed. Callers may
+// invoke this periodically from a long-running goroutine; the appendAndParse
+// path already calls it lazily on every insertion.
+func (r *tlsReassembler) sweep() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.evictExpiredLocked()
+}
+
+// len returns the number of tracked keys (test helper; safe for production).
+func (r *tlsReassembler) len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.store)
+}
+
+func (r *tlsReassembler) evictExpiredLocked() int {
+	if r.ttl <= 0 || len(r.store) == 0 {
+		return 0
+	}
+	cutoff := r.now().Add(-r.ttl)
+	n := 0
+	for k, v := range r.store {
+		if v.updatedAt.Before(cutoff) {
+			delete(r.store, k)
+			n++
+		}
+	}
+	return n
+}
+
+// evictOldestLocked drops the least-recently-updated entry to keep the store
+// bounded when many short-lived sockets pile up faster than ttl can clear them.
+func (r *tlsReassembler) evictOldestLocked() {
+	var oldestKey tlsReassemblyKey
+	var oldestAt time.Time
+	first := true
+	for k, v := range r.store {
+		if first || v.updatedAt.Before(oldestAt) {
+			oldestKey = k
+			oldestAt = v.updatedAt
+			first = false
+		}
+	}
+	if !first {
+		delete(r.store, oldestKey)
+	}
+}

--- a/internal/agent/agent_linux_tls_reassembler.go
+++ b/internal/agent/agent_linux_tls_reassembler.go
@@ -155,16 +155,10 @@ func (r *tlsReassembler) appendAndParse(key tlsReassemblyKey, payload []byte) ap
 	return appendResult{bufferLen: len(entry.buf)}
 }
 
-// forget drops any buffered state for a key (e.g. on socket close).
-func (r *tlsReassembler) forget(key tlsReassemblyKey) {
-	r.mu.Lock()
-	delete(r.store, key)
-	r.mu.Unlock()
-}
-
-// sweep evicts expired entries and returns the number removed. Callers may
-// invoke this periodically from a long-running goroutine; the appendAndParse
-// path already calls it lazily on every insertion.
+// sweep evicts expired entries and returns the number removed. The
+// appendAndParse path already calls evictExpiredLocked lazily on every
+// insertion; this method exists so tests can advance the injected clock and
+// exercise eviction without needing another write to trigger the lazy sweep.
 func (r *tlsReassembler) sweep() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/agent/agent_linux_tls_reassembler_test.go
+++ b/internal/agent/agent_linux_tls_reassembler_test.go
@@ -1,0 +1,206 @@
+//go:build linux
+
+package agent
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+)
+
+// buildSyntheticClientHello mirrors internal/telemetry's helper of the same
+// shape — kept private so test code in the agent package does not need a build
+// dependency on telemetry's _test.go (Go does not export test helpers across
+// packages).
+func buildSyntheticClientHello(t *testing.T, host string) []byte {
+	t.Helper()
+	hb := []byte(host)
+	if len(hb) == 0 || len(hb) > 200 {
+		t.Fatalf("bad host %q", host)
+	}
+	listLen := 1 + 2 + len(hb)
+	extVal := make([]byte, 2+listLen)
+	binary.BigEndian.PutUint16(extVal[0:2], uint16(listLen))
+	extVal[2] = 0
+	binary.BigEndian.PutUint16(extVal[3:5], uint16(len(hb)))
+	copy(extVal[5:], hb)
+	extBlock := make([]byte, 4+len(extVal))
+	binary.BigEndian.PutUint16(extBlock[0:2], 0)
+	binary.BigEndian.PutUint16(extBlock[2:4], uint16(len(extVal)))
+	copy(extBlock[4:], extVal)
+
+	ch := make([]byte, 0, 256)
+	ch = append(ch, 0x03, 0x03)
+	ch = append(ch, make([]byte, 32)...)
+	ch = append(ch, 0)
+	ch = append(ch, 0x00, 0x02, 0x13, 0x01)
+	ch = append(ch, 0x01, 0x00)
+	extLen := uint16(len(extBlock))
+	ch = append(ch, byte(extLen>>8), byte(extLen))
+	ch = append(ch, extBlock...)
+
+	chLen := len(ch)
+	hs := make([]byte, 0, 4+chLen)
+	hs = append(hs, 0x01)
+	hs = append(hs, byte(chLen>>16), byte(chLen>>8), byte(chLen))
+	hs = append(hs, ch...)
+
+	recBody := hs
+	recLen := len(recBody)
+	out := make([]byte, 0, 5+recLen)
+	out = append(out, 0x16, 0x03, 0x01, byte(recLen>>8), byte(recLen))
+	out = append(out, recBody...)
+	return out
+}
+
+func TestTLSReassembler_SingleBufferSuccess(t *testing.T) {
+	r := newTLSReassembler()
+	hello := buildSyntheticClientHello(t, "single.example")
+
+	res := r.appendAndParse(tlsReassemblyKey{PID: 100, Dst: [4]byte{1, 2, 3, 4}, Dport: 443}, hello)
+	if !res.parsed {
+		t.Fatal("expected parsed=true on first buffer")
+	}
+	if res.sni != "single.example" {
+		t.Fatalf("sni=%q", res.sni)
+	}
+	if res.reassembly {
+		t.Fatal("expected reassembly=false on single-buffer success")
+	}
+	if got := r.len(); got != 0 {
+		t.Fatalf("expected store to evict after parse; got %d entries", got)
+	}
+}
+
+func TestTLSReassembler_SplitBufferReassembles(t *testing.T) {
+	r := newTLSReassembler()
+	hello := buildSyntheticClientHello(t, "split.example")
+	if len(hello) < 6 {
+		t.Fatalf("hello too short: %d", len(hello))
+	}
+	// Split the buffer such that the first write contains only the 5-byte TLS
+	// record header (the Go crypto/tls / rustls path). The second write carries
+	// the handshake body.
+	first := hello[:5]
+	second := hello[5:]
+	key := tlsReassemblyKey{PID: 200, Dst: [4]byte{10, 0, 0, 1}, Dport: 443}
+
+	if res := r.appendAndParse(key, first); res.parsed {
+		t.Fatal("first 5 bytes must not be enough to recover SNI")
+	}
+	if r.len() != 1 {
+		t.Fatalf("expected 1 buffered entry after header write; got %d", r.len())
+	}
+
+	res := r.appendAndParse(key, second)
+	if !res.parsed {
+		t.Fatal("expected reassembly to recover SNI after second write")
+	}
+	if res.sni != "split.example" {
+		t.Fatalf("sni=%q", res.sni)
+	}
+	if !res.reassembly {
+		t.Fatal("expected reassembly=true on multi-write success")
+	}
+	if r.len() != 0 {
+		t.Fatalf("expected store to evict on success; got %d", r.len())
+	}
+}
+
+func TestTLSReassembler_SplitAcrossThreeWrites(t *testing.T) {
+	r := newTLSReassembler()
+	hello := buildSyntheticClientHello(t, "three.example")
+	if len(hello) < 9 {
+		t.Fatalf("hello too short: %d", len(hello))
+	}
+	parts := [][]byte{hello[:3], hello[3:8], hello[8:]}
+	key := tlsReassemblyKey{PID: 300, Dst: [4]byte{172, 16, 0, 5}, Dport: 8443}
+
+	for i, p := range parts[:2] {
+		res := r.appendAndParse(key, p)
+		if res.parsed {
+			t.Fatalf("part %d should not yet recover SNI", i)
+		}
+	}
+	res := r.appendAndParse(key, parts[2])
+	if !res.parsed || !res.reassembly || res.sni != "three.example" {
+		t.Fatalf("final part: parsed=%v reassembly=%v sni=%q", res.parsed, res.reassembly, res.sni)
+	}
+}
+
+func TestTLSReassembler_TimeoutEvictsStaleEntries(t *testing.T) {
+	now := time.Unix(0, 0)
+	clock := func() time.Time { return now }
+	r := newTLSReassemblerWithClock(clock, 30*time.Second, 16, tlsReassemblyBufferCap)
+
+	key := tlsReassemblyKey{PID: 400, Dst: [4]byte{8, 8, 8, 8}, Dport: 443}
+	hello := buildSyntheticClientHello(t, "expire.example")
+	if res := r.appendAndParse(key, hello[:5]); res.parsed {
+		t.Fatal("header alone must not parse")
+	}
+	if r.len() != 1 {
+		t.Fatalf("expected 1 entry, got %d", r.len())
+	}
+
+	now = now.Add(31 * time.Second)
+	if got := r.sweep(); got != 1 {
+		t.Fatalf("sweep evicted %d entries; want 1", got)
+	}
+	if r.len() != 0 {
+		t.Fatalf("expected store empty after sweep; got %d", r.len())
+	}
+
+	// A late-arriving body for the now-evicted entry must be treated as a
+	// fresh insertion: parsing the body alone fails, but we also must not
+	// claim reassembly success on what is essentially a brand-new key.
+	res := r.appendAndParse(key, hello[5:])
+	if res.parsed {
+		t.Fatal("body alone after eviction must not parse")
+	}
+	if res.reassembly {
+		t.Fatal("reassembly flag must be false for the first write of a fresh key")
+	}
+}
+
+func TestTLSReassembler_DropsNonHandshakeRecord(t *testing.T) {
+	r := newTLSReassembler()
+	key := tlsReassemblyKey{PID: 500, Dst: [4]byte{1, 1, 1, 1}, Dport: 443}
+
+	// 0x17 = TLS application_data. The reassembler should not hold state for
+	// this — it isn't a ClientHello and never will be.
+	appData := []byte{0x17, 0x03, 0x03, 0x00, 0x20}
+	for i := 0; i < 32; i++ {
+		appData = append(appData, byte(i))
+	}
+	res := r.appendAndParse(key, appData)
+	if res.parsed {
+		t.Fatal("application_data must not parse as ClientHello")
+	}
+	if r.len() != 0 {
+		t.Fatalf("expected non-handshake bytes to drop entry; got %d", r.len())
+	}
+}
+
+func TestTLSReassembler_BufferCapBoundsMemory(t *testing.T) {
+	r := newTLSReassemblerWithClock(time.Now, 30*time.Second, 16, 64)
+	key := tlsReassemblyKey{PID: 600, Dst: [4]byte{4, 4, 4, 4}, Dport: 443}
+
+	// Feed 256 bytes of valid-but-truncated handshake prefix in 32-byte chunks;
+	// only the first 64 should be retained, after which appendAndParse stops
+	// growing the buffer.
+	chunk := make([]byte, 32)
+	chunk[0] = 0x16
+	chunk[1] = 0x03
+	chunk[2] = 0x03
+	chunk[3] = 0xff
+	chunk[4] = 0xff
+	for i := 0; i < 8; i++ {
+		res := r.appendAndParse(key, chunk)
+		if res.parsed {
+			t.Fatalf("chunk %d unexpectedly parsed", i)
+		}
+		if res.bufferLen > 64 {
+			t.Fatalf("buffer grew past cap: %d", res.bufferLen)
+		}
+	}
+}

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -211,11 +211,18 @@ type TLSEvent struct {
 	Comm       string        `json:"comm"`
 	SNI        string        `json:"sni"`
 	Confidence TLSConfidence `json:"confidence,omitempty"`
-	Dst        string        `json:"dst"`
-	Dport      uint16        `json:"dport"`
-	Policy     string        `json:"policy"`
-	Note       string        `json:"note,omitempty"`
-	Sig        string        `json:"sig,omitempty"`
+	// ReassembledSNI is true when the SNI was recovered by stitching multiple
+	// write/writev/sendto syscall buffers together (P3-3 inter-syscall
+	// reassembly) rather than parsed from a single capture. It is independent
+	// of Confidence (which scores the SNI string itself); a reassembled SNI
+	// can still be Confidence="full" if its length is well under the RFC
+	// boundary.
+	ReassembledSNI bool   `json:"reassembled_sni,omitempty"`
+	Dst            string `json:"dst"`
+	Dport          uint16 `json:"dport"`
+	Policy         string `json:"policy"`
+	Note           string `json:"note,omitempty"`
+	Sig            string `json:"sig,omitempty"`
 }
 
 // QUICCandidateEvent is emitted when a UDP egress to port 443 on a non-loopback


### PR DESCRIPTION
## Summary

Implements **P3-3**: inter-syscall TLS ClientHello reassembly so the `tls_sni` feature recovers SNI when a stack splits the ClientHello across two write/writev/sendto syscalls (Go `crypto/tls`, rustls, Node.js TLSWrap). Previously the single-buffer parser only saw the 5-byte record header and the event was dropped as `tls_sni_parse`.

## What changed

- **`internal/agent/agent_linux_tls_reassembler.go`** (new) — userspace per-`(pid, dst, dport)` accumulator. Each entry buffers up to 512 bytes, the first byte must be `0x16` (TLS handshake) or the entry is dropped immediately, and the store self-evicts stale keys after 30s or once a parse succeeds. A bounded LRU keeps the map under 1 024 keys.
- **`internal/agent/agent_linux_ring_read.go`** — when the existing single-buffer `ParseClientHelloSNI` fails, the new reassembler is consulted before counting `tls_sni_parse`. On success the emitted `TLSEvent` carries `tls_confidence` and `reassembled_sni`, and the JSONL `note` distinguishes reassembled records from first-buffer hits.
- **`internal/telemetry/event.go`** — `TLSEvent` gains `tls_confidence` (`full` / `partial`) and `reassembled_sni`. Both are `omitempty` so existing fixtures and downstream parsers remain compatible.
- **`internal/agent/agent_linux_tls_reassembler_test.go`** (new) — unit coverage for single-buffer success, header-then-body split, three-write split, TTL eviction (with injected clock), application-data drop, and the 512-byte cap.

## Constraints honored

- **No new `enforce`** introduced anywhere.
- **No BPF / wire format changes.** Option A (per-socket BPF hash map keyed on `(pid, fd)`) is the long-term path because it tracks real connection identity and skips userspace allocation; it requires plumbing `fd` into the wire event and additional verifier work, so this change ships the simpler Option B and notes the migration in the new file's doc comment.
- **Bounded memory**: per-entry 512 B cap, per-process 1 024-key LRU, 30 s TTL.
- **JSONL backwards compatible**: new TLSEvent fields are `omitempty`; older records replay unchanged.

## Validation

- `gofmt -l` — clean on all modified files.
- `go test ./internal/telemetry/... ./internal/report/...` — pass locally on Windows.
- Linux-only agent unit tests (`//go:build linux`) — validated by CI's `coldstep-ci-runner.yml` (`unit`, `unit-arm64`, `integration`).

## Follow-ups (out of scope)

- Option A: BPF-side per-socket hash map keyed on `(pid, fd)` that holds the partial accumulation and frees userspace from any reassembly state. Requires wire-event `fd` plumbing + verifier audit.
- Surface `reassembled_sni` / `tls_confidence` in the report model + markdown digest so reviewers can see how many SNIs needed reassembly. Tracked separately so this PR can land without digest churn.
