### PR TITLE
feat(agent): P4 wire KTLS offload detection into TLS SNI confidence

### DIFF
--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -49,6 +49,10 @@ func Run(ctx context.Context, cfg config.Config) error {
 		slog.Warn("runner_compat_warning", "code", w.Code, "detail", w.Detail)
 	}
 	stats := newRunStats()
+	// P4: shared between readKTLSRing (Mark) and readTLSRing (IsKTLS) so a
+	// pre-offload ClientHello sniff is reclassified as Confidence=unknown
+	// with confidence_reason="ktls" before it lands in JSONL.
+	ktlsTr := newKTLSTracker()
 	maxRows := report.DefaultMaxRowsPerSection
 	rows := newRowBuffer(maxRows)
 	sectionState := newNetworkSectionState()
@@ -896,7 +900,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			errCh <- readTLSRing(runCtx, cfg, tlsRd.R, pol, stats, rows, &seq, &jsonlMu, sectionState, signer)
+			errCh <- readTLSRing(runCtx, cfg, tlsRd.R, pol, stats, rows, &seq, &jsonlMu, sectionState, signer, ktlsTr)
 		}()
 	}
 	if denyRd.R != nil {
@@ -931,7 +935,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			errCh <- readKTLSRing(runCtx, cfg, ktlsRd.R, stats, &seq, &jsonlMu, signer)
+			errCh <- readKTLSRing(runCtx, cfg, ktlsRd.R, stats, &seq, &jsonlMu, signer, ktlsTr)
 		}()
 	}
 

--- a/internal/agent/agent_linux_digest.go
+++ b/internal/agent/agent_linux_digest.go
@@ -88,7 +88,7 @@ func buildDigestInput(
 	canarySnap canarySnapshot,
 ) report.DigestInput {
 	execN, tcpN, udpN, httpN, tlsN, fsN := stats.counts()
-	tlsConfFull, tlsConfPartial, tlsConfInferred, tlsConfUnknown := stats.tlsConfidenceCounts()
+	tlsConfFull, tlsConfPartial, tlsConfInferred, tlsConfUnknown, tlsConfUnknownKTLS := stats.tlsConfidenceCounts()
 	rawTPName := "raw_tp/sys_enter (connect, sendto, http sniff, tls)"
 	in := report.DigestInput{
 		DetectProfile:                  cfg.DetectProfile,
@@ -102,6 +102,7 @@ func buildDigestInput(
 		TLSConfidencePartial:           tlsConfPartial,
 		TLSConfidenceInferred:          tlsConfInferred,
 		TLSConfidenceUnknown:           tlsConfUnknown,
+		TLSConfidenceUnknownKTLS:       tlsConfUnknownKTLS,
 		TLSSNIGate:                     tlsSNIGate,
 		PolicyCounts:                   stats.snapshotPolicyCounts(),
 		TCPResultCounts:                stats.snapshotTCPResultCounts(),

--- a/internal/agent/agent_linux_ktls_tracker.go
+++ b/internal/agent/agent_linux_ktls_tracker.go
@@ -1,0 +1,129 @@
+//go:build linux
+
+package agent
+
+import (
+	"sync"
+	"time"
+)
+
+// ktlsTrackerTTL is the window during which a recorded setsockopt(SOL_TLS)
+// offload is treated as still load-bearing for a subsequent TLS event on the
+// same socket. 60 seconds covers the realistic gap between the KTLS handshake
+// (which fires once per connection setup) and the longest run-of-the-mill
+// keepalive/idle gaps within a single CI step.
+const ktlsTrackerTTL = 60 * time.Second
+
+// ktlsKey identifies one offloaded socket within a run. PID is the tgid as
+// emitted by trace_ktls.bpf.c; FD is the userspace file descriptor passed to
+// setsockopt(2). The pair is unique within the lifetime of the process and —
+// for our purposes — within the ktlsTrackerTTL window: even if the fd is
+// later reused for a non-TLS socket, that would race with KTLS teardown and
+// is well outside the time horizon we care about.
+type ktlsKey struct {
+	PID uint32
+	FD  uint32
+}
+
+// ktlsTracker correlates `ktls_offload` events with subsequent `tls`
+// ClientHello events emitted by trace_tls_write.inc. Both events flow through
+// the agent's ringbuf readers (readKTLSRing -> Mark, readTLSRing -> IsKTLS).
+//
+// The tracker exists because once setsockopt(SOL_TLS, TLS_TX|TLS_RX) succeeds
+// the kernel takes over TLS encryption — write(2) buffers carry ciphertext and
+// the userspace SNI sniffer can never resolve a server name on that socket.
+// Any TLS event still produced for that socket (e.g. from a pre-offload write
+// observed before the offload setsockopt) is a misleading "full" or "partial"
+// confidence row. P4 forces those rows to TLSConfidenceUnknown with the
+// confidence_reason "ktls" so operators can tell SNI failures caused by KTLS
+// offload (structural) apart from SNI failures caused by fragmentation (which
+// may be recoverable with reassembly tuning).
+//
+// Implementation notes:
+//
+//   - The TLS event wire format (tls_sniff_event in trace_connect_obs.h) does
+//     not carry fd today. IsKTLS therefore accepts fd==0 as a wildcard match
+//     meaning "any KTLS offload recorded for this pid within the TTL window".
+//     The (pid, fd) primary key remains the canonical record so a future BPF
+//     change that adds fd to tls_sniff_event can switch IsKTLS to the exact
+//     lookup without churning the tracker contract.
+//
+//   - Eviction is amortized into Mark: every insert sweeps entries older than
+//     ktlsTrackerTTL. There is no background goroutine — the tracker lives
+//     as long as a single agent run and the entry count is bounded by the
+//     per-run KTLS setsockopt rate (single-digit to low-thousands).
+type ktlsTracker struct {
+	mu     sync.Mutex
+	now    func() time.Time
+	by     map[ktlsKey]time.Time
+	latest map[uint32]time.Time // pid -> most recent offload time (wildcard path)
+}
+
+// newKTLSTracker constructs a tracker with the wall-clock time source. Tests
+// substitute now via the unexported newKTLSTrackerClock so TTL eviction is
+// deterministic.
+func newKTLSTracker() *ktlsTracker {
+	return newKTLSTrackerClock(time.Now)
+}
+
+func newKTLSTrackerClock(now func() time.Time) *ktlsTracker {
+	return &ktlsTracker{
+		now:    now,
+		by:     make(map[ktlsKey]time.Time),
+		latest: make(map[uint32]time.Time),
+	}
+}
+
+// Mark records that (pid, fd) handed TLS encryption to the kernel at the
+// current clock tick. Subsequent IsKTLS queries within ktlsTrackerTTL will
+// return true for either the exact key or the (pid, 0) wildcard form used by
+// the TLS ring reader. Each call also evicts any expired entries.
+func (t *ktlsTracker) Mark(pid, fd uint32) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	now := t.now()
+	t.evictLocked(now)
+	t.by[ktlsKey{PID: pid, FD: fd}] = now
+	t.latest[pid] = now
+}
+
+// IsKTLS reports whether (pid, fd) has been Marked within ktlsTrackerTTL.
+// When fd==0 the lookup falls back to the per-pid latest offload time — the
+// wildcard path used by the TLS ring reader, whose wire event does not carry
+// fd. Callers pass fd==0 deliberately to opt into that fallback.
+func (t *ktlsTracker) IsKTLS(pid, fd uint32) bool {
+	if t == nil {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	now := t.now()
+	cutoff := now.Add(-ktlsTrackerTTL)
+	if fd != 0 {
+		if ts, ok := t.by[ktlsKey{PID: pid, FD: fd}]; ok && ts.After(cutoff) {
+			return true
+		}
+		return false
+	}
+	if ts, ok := t.latest[pid]; ok && ts.After(cutoff) {
+		return true
+	}
+	return false
+}
+
+func (t *ktlsTracker) evictLocked(now time.Time) {
+	cutoff := now.Add(-ktlsTrackerTTL)
+	for k, ts := range t.by {
+		if !ts.After(cutoff) {
+			delete(t.by, k)
+		}
+	}
+	for pid, ts := range t.latest {
+		if !ts.After(cutoff) {
+			delete(t.latest, pid)
+		}
+	}
+}

--- a/internal/agent/agent_linux_ktls_tracker_test.go
+++ b/internal/agent/agent_linux_ktls_tracker_test.go
@@ -1,0 +1,95 @@
+//go:build linux
+
+package agent
+
+import (
+	"testing"
+	"time"
+
+	"github.com/coldstep-io/coldstep/internal/telemetry"
+)
+
+// TestKTLSTracker_OverridesConfidence covers the P4 happy path: when a
+// ktls_offload event is observed for (pid, fd), the next TLS event on the
+// same socket flows through the same override path and ends up with
+// Confidence=unknown and ConfidenceReason="ktls". The test mirrors the
+// production override sequence in readTLSRing rather than calling into the
+// ring reader directly so it stays isolated from BPF/ringbuf wiring.
+func TestKTLSTracker_OverridesConfidence(t *testing.T) {
+	tr := newKTLSTracker()
+
+	const pid uint32 = 1234
+	const fd uint32 = 7
+
+	tr.Mark(pid, fd)
+
+	if !tr.IsKTLS(pid, fd) {
+		t.Fatalf("IsKTLS(%d, %d) = false right after Mark; want true", pid, fd)
+	}
+	// Wildcard fd path used by the TLS ring reader (tls_sniff_event has no fd
+	// today). The TLS event also has to be flipped to unknown/ktls in that
+	// path, so the wildcard must hit too.
+	if !tr.IsKTLS(pid, 0) {
+		t.Fatalf("IsKTLS(%d, 0) wildcard = false right after Mark; want true", pid)
+	}
+
+	conf := telemetry.ScoreTLSConfidence("example.com")
+	reason := ""
+	if tr.IsKTLS(pid, 0) {
+		conf = telemetry.TLSConfidenceUnknown
+		reason = "ktls"
+	}
+	if conf != telemetry.TLSConfidenceUnknown {
+		t.Fatalf("overridden Confidence = %q; want %q", conf, telemetry.TLSConfidenceUnknown)
+	}
+	if reason != "ktls" {
+		t.Fatalf("overridden ConfidenceReason = %q; want %q", reason, "ktls")
+	}
+}
+
+// TestKTLSTracker_TTLEviction asserts that an offload recorded more than
+// ktlsTrackerTTL ago is not used to override a later TLS event. fd reuse and
+// long-lived runners can re-bind the same (pid, fd) to a non-KTLS socket; the
+// TTL bounds the blast radius of that race.
+func TestKTLSTracker_TTLEviction(t *testing.T) {
+	var now = time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	tr := newKTLSTrackerClock(clock)
+
+	const pid uint32 = 4242
+	const fd uint32 = 11
+
+	tr.Mark(pid, fd)
+	if !tr.IsKTLS(pid, fd) {
+		t.Fatalf("IsKTLS(%d, %d) = false immediately after Mark; want true", pid, fd)
+	}
+
+	// Advance the injected clock past the TTL. Mark on a different pid forces
+	// the amortized eviction sweep so the original entry is provably gone
+	// rather than merely returning false from a one-shot read.
+	now = now.Add(ktlsTrackerTTL + time.Second)
+	tr.Mark(9999, 1)
+
+	if tr.IsKTLS(pid, fd) {
+		t.Fatalf("IsKTLS(%d, %d) = true after %v; want false (entry should be evicted)",
+			pid, fd, ktlsTrackerTTL+time.Second)
+	}
+	if tr.IsKTLS(pid, 0) {
+		t.Fatalf("IsKTLS(%d, 0) wildcard = true after eviction; want false", pid)
+	}
+}
+
+// TestKTLSTracker_WildcardIsolation guards the per-pid wildcard against
+// cross-pid bleed: marking pid=A must not make IsKTLS(pid=B, 0) return true.
+// Without this property the digest would falsely tag unrelated TLS events as
+// KTLS-overridden whenever any process on the runner happened to use kTLS.
+func TestKTLSTracker_WildcardIsolation(t *testing.T) {
+	tr := newKTLSTracker()
+	tr.Mark(100, 3)
+	if !tr.IsKTLS(100, 0) {
+		t.Fatalf("IsKTLS(100, 0) = false after Mark(100, 3); want true")
+	}
+	if tr.IsKTLS(200, 0) {
+		t.Fatalf("IsKTLS(200, 0) = true after Mark(100, 3); want false (cross-pid bleed)")
+	}
+}

--- a/internal/agent/agent_linux_ring_read.go
+++ b/internal/agent/agent_linux_ring_read.go
@@ -381,7 +381,7 @@ func readConnectRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader,
 }
 
 func readTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, pol *policy.Policy,
-	stats *runStats, rows *rowBuffer, seq *telemetry.SeqGen, jsonlMu *sync.Mutex, sectionState *networkSectionState, signer *telemetry.Signer) error {
+	stats *runStats, rows *rowBuffer, seq *telemetry.SeqGen, jsonlMu *sync.Mutex, sectionState *networkSectionState, signer *telemetry.Signer, ktlsTr *ktlsTracker) error {
 	backoff := newRingReadRetryBackoff()
 	reasm := newTLSReassembler()
 	for {
@@ -436,15 +436,29 @@ func readTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, pol
 		sni = telemetry.SanitizeField(sni, 253)
 		cl := pol.Classify(sni, ip)
 		conf := telemetry.ScoreTLSConfidence(sni)
-		stats.addTLS(cl, conf)
+		// P4: if trace_ktls observed setsockopt(SOL_TLS) for this pid within the
+		// tracker TTL, the SNI we just parsed (if any) is a pre-offload artifact —
+		// kernel-TLS will encrypt every subsequent write on the socket and any
+		// "full"/"partial" verdict is misleading. Force unknown with reason="ktls"
+		// before the row lands in the digest or the JSONL. tls_sniff_event has no
+		// fd field today, so we query the tracker with the wildcard form (fd=0)
+		// — see internal/agent/agent_linux_ktls_tracker.go for the contract.
+		confReason := ""
+		if ktlsTr != nil && ktlsTr.IsKTLS(tgid, 0) {
+			slog.Debug("ktls override applied", "pid", tgid, "sni", sni)
+			conf = telemetry.TLSConfidenceUnknown
+			confReason = "ktls"
+		}
+		stats.addTLS(cl, conf, confReason == "ktls")
 
 		ts := time.Now().UTC().Format(time.RFC3339Nano)
 		rows.addTLS(report.TLSDigestRow{
 			TS: ts, PID: tgid, Comm: comm,
-			SNI:        sni,
-			Remote:     fmt.Sprintf("`%s:%d`", ip.String(), port),
-			Policy:     cl.Display(),
-			Confidence: conf,
+			SNI:              sni,
+			Remote:           fmt.Sprintf("`%s:%d`", ip.String(), port),
+			Policy:           cl.Display(),
+			Confidence:       conf,
+			ConfidenceReason: confReason,
 		}, stats)
 
 		if cfg.EventsLogPath != "" {
@@ -458,9 +472,10 @@ func readTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, pol
 				Type: "tls", TS: ts, Seq: n,
 				PID: tgid, TGID: tgid, ThreadID: tid,
 				Comm: comm, SNI: sni,
-				Confidence:     conf,
-				ReassembledSNI: reassembled,
-				Dst:            ip.String(), Dport: port,
+				Confidence:       conf,
+				ConfidenceReason: confReason,
+				ReassembledSNI:   reassembled,
+				Dst:              ip.String(), Dport: port,
 				Policy: string(cl),
 				Note:   note,
 			}
@@ -690,7 +705,7 @@ func readDNSRing(ctx context.Context, rd *ringbuf.Reader, cache *DNSCache, stats
 // observe ciphertext on that fd and cannot resolve SNI. Counted in runStats
 // for the digest KPI; appended to JSONL when EventsLogPath is set.
 func readKTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, stats *runStats,
-	seq *telemetry.SeqGen, jsonlMu *sync.Mutex, signer *telemetry.Signer) error {
+	seq *telemetry.SeqGen, jsonlMu *sync.Mutex, signer *telemetry.Signer, ktlsTr *ktlsTracker) error {
 	backoff := newRingReadRetryBackoff()
 	for {
 		record, err := rd.Read()
@@ -714,6 +729,14 @@ func readKTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, st
 			continue
 		}
 		stats.addKTLS()
+		// P4: record (pid, fd) so any TLS event for the same pid that flows
+		// through readTLSRing within ktlsTrackerTTL gets reclassified to
+		// Confidence=unknown / ConfidenceReason="ktls". Forward-only: a TLS
+		// event that already shipped before this Mark keeps its original
+		// confidence (plan p4-ktls-sni-confidence-integration.md, Non-goals).
+		if ktlsTr != nil {
+			ktlsTr.Mark(tgid, fd)
+		}
 		comm := string(bytes.TrimRight(commb[:], "\x00"))
 		direction := ktlsDirectionLabel(dirByte)
 		ts := time.Now().UTC().Format(time.RFC3339Nano)

--- a/internal/agent/agent_linux_state.go
+++ b/internal/agent/agent_linux_state.go
@@ -28,16 +28,21 @@ import (
 )
 
 type runStats struct {
-	mu                              sync.Mutex
-	execN                           int
-	tcpN                            int
-	udpN                            int
-	httpN                           int
-	tlsN                            int
-	tlsConfidenceFullN              int
-	tlsConfidencePartialN           int
-	tlsConfidenceInferredN          int
-	tlsConfidenceUnknownN           int
+	mu                     sync.Mutex
+	execN                  int
+	tcpN                   int
+	udpN                   int
+	httpN                  int
+	tlsN                   int
+	tlsConfidenceFullN     int
+	tlsConfidencePartialN  int
+	tlsConfidenceInferredN int
+	tlsConfidenceUnknownN  int
+	// tlsConfidenceUnknownKTLSN is the subset of tlsConfidenceUnknownN whose
+	// Confidence was forced from full/partial/unknown to unknown by the P4
+	// KTLS override in readTLSRing. Surfaced in the digest as the
+	// `(N ktls-offloaded)` annotation on the TLS SNI KPI cell.
+	tlsConfidenceUnknownKTLSN       int
 	procForkN                       int
 	fsN                             int
 	ktlsN                           int
@@ -209,7 +214,7 @@ func (s *runStats) addHTTP(cl policy.Class) {
 	s.addPolicyLocked(cl)
 }
 
-func (s *runStats) addTLS(cl policy.Class, conf telemetry.TLSConfidence) {
+func (s *runStats) addTLS(cl policy.Class, conf telemetry.TLSConfidence, ktlsOverride bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.tlsN++
@@ -222,16 +227,21 @@ func (s *runStats) addTLS(cl policy.Class, conf telemetry.TLSConfidence) {
 		s.tlsConfidenceInferredN++
 	default:
 		s.tlsConfidenceUnknownN++
+		if ktlsOverride {
+			s.tlsConfidenceUnknownKTLSN++
+		}
 	}
 	s.addPolicyLocked(cl)
 }
 
 // tlsConfidenceCounts returns per-tier TLS confidence counters (full,
-// partial, inferred, unknown) for digest reporting.
-func (s *runStats) tlsConfidenceCounts() (full, partial, inferred, unknown int) {
+// partial, inferred, unknown) for digest reporting. unknownKTLS is the subset
+// of unknown attributed to the P4 KTLS override; the digest renders it as a
+// sub-bucket inside the unknown count.
+func (s *runStats) tlsConfidenceCounts() (full, partial, inferred, unknown, unknownKTLS int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.tlsConfidenceFullN, s.tlsConfidencePartialN, s.tlsConfidenceInferredN, s.tlsConfidenceUnknownN
+	return s.tlsConfidenceFullN, s.tlsConfidencePartialN, s.tlsConfidenceInferredN, s.tlsConfidenceUnknownN, s.tlsConfidenceUnknownKTLSN
 }
 
 func (s *runStats) setConnect4TupleUpdateFailures(n int) {

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -711,6 +711,13 @@ func writeTLSSection(b *strings.Builder, in DigestInput) {
 			if conf == "" {
 				conf = string(telemetry.TLSConfidenceUnknown)
 			}
+			if r.ConfidenceReason == "ktls" {
+				// P4: keep the machine-readable confidence in backticks but tack on a
+				// human "⚠ ktls" suffix so the per-row cell signals "unknown because
+				// kernel-TLS structurally hides the SNI" rather than "unknown because
+				// parse failed".
+				conf = conf + " ⚠ ktls"
+			}
 			fmt.Fprintf(b, "| %s | `%d` | `%s` | `%s` | %s | %s | `%s` |\n",
 				sanitizeCell(r.TS), r.PID, sanitizeCell(r.Comm),
 				sanitizeCell(r.SNI), sanitizeCell(r.Remote), sanitizeCell(r.Policy),
@@ -809,6 +816,13 @@ func writeKPISemantics(b *strings.Builder, in DigestInput, max int) {
 			b.WriteString("    - `partial` — SNI length hit the capture/RFC boundary (`TLSSNIMaxLen=255`); the captured name may be a prefix of the real server name (fragmented or truncated ClientHello).\n")
 			b.WriteString("    - `inferred` — SNI inferred from prior DNS / connect correlation rather than parsed directly. Reserved for a future enricher and not currently emitted by the BPF path.\n")
 			b.WriteString("    - `unknown` — TLS framing detected but no usable SNI signal was captured.\n")
+			if in.TLSConfidenceUnknownKTLS > 0 {
+				// P4: kernel-TLS offload is a structural reason the SNI sniffer cannot
+				// resolve a server name. Surface it inside the technical-details fold
+				// so operators reading the digest know why the `unknown` bucket grew
+				// and where to cross-reference the affected sockets in the JSONL.
+				fmt.Fprintf(b, "- **KTLS-offloaded sockets** (%d detected): kernel TLS offload was active on these sockets. After `setsockopt(SOL_TLS, TLS_TX/RX)`, write syscalls carry ciphertext; SNI extraction is structurally impossible. These connections appear in the `unknown` confidence bucket. The `ktls_offload` events in the JSONL record the exact socket `(pid, fd)` for cross-reference.\n", in.TLSConfidenceUnknownKTLS)
+			}
 		}
 	}
 	if in.KTLSOffloadTotal > 0 {

--- a/internal/report/digest_aggregation.go
+++ b/internal/report/digest_aggregation.go
@@ -234,7 +234,14 @@ func formatTLSConfidenceCell(in DigestInput) string {
 	if in.TLSConfidenceInferred > 0 {
 		parts = append(parts, fmt.Sprintf("inferred=%d", in.TLSConfidenceInferred))
 	}
-	parts = append(parts, fmt.Sprintf("unknown=%d", in.TLSConfidenceUnknown))
+	unknown := fmt.Sprintf("unknown=%d", in.TLSConfidenceUnknown)
+	if in.TLSConfidenceUnknownKTLS > 0 {
+		// P4: split the unknown bucket so operators see how much of it is
+		// structurally unobservable (kernel-TLS offload) vs failed parse/
+		// reassembly. Renders inline so the KPI cell stays one row.
+		unknown += fmt.Sprintf(" (%d ktls-offloaded)", in.TLSConfidenceUnknownKTLS)
+	}
+	parts = append(parts, unknown)
 	return strings.Join(parts, " · ")
 }
 

--- a/internal/report/digest_test.go
+++ b/internal/report/digest_test.go
@@ -1151,3 +1151,82 @@ func TestBuildDetectMarkdown_DomainContactCounts_HiddenWhenEmpty(t *testing.T) {
 		t.Fatalf("section should be suppressed when empty; got:\n%s", md)
 	}
 }
+
+// TestBuildDetectMarkdown_KTLSBucket exercises the P4 wiring: a TLSDigestRow
+// whose Confidence was forced to unknown by the readTLSRing KTLS override
+// (ConfidenceReason="ktls") must surface in three places in the digest:
+//  1. The TLS SNI KPI cell gets a `(N ktls-offloaded)` annotation inside the
+//     unknown bucket so the headline count splits structural vs parse-failure.
+//  2. The per-row Confidence column reads `unknown ⚠ ktls` instead of plain
+//     `unknown` so operators can attribute the row to kernel-TLS offload.
+//  3. The technical-details fold gains a "KTLS-offloaded sockets" paragraph
+//     that points operators at the `ktls_offload` JSONL events for cross-ref.
+//
+// Gated on TLSConfidenceUnknownKTLS > 0 throughout — the regression that this
+// test catches is silently rolling the override into the plain unknown bucket
+// and losing the structural-vs-parse-failure signal.
+func TestBuildDetectMarkdown_KTLSBucket(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{
+		BPF:                      []telemetry.BPFStatus{{Name: "raw_tp/sys_enter (connect, sendto, http sniff, tls)", OK: true}},
+		TCPTotal:                 1,
+		TLSTotal:                 1,
+		TLSConfidenceFull:        0,
+		TLSConfidencePartial:     0,
+		TLSConfidenceUnknown:     1,
+		TLSConfidenceUnknownKTLS: 1,
+		TLSSNIGate:               true,
+		PolicyCounts:             map[string]int{"monitor": 1},
+		TLSRows: []TLSDigestRow{
+			{
+				TS: "t1", PID: 4242, Comm: "nginx",
+				SNI:              "",
+				Remote:           "`10.0.0.1:443`",
+				Policy:           "monitor",
+				Confidence:       telemetry.TLSConfidenceUnknown,
+				ConfidenceReason: "ktls",
+			},
+		},
+		JSONLPath:         "/tmp/x.jsonl",
+		SeqFirst:          1,
+		SeqLast:           1,
+		MaxRowsPerSection: 50,
+	})
+	for _, needle := range []string{
+		// KPI cell — unknown bucket carries the ktls sub-count.
+		"unknown=1 (1 ktls-offloaded)",
+		// Per-row column — confidence annotated with the ktls reason.
+		"`unknown ⚠ ktls`",
+		// Technical-details paragraph — explains the structural blind spot.
+		"**KTLS-offloaded sockets** (1 detected)",
+		"SNI extraction is structurally impossible",
+		"`ktls_offload` events in the JSONL",
+	} {
+		if !strings.Contains(md, needle) {
+			t.Fatalf("missing %q in digest:\n%s", needle, md)
+		}
+	}
+}
+
+// TestBuildDetectMarkdown_KTLSBucketHiddenWhenZero guards against the digest
+// surfacing the KTLS annotation/paragraph on runs where no TLS event was
+// overridden — the headline KPI cell must read plain `unknown=K` without the
+// trailing `(N ktls-offloaded)` parenthetical and the tech-details paragraph
+// must stay folded out of the markdown.
+func TestBuildDetectMarkdown_KTLSBucketHiddenWhenZero(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{
+		BPF:                      []telemetry.BPFStatus{{Name: "raw_tp/sys_enter (connect, sendto, http sniff, tls)", OK: true}},
+		TLSTotal:                 1,
+		TLSConfidenceFull:        1,
+		TLSConfidenceUnknown:     0,
+		TLSConfidenceUnknownKTLS: 0,
+		TLSSNIGate:               true,
+		PolicyCounts:             map[string]int{"monitor": 1},
+		MaxRowsPerSection:        50,
+	})
+	if strings.Contains(md, "ktls-offloaded)") {
+		t.Fatalf("KPI ktls-offloaded annotation should be hidden when count is zero:\n%s", md)
+	}
+	if strings.Contains(md, "**KTLS-offloaded sockets**") {
+		t.Fatalf("tech-details KTLS paragraph should be hidden when count is zero:\n%s", md)
+	}
+}

--- a/internal/report/digest_types.go
+++ b/internal/report/digest_types.go
@@ -77,6 +77,12 @@ type TLSDigestRow struct {
 	Remote     string
 	Policy     string
 	Confidence telemetry.TLSConfidence
+	// ConfidenceReason qualifies a non-default Confidence verdict. The only
+	// value emitted today is "ktls" (P4): forced to TLSConfidenceUnknown
+	// because trace_ktls observed setsockopt(SOL_TLS) on the socket and
+	// userspace can no longer parse the ClientHello. Mirrors the JSONL field
+	// of the same name on telemetry.TLSEvent.
+	ConfidenceReason string
 }
 
 // FSDigestRow is one filesystem event line in the markdown digest.
@@ -123,7 +129,13 @@ type DigestInput struct {
 	TLSConfidencePartial  int
 	TLSConfidenceInferred int
 	TLSConfidenceUnknown  int
-	PolicyCounts          map[string]int
+	// TLSConfidenceUnknownKTLS is the subset of TLSConfidenceUnknown attributed
+	// to the P4 KTLS override (ConfidenceReason=="ktls"). Surfaced in the KPI
+	// cell as `(N ktls-offloaded)` and in the technical-details paragraph so
+	// operators can separate "unknown because we could not parse it" from
+	// "unknown because kernel-TLS structurally hides the SNI".
+	TLSConfidenceUnknownKTLS int
+	PolicyCounts             map[string]int
 
 	ExecRows  []ExecDigestRow
 	TCPRows   []TCPDigestRow

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -231,6 +231,16 @@ type TLSEvent struct {
 	Comm       string        `json:"comm"`
 	SNI        string        `json:"sni"`
 	Confidence TLSConfidence `json:"confidence,omitempty"`
+	// ConfidenceReason is an open-string tag explaining a non-default
+	// Confidence verdict. Current values:
+	//   - "ktls" — Confidence forced to "unknown" because trace_ktls observed
+	//     setsockopt(SOL_TLS) on this socket; the captured SNI (if any) is a
+	//     pre-offload artifact and the in-kernel TLS encryption blinds the
+	//     userspace ClientHello sniffer for the rest of the connection (P4).
+	//   - "" — Confidence speaks for itself; no extra qualifier required.
+	// Kept as a free-form string (not an enum) so future enrichers can
+	// add their own reasons without churning the event schema.
+	ConfidenceReason string `json:"confidence_reason,omitempty"`
 	// ReassembledSNI is true when the SNI was recovered by stitching multiple
 	// write/writev/sendto syscall buffers together (P3-3 inter-syscall
 	// reassembly) rather than parsed from a single capture. It is independent


### PR DESCRIPTION
## Summary

Wires the P3-1 KTLS offload detection into the P3-4 TLS SNI confidence
column so kernel-TLS sockets stop showing misleading `full`/`partial`
confidence on their pre-offload ClientHello rows. Forward-only fix.

- **New** `ktlsTracker` (`internal/agent/agent_linux_ktls_tracker.go`):
  `sync.Mutex` + `map[ktlsKey]time.Time` with a 60s TTL and amortized
  eviction. `Mark(pid, fd)` and `IsKTLS(pid, fd)`. `fd == 0` is the
  wildcard form used by readTLSRing because `tls_sniff_event` does not
  carry fd today — the (pid, fd) primary key stays intact so a future
  BPF change to add fd to the sniff event can swap in the exact lookup
  without churning the tracker contract.
- **`readKTLSRing` -> Mark / `readTLSRing` -> IsKTLS**: when an offload
  hits within TTL, the TLS row is forced to `TLSConfidenceUnknown` and
  the new `ConfidenceReason="ktls"` tag is set before it reaches the
  digest or the JSONL writer. `runStats.addTLS` gained a
  `ktlsOverride bool` arg so we can split the unknown bucket in the
  KPI cell.
- **JSONL schema**: new `confidence_reason` field on `telemetry.TLSEvent`
  (open string, current values `"ktls"` / `""`). Backwards-compatible —
  the field is `omitempty`, so existing replay tooling keeps working on
  pre-P4 events.
- **Digest** (`internal/report/digest*.go`):
  - KPI cell: `unknown=K (N ktls-offloaded)` annotation inside the
    unknown bucket when the override fired.
  - Per-row Confidence column: renders `unknown ⚠ ktls` rather than
    plain `unknown` so operators can distinguish "unknown because parse
    failed" from "unknown because kernel-TLS structurally hides the SNI".
  - Technical-details fold: gains a `**KTLS-offloaded sockets** (N
    detected)` paragraph pointing operators at the `ktls_offload`
    JSONL events for cross-reference.

### Plan

Implements `plans/p4-ktls-sni-confidence-integration.md` (gitignored,
local). Deviation from the plan: the plan keys the tracker on
`(pid, fd)` but `tls_sniff_event` has no fd on the wire, so the TLS
ring reader queries the tracker with `fd == 0` and falls back to a
per-pid "any offload recorded within TTL?" check. This costs precision
on a process that simultaneously runs a kTLS-offloaded socket and a
plain TLS socket — a deliberately narrow case in practice — and avoids
churning the BPF wire ABI.

### Non-goals (preserved from the plan)

- No retroactive JSONL rewriting. TLS events already on disk before the
  matching KTLS Mark keep their original confidence.
- No KTLS content inspection. Plaintext recovery from kernel-TLS would
  require sock_ops record inspection and is out of scope.

## Test plan

- [ ] `go test ./internal/report/... ./internal/telemetry/...` passes
      locally on Windows.
- [ ] `go test ./internal/agent/... -count=1` passes on hosted Linux
      runner (new `agent_linux_ktls_tracker_test.go` covers TTL eviction
      with an injected clock and per-pid wildcard isolation).
- [ ] `TestBuildDetectMarkdown_KTLSBucket` asserts the KPI annotation,
      per-row badge, and tech-details paragraph render together when
      `TLSConfidenceUnknownKTLS > 0`; `_HiddenWhenZero` keeps them out
      of the markdown otherwise.
- [ ] CI defend-mode + integration matrix exercise the live ring reader
      wiring on real BPF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
