### PR TITLE
feat(report): per-row TLS SNI confidence column + tier legend (P3-4)

### DIFF
--- a/.github/pr-bodies/pr-p3-4-tls-confidence-digest.md
+++ b/.github/pr-bodies/pr-p3-4-tls-confidence-digest.md
@@ -1,0 +1,24 @@
+## Summary
+
+Additive follow-up to **P1-4** (#163), which introduced `telemetry.TLSConfidence`, `ScoreTLSConfidence`, and the `tls SNI confidence` KPI row. P1-4 surfaced confidence as an aggregate count; this PR makes the per-event reason code **visible per row** and **defined in-place** so operators can attribute KPI numbers to specific destinations and look up what each tier means without leaving the digest.
+
+## What changed
+
+- **Per-row Confidence column** in the recent TLS table (`internal/report/digest.go::writeTLSSection`) — every SNI row now shows its `full` / `partial` / `inferred` / `unknown` reason code next to the policy verdict.
+- **Tier-meaning legend** under the existing `tls KPI` bullet in the Technical-details fold — defines all four codes (`full`, `partial`, `inferred`, `unknown`) with their capture semantics, including a reference to the `TLSSNIMaxLen=255` boundary that drives the `full → partial` transition.
+- **`TLSDigestRow.Confidence`** field plumbed through the agent's TLS ring reader so each row carries the already-scored confidence into the digest. The row defaults to `unknown` when zero-valued, so the column is never blank.
+- **Gating consistent with P1-4**: the legend is only emitted when `TLSTotal > 0` (matching the existing KPI-row gate), so a TLS-gated run with no events stays terse.
+
+## Why this is small
+
+P1-4 already implemented the scoring, the JSONL `Confidence` field, the per-tier counters, and the KPI row. Re-defining those would conflict and add no value. This PR is strictly additive: 4 files, no new types, no new fields on `TLSEvent`, no behavioral change to scoring.
+
+## Test plan
+
+- [x] `go test ./internal/telemetry/... ./internal/report/... -count=1` — passing locally.
+- [x] New tests in `digest_test.go`:
+  - `TestBuildDetectMarkdown_TLSConfidencePerRowAndLegend` — co-existing tiers render in the Confidence column **and** the legend is emitted.
+  - `TestBuildDetectMarkdown_TLSConfidenceEmptyRowDefault` — zero-value `Confidence` falls back to `unknown`.
+- [x] `gofmt -l internal/` clean.
+- [ ] `coldstep-ci-runner.yml` matrix on PR (gofmt, encoding, unit, unit-arm64, integration, action_bundle, detect-mode, defend-mode).
+- [ ] Confirm Job Summary on the `detect-mode` workflow shows the new Confidence column + legend.

--- a/internal/agent/agent_linux_ring_read.go
+++ b/internal/agent/agent_linux_ring_read.go
@@ -394,9 +394,10 @@ func readTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, pol
 		ts := time.Now().UTC().Format(time.RFC3339Nano)
 		rows.addTLS(report.TLSDigestRow{
 			TS: ts, PID: tgid, Comm: comm,
-			SNI:    sni,
-			Remote: fmt.Sprintf("`%s:%d`", ip.String(), port),
-			Policy: cl.Display(),
+			SNI:        sni,
+			Remote:     fmt.Sprintf("`%s:%d`", ip.String(), port),
+			Policy:     cl.Display(),
+			Confidence: conf,
 		}, stats)
 
 		if cfg.EventsLogPath != "" {

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/coldstep-io/coldstep/internal/atomicwrite"
+	"github.com/coldstep-io/coldstep/internal/telemetry"
 )
 
 // partialEgressTotal sums the BG-01 per-syscall partial-observe counters so the
@@ -691,14 +692,19 @@ func writeTLSSection(b *strings.Builder, in DigestInput) {
 		return
 	}
 	b.WriteString("<details>\n<summary><strong>TLS ClientHello / SNI (recent)</strong></summary>\n\n")
-	b.WriteString("| Time (UTC) | PID | Comm | SNI | Remote | Policy |\n|:--|--:|:-|:-|:-|:-|\n")
+	b.WriteString("| Time (UTC) | PID | Comm | SNI | Remote | Policy | Confidence |\n|:--|--:|:-|:-|:-|:-|:-|\n")
 	if len(in.TLSRows) == 0 {
-		fmt.Fprintf(b, "| — | — | — | — | — | %s |\n", sanitizeCell(protocolEmptyReason(in.TLSDegradedHook, in.TLSReaderErrors)))
+		fmt.Fprintf(b, "| — | — | — | — | — | %s | — |\n", sanitizeCell(protocolEmptyReason(in.TLSDegradedHook, in.TLSReaderErrors)))
 	} else {
 		for _, r := range in.TLSRows {
-			fmt.Fprintf(b, "| %s | `%d` | `%s` | `%s` | %s | %s |\n",
+			conf := string(r.Confidence)
+			if conf == "" {
+				conf = string(telemetry.TLSConfidenceUnknown)
+			}
+			fmt.Fprintf(b, "| %s | `%d` | `%s` | `%s` | %s | %s | `%s` |\n",
 				sanitizeCell(r.TS), r.PID, sanitizeCell(r.Comm),
-				sanitizeCell(r.SNI), sanitizeCell(r.Remote), sanitizeCell(r.Policy))
+				sanitizeCell(r.SNI), sanitizeCell(r.Remote), sanitizeCell(r.Policy),
+				sanitizeCell(conf))
 		}
 	}
 	b.WriteString("\n</details>\n\n")
@@ -787,6 +793,13 @@ func writeKPISemantics(b *strings.Builder, in DigestInput, max int) {
 	b.WriteString("- **HTTP KPI** counts cleartext HTTP/1 request bytes on `sendto` to destination port 80 only; HTTPS traffic appears as TCP connect events.\n")
 	if tlsKPIVisible(in) {
 		b.WriteString("- **tls KPI** counts ClientHello **SNI** parsed from the first cleartext handshake buffer on `write`/`writev`/`pwrite`/`pwritev`/`pwritev2`/`sendto` paths after an IPv4 `connect` when `COLDSTEP_FEATURE_GATES=tls_sni=1` (not decrypted TLS).\n")
+		if in.TLSTotal > 0 {
+			b.WriteString("- **tls SNI confidence** reason codes (rolled up in the KPI and shown per-row in the TLS table):\n")
+			b.WriteString("    - `full` — complete ClientHello parsed in a single syscall buffer; SNI is below the RFC 1035 server-name boundary and not truncated.\n")
+			b.WriteString("    - `partial` — SNI length hit the capture/RFC boundary (`TLSSNIMaxLen=255`); the captured name may be a prefix of the real server name (fragmented or truncated ClientHello).\n")
+			b.WriteString("    - `inferred` — SNI inferred from prior DNS / connect correlation rather than parsed directly. Reserved for a future enricher and not currently emitted by the BPF path.\n")
+			b.WriteString("    - `unknown` — TLS framing detected but no usable SNI signal was captured.\n")
+		}
 	}
 	if procForkKPIVisible(in) {
 		b.WriteString("- **proc_fork** counts `sched_process_fork` events (best-effort parent/child lineage).\n")

--- a/internal/report/digest_test.go
+++ b/internal/report/digest_test.go
@@ -294,6 +294,64 @@ func TestBuildDetectMarkdown_TLSConfidenceRowHiddenWhenNoTLS(t *testing.T) {
 	}
 }
 
+// TestBuildDetectMarkdown_TLSConfidencePerRowAndLegend exercises the
+// per-row Confidence column in the recent-TLS table and the tier-meaning
+// legend that lands in the Technical-details fold. Co-existing tiers must
+// be rendered with their reason code so operators can attribute KPI counts
+// to specific destinations.
+func TestBuildDetectMarkdown_TLSConfidencePerRowAndLegend(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{
+		BPF:                  []telemetry.BPFStatus{{Name: "raw_tp/sys_enter (connect, sendto, http sniff, tls)", OK: true}},
+		TCPTotal:             1,
+		TLSTotal:             3,
+		TLSConfidenceFull:    1,
+		TLSConfidencePartial: 1,
+		TLSConfidenceUnknown: 1,
+		TLSSNIGate:           true,
+		PolicyCounts:         map[string]int{"monitor": 3},
+		TLSRows: []TLSDigestRow{
+			{TS: "t1", PID: 10, Comm: "curl", SNI: "a.example", Remote: "`1.1.1.1:443`", Policy: "monitor", Confidence: telemetry.TLSConfidenceFull},
+			{TS: "t2", PID: 11, Comm: "curl", SNI: strings.Repeat("a", 255), Remote: "`1.1.1.2:443`", Policy: "monitor", Confidence: telemetry.TLSConfidencePartial},
+			{TS: "t3", PID: 12, Comm: "curl", SNI: "", Remote: "`1.1.1.3:443`", Policy: "monitor", Confidence: telemetry.TLSConfidenceUnknown},
+		},
+		JSONLPath:         "/tmp/x.jsonl",
+		SeqFirst:          1,
+		SeqLast:           3,
+		MaxRowsPerSection: 50,
+	})
+	for _, needle := range []string{
+		"| Time (UTC) | PID | Comm | SNI | Remote | Policy | Confidence |",
+		"`full`",
+		"`partial`",
+		"`unknown`",
+		"complete ClientHello parsed in a single syscall buffer",
+		"capture/RFC boundary",
+		"inferred from prior DNS / connect correlation",
+		"TLS framing detected but no usable SNI signal",
+	} {
+		if !strings.Contains(md, needle) {
+			t.Fatalf("missing %q in:\n%s", needle, md)
+		}
+	}
+}
+
+// TestBuildDetectMarkdown_TLSConfidenceEmptyRowDefault verifies that a
+// TLSDigestRow with no Confidence value renders as the reserved "unknown"
+// tier so the column is never blank in the recent-TLS table.
+func TestBuildDetectMarkdown_TLSConfidenceEmptyRowDefault(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{
+		BPF:               []telemetry.BPFStatus{{Name: "raw_tp/sys_enter (connect, sendto, http sniff, tls)", OK: true}},
+		TLSTotal:          1,
+		TLSSNIGate:        true,
+		PolicyCounts:      map[string]int{"monitor": 1},
+		TLSRows:           []TLSDigestRow{{TS: "t", PID: 1, Comm: "x", SNI: "n.example", Remote: "`1.1.1.1:443`", Policy: "monitor"}},
+		MaxRowsPerSection: 50,
+	})
+	if !strings.Contains(md, "`unknown`") {
+		t.Fatalf("expected zero-value confidence to render as `unknown`, got:\n%s", md)
+	}
+}
+
 func TestTruncateExeForDigest(t *testing.T) {
 	long := strings.Repeat("a", execExeDigestMaxBytes+20)
 	out := TruncateExeForDigest(long)

--- a/internal/report/digest_types.go
+++ b/internal/report/digest_types.go
@@ -64,13 +64,19 @@ type HTTPDigestRow struct {
 }
 
 // TLSDigestRow is one TLS ClientHello / SNI line in the markdown digest.
+// Confidence is the per-row tier classification produced by
+// telemetry.ScoreTLSConfidence; it is rendered as its own column so operators
+// can see at a glance whether a specific SNI match should be trusted (full /
+// partial / inferred / unknown). The KPI row above aggregates these tiers,
+// while this column attributes them to specific destinations.
 type TLSDigestRow struct {
-	TS     string
-	PID    uint32
-	Comm   string
-	SNI    string
-	Remote string
-	Policy string
+	TS         string
+	PID        uint32
+	Comm       string
+	SNI        string
+	Remote     string
+	Policy     string
+	Confidence telemetry.TLSConfidence
 }
 
 // FSDigestRow is one filesystem event line in the markdown digest.


### PR DESCRIPTION
## Summary

Additive follow-up to **P1-4** (#163), which introduced `telemetry.TLSConfidence`, `ScoreTLSConfidence`, and the `tls SNI confidence` KPI row. P1-4 surfaced confidence as an aggregate count; this PR makes the per-event reason code **visible per row** and **defined in-place** so operators can attribute KPI numbers to specific destinations and look up what each tier means without leaving the digest.

## What changed

- **Per-row Confidence column** in the recent TLS table (`internal/report/digest.go::writeTLSSection`) — every SNI row now shows its `full` / `partial` / `inferred` / `unknown` reason code next to the policy verdict.
- **Tier-meaning legend** under the existing `tls KPI` bullet in the Technical-details fold — defines all four codes (`full`, `partial`, `inferred`, `unknown`) with their capture semantics, including a reference to the `TLSSNIMaxLen=255` boundary that drives the `full → partial` transition.
- **`TLSDigestRow.Confidence`** field plumbed through the agent's TLS ring reader so each row carries the already-scored confidence into the digest. The row defaults to `unknown` when zero-valued, so the column is never blank.
- **Gating consistent with P1-4**: the legend is only emitted when `TLSTotal > 0` (matching the existing KPI-row gate), so a TLS-gated run with no events stays terse.

## Why this is small

P1-4 already implemented the scoring, the JSONL `Confidence` field, the per-tier counters, and the KPI row. Re-defining those would conflict and add no value. This PR is strictly additive: 4 files, no new types, no new fields on `TLSEvent`, no behavioral change to scoring.

## Test plan

- [x] `go test ./internal/telemetry/... ./internal/report/... -count=1` — passing locally.
- [x] New tests in `digest_test.go`:
  - `TestBuildDetectMarkdown_TLSConfidencePerRowAndLegend` — co-existing tiers render in the Confidence column **and** the legend is emitted.
  - `TestBuildDetectMarkdown_TLSConfidenceEmptyRowDefault` — zero-value `Confidence` falls back to `unknown`.
- [x] `gofmt -l internal/` clean.
- [ ] `coldstep-ci-runner.yml` matrix on PR (gofmt, encoding, unit, unit-arm64, integration, action_bundle, detect-mode, defend-mode).
- [ ] Confirm Job Summary on the `detect-mode` workflow shows the new Confidence column + legend.
