### PR TITLE
docs(digest): document TLS ECH and SNI extraction limits

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -118,6 +118,15 @@ jobs:
 - `report: job-summary` (default): merge the digest into the Job Summary tab. Use `pr-comment`, `both`, or `none` for other surfaces.
 - `fail-on-error: true`: fail the step if agent **operational** readiness cannot be established (BPF/load), not merely on policy noise.
 
+### SNI extraction limits
+
+`tls_sni` parses the **ClientHello SNI** from cleartext bytes on the userspace-syscall write path; TLS is not decrypted. A SNI row may be missing or non-authoritative under these conditions:
+
+- **Fragmented ClientHello** (split across multiple `write(2)` / `writev(2)` calls): **handled** by a bounded `iov[1]` peek on the same `(tgid,fd)` for the supported syscall set. Heavy fragmentation across more than two segments, or fragmentation on a syscall not in the supported set, may still produce no row.
+- **KTLS offload** (kernel TLS, `setsockopt(SOL_TLS, …)`): encryption moves into the kernel after the upgrade; ClientHello bytes are cleartext but may not surface if the application library skips the traced syscall set.
+- **TLS 1.3 Encrypted ClientHello (ECH):** only the **outer** (CDN/proxy) SNI is visible (e.g., `cloudflare-ech.com`); the **real** server name is encrypted and **cannot** be recovered by BPF inspection. Cross-reference DNS HTTPS records or app-level logs for the true destination.
+- **`io_uring` submissions** bypass per-syscall tracepoints. Default **`io-uring-disable: true`** blocks `io_uring_setup(2)` via sysctl and records the attempt; with that hardening off, ClientHello bytes submitted through io_uring will not produce a SNI row.
+
 ---
 
 ## Defend mode (optional)

--- a/README.md
+++ b/README.md
@@ -150,6 +150,15 @@ Enrichment walks indicators present in the report model when **`OTX_API_KEY`** i
 - Prefer **JSONL** over the Summary for forensics; the Summary is **capped** (GitHub limit ~1 MiB per step).
 - **Agent env (advanced):** the Go agent enables **verbose BPF verifier logging** for the large `traceconnect` program only when **`COLDSTEP_BPF_VERBOSE_VERIFY`** is set in the job environment. Leave it unset on GitHub-hosted runners (default) so `LoadTraceconnectObjects` stays fast; set it when debugging verifier rejections locally or in a dedicated job.
 
+### SNI extraction limits
+
+The optional **`tls_sni`** feature parses the **ClientHello SNI** from cleartext bytes on the userspace-syscall write path; it does **not** decrypt TLS. Several real-world conditions can produce a missing or non-authoritative SNI row even when the connection is healthy:
+
+- **Fragmented ClientHello** (TLS record split across multiple `write(2)` / `writev(2)` calls) — **handled** by a bounded `iov[1]` peek on the same `(tgid,fd)` for the supported syscall set (see `bpf/trace_tls_write.inc`). Pathological fragmentation across more than two segments, or fragmentation on a syscall not in the supported set, may still produce no row.
+- **KTLS offload** (kernel TLS, `setsockopt(SOL_TLS, …)`): once a socket is upgraded to KTLS, encryption happens inside the kernel **before** the userspace `write` path the SNI probe observes. The ClientHello itself is still cleartext (it precedes the upgrade), but if the application library hands the kernel a single buffer containing the ClientHello + later records, or skips the traced syscall set, the SNI may not surface.
+- **TLS 1.3 Encrypted ClientHello (ECH):** when ECH is active the **real** server name is encrypted and only the **outer** (CDN/proxy) SNI is visible on the wire — for example, a connection to a private origin behind a Cloudflare ECH endpoint will surface as `cloudflare-ech.com`. This is a deliberate TLS privacy feature and **cannot** be resolved by BPF-level inspection; cross-reference DNS HTTPS resource records or application-level logs for the true destination.
+- **`io_uring` submissions** bypass the per-syscall tracepoints the SNI hook attaches to. With the default **`io-uring-disable: true`**, `io_uring_setup(2)` is blocked by sysctl on the runner and the attempt is recorded in the digest; with that hardening off, ClientHello bytes submitted through io_uring will not produce a SNI row.
+
 ---
 
 ## Supply chain (optional)

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -451,6 +451,9 @@ func writeTechnicalDetails(b *strings.Builder, in DigestInput, max int) {
 	if tlsKPIVisible(in) {
 		b.WriteString("- **tls KPI** counts ClientHello **SNI** parsed from the first cleartext handshake buffer on `write`/`writev`/`pwrite`/`pwritev`/`pwritev2`/`sendto` paths after an IPv4 `connect` when `COLDSTEP_FEATURE_GATES=tls_sni=1` (not decrypted TLS).\n")
 	}
+	if in.TLSTotal > 0 {
+		b.WriteString("\n> **TLS 1.3 Encrypted ClientHello (ECH):** When ECH is active, the real server name is encrypted in transit and only the outer (CDN/proxy) SNI is visible to network-layer observers, including this agent. Connections to ECH-enabled endpoints appear with the outer SNI (e.g., `cloudflare-ech.com`) rather than the true destination. This is a deliberate TLS privacy feature and cannot be resolved by BPF-level inspection. Cross-reference DNS HTTPS records or application-level logs for the true destination.\n\n")
+	}
 	if procForkKPIVisible(in) {
 		b.WriteString("- **proc_fork** counts `sched_process_fork` events (best-effort parent/child lineage).\n")
 	}

--- a/internal/report/digest_test.go
+++ b/internal/report/digest_test.go
@@ -191,6 +191,39 @@ func TestBuildDetectMarkdown_TLSKPIAndSection(t *testing.T) {
 	}
 }
 
+func TestBuildDetectMarkdown_ECHNote_PresentWhenTLSObserved(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{
+		BPF:               []telemetry.BPFStatus{{Name: "raw_tp/sys_enter (connect, tls)", OK: true}},
+		TCPTotal:          1,
+		TLSTotal:          1,
+		TLSSNIGate:        true,
+		MaxRowsPerSection: 50,
+	})
+	for _, needle := range []string{
+		"**TLS 1.3 Encrypted ClientHello (ECH):**",
+		"outer (CDN/proxy) SNI",
+		"cloudflare-ech.com",
+		"DNS HTTPS records",
+	} {
+		if !strings.Contains(md, needle) {
+			t.Fatalf("missing %q in:\n%s", needle, md)
+		}
+	}
+}
+
+func TestBuildDetectMarkdown_ECHNote_AbsentWhenNoTLS(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{
+		BPF:               []telemetry.BPFStatus{{Name: "sched_process_exec", OK: true}},
+		ExecTotal:         1,
+		TCPTotal:          1,
+		TLSTotal:          0,
+		MaxRowsPerSection: 50,
+	})
+	if strings.Contains(md, "Encrypted ClientHello") {
+		t.Fatalf("ECH paragraph should be absent when TLSTotal == 0:\n%s", md)
+	}
+}
+
 func TestTruncateExeForDigest(t *testing.T) {
 	long := strings.Repeat("a", execExeDigestMaxBytes+20)
 	out := TruncateExeForDigest(long)


### PR DESCRIPTION
## Summary

Documents TLS 1.3 Encrypted ClientHello (ECH) as a known SNI extraction limit and surfaces the full set of `tls_sni` caveats in the public docs.

- **`internal/report/digest.go`** — adds an ECH callout to the technical-details fold, gated on `TLSTotal > 0` and placed inside the TLS-related notes block (before the conditional io_uring note). The paragraph explains that only the outer (CDN/proxy) SNI is visible when ECH is active, and points operators at DNS HTTPS records / app logs for the true destination.
- **`README.md`** / **`QUICK_START.md`** — new "SNI extraction limits" subsection under the existing TLS / SNI material covering fragmented ClientHello (handled), KTLS offload, ECH, and io_uring bypass.
- **`internal/report/digest_test.go`** — two new tests: one asserts the ECH paragraph renders when `TLSTotal > 0`, the other asserts it is absent when `TLSTotal == 0`.

## Test plan

- [x] `go test ./internal/report/... -count=1` (passes locally on Windows)
- [x] `gofmt -l internal/report/digest.go internal/report/digest_test.go` (no output)
- [x] `bash scripts/check-encoding.sh` (no mojibake)
- [ ] CI (`coldstep-ci.yml`) green on `docs/p7-ech-limits`
