### PR TITLE
fix: P3 bug audit — 5 fixes + 2 test gaps

### DIFF
--- a/bpf/trace_ktls.bpf.c
+++ b/bpf/trace_ktls.bpf.c
@@ -45,7 +45,16 @@ _Static_assert(sizeof(struct ktls_event) == 32,
 
 struct {
 	__uint(type, BPF_MAP_TYPE_RINGBUF);
-	__uint(max_entries, 1 << 12); /* 4 KiB — KTLS calls are rare per run */
+	/*
+	 * 64 KiB. Earlier sizing (4 KiB) assumed KTLS setsockopt is rare per
+	 * run, but a single Go binary using crypto/tls + KTLS handshakes
+	 * during dependency fetch can burst dozens of offload events in the
+	 * first second — the ringbuf reserve-failure counter then climbed
+	 * before the userspace reader drained it. 64 KiB gives the reader
+	 * room to absorb that burst without dropping events on the floor
+	 * (P3-bug-audit Bug 4).
+	 */
+	__uint(max_entries, 1 << 16);
 } ktls_events SEC(".maps");
 
 struct {

--- a/bpf/trace_tcp_connect_kprobe.inc
+++ b/bpf/trace_tcp_connect_kprobe.inc
@@ -10,13 +10,17 @@
  * connect_events ringbuf, correlated by pid_tgid.
  *
  * tcp_v4_connect runs synchronously in the caller's task context (no
- * scheduling between entry and return on the IPv4 TCP path), so a HASH
- * map keyed by bpf_get_current_pid_tgid() is a sufficient correlation
- * primitive — no cross-CPU concerns. The map bounds the in-flight set at
- * 4096 entries; in practice the kernel rarely has more than a few
- * concurrent tcp_v4_connect invocations per CPU. If userspace blows past
- * the bound we silently drop the result event — the entry connect_event
- * is still recorded, just without a paired result.
+ * scheduling between entry and return on the IPv4 TCP path), so an
+ * LRU_HASH map keyed by bpf_get_current_pid_tgid() is a sufficient
+ * correlation primitive — no cross-CPU concerns. The map bounds the
+ * in-flight set at 4096 entries; in practice the kernel rarely has more
+ * than a few concurrent tcp_v4_connect invocations per CPU. LRU_HASH (vs
+ * plain HASH) is chosen so that orphaned entries from dropped or missed
+ * kretprobes (e.g. when an attach point is bypassed by a fault path) are
+ * automatically evicted by the kernel rather than filling the table and
+ * silently blocking every subsequent BPF_NOEXIST insert. If userspace
+ * blows past the bound we silently drop the result event — the entry
+ * connect_event is still recorded, just without a paired result.
  *
  * Wire compatibility: connect_result_event reuses the connect_events
  * ringbuf (already drained by readConnectRing) but is distinguished from
@@ -41,7 +45,7 @@ _Static_assert(sizeof(struct connect_result_event) == 32,
 	       "connect_result_event wire size must match connectResultEventWireSize=32 in agent_linux.go");
 
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__uint(max_entries, 4096);
 	__type(key, __u64);
 	__type(value, __u8);

--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -817,17 +817,31 @@ func Run(ctx context.Context, cfg config.Config) error {
 	var wg sync.WaitGroup
 	errCh := make(chan error, readerCount)
 
+	// sendReaderErr cancels runCtx whenever a reader returns a fatal error
+	// (anything other than context.Canceled). Without this, an isolated
+	// reader failure left the canary and heartbeat goroutines blocked on
+	// runCtx.Done forever — wg.Wait() then hung the whole agent (P3-bug-audit
+	// Bug 5). The cancel propagates to every peer goroutine and lets the
+	// outer wg.Wait return promptly so the deferred digest/telemetry writers
+	// can run.
+	sendReaderErr := func(err error) {
+		if err != nil && !errors.Is(err, context.Canceled) {
+			runCancel()
+		}
+		errCh <- err
+	}
+
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		errCh <- readExecRing(runCtx, cfg, execRd.R, stats, rows, &seq, &jsonlMu, signer)
+		sendReaderErr(readExecRing(runCtx, cfg, execRd.R, stats, rows, &seq, &jsonlMu, signer))
 	}()
 
 	if forkRd.R != nil && forkBuf != nil && forkState != nil {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			errCh <- readForkRing(runCtx, cfg, forkRd.R, stats, forkBuf, forkState, &seq, &jsonlMu, signer)
+			sendReaderErr(readForkRing(runCtx, cfg, forkRd.R, stats, forkBuf, forkState, &seq, &jsonlMu, signer))
 		}()
 	}
 
@@ -835,7 +849,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			errCh <- readFSRing(runCtx, cfg, fsRd.R, stats, fsRowBuf, fsSt, &seq, &jsonlMu, signer)
+			sendReaderErr(readFSRing(runCtx, cfg, fsRd.R, stats, fsRowBuf, fsSt, &seq, &jsonlMu, signer))
 		}()
 	}
 
@@ -843,7 +857,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			errCh <- readConnectRing(runCtx, cfg, connRd.R, dnsCache, pol, stats, rows, &seq, &jsonlMu, sectionState, canary, signer)
+			sendReaderErr(readConnectRing(runCtx, cfg, connRd.R, dnsCache, pol, stats, rows, &seq, &jsonlMu, sectionState, canary, signer))
 		}()
 	}
 
@@ -922,63 +936,63 @@ func Run(ctx context.Context, cfg config.Config) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			errCh <- readUDPRing(runCtx, cfg, udpRd.R, dnsCache, pol, stats, rows, &seq, &jsonlMu, sectionState, signer)
+			sendReaderErr(readUDPRing(runCtx, cfg, udpRd.R, dnsCache, pol, stats, rows, &seq, &jsonlMu, sectionState, signer))
 		}()
 	}
 	if httpRd.R != nil {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			errCh <- readHTTPRing(runCtx, cfg, httpRd.R, pol, stats, rows, &seq, &jsonlMu, sectionState, signer)
+			sendReaderErr(readHTTPRing(runCtx, cfg, httpRd.R, pol, stats, rows, &seq, &jsonlMu, sectionState, signer))
 		}()
 	}
 	if tlsRd.R != nil {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			errCh <- readTLSRing(runCtx, cfg, tlsRd.R, pol, stats, rows, &seq, &jsonlMu, sectionState, signer, ktlsTr)
+			sendReaderErr(readTLSRing(runCtx, cfg, tlsRd.R, pol, stats, rows, &seq, &jsonlMu, sectionState, signer, ktlsTr))
 		}()
 	}
 	if tcpStateRd.R != nil {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			errCh <- readTCPStateRing(runCtx, cfg, tcpStateRd.R, stats, &seq, &jsonlMu, signer)
+			sendReaderErr(readTCPStateRing(runCtx, cfg, tcpStateRd.R, stats, &seq, &jsonlMu, signer))
 		}()
 	}
 	if denyRd.R != nil {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			errCh <- readDenyRing(runCtx, cfg, denyRd.R, &seq, &jsonlMu, defendState, signer, "cgroup", dnsCache)
+			sendReaderErr(readDenyRing(runCtx, cfg, denyRd.R, &seq, &jsonlMu, defendState, signer, "cgroup", dnsCache))
 		}()
 	}
 	if lsmDenyRd.R != nil {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			errCh <- readDenyRing(runCtx, cfg, lsmDenyRd.R, &seq, &jsonlMu, defendState, signer, "lsm", dnsCache)
+			sendReaderErr(readDenyRing(runCtx, cfg, lsmDenyRd.R, &seq, &jsonlMu, defendState, signer, "lsm", dnsCache))
 		}()
 	}
 	if dnsRd.R != nil {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			errCh <- readDNSRing(runCtx, dnsRd.R, dnsCache, stats)
+			sendReaderErr(readDNSRing(runCtx, dnsRd.R, dnsCache, stats))
 		}()
 	}
 	if bpfAuditRd.R != nil {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			errCh <- readBPFAuditRing(runCtx, cfg, bpfAuditRd.R, stats, &seq, &jsonlMu, signer)
+			sendReaderErr(readBPFAuditRing(runCtx, cfg, bpfAuditRd.R, stats, &seq, &jsonlMu, signer))
 		}()
 	}
 	if ktlsRd.R != nil {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			errCh <- readKTLSRing(runCtx, cfg, ktlsRd.R, stats, &seq, &jsonlMu, signer, ktlsTr)
+			sendReaderErr(readKTLSRing(runCtx, cfg, ktlsRd.R, stats, &seq, &jsonlMu, signer, ktlsTr))
 		}()
 	}
 
@@ -986,14 +1000,14 @@ func Run(ctx context.Context, cfg config.Config) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			errCh <- watchMapIntegrity(runCtx, cfg, defendObjs.DefendCfg, defendObjs.AllowedIpv4, defendObjs.IgnoredIpv4Lpm, defendCompiled, pol, stats, defendState, &seq, &jsonlMu, signer)
+			sendReaderErr(watchMapIntegrity(runCtx, cfg, defendObjs.DefendCfg, defendObjs.AllowedIpv4, defendObjs.IgnoredIpv4Lpm, defendCompiled, pol, stats, defendState, &seq, &jsonlMu, signer))
 		}()
 	}
 	if hasLSM {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			errCh <- watchMapIntegrity(runCtx, cfg, defendObjs.LsmDefendCfg, defendObjs.LsmAllowedIpv4, defendObjs.LsmIgnoredIpv4Lpm, defendCompiled, pol, stats, defendState, &seq, &jsonlMu, signer)
+			sendReaderErr(watchMapIntegrity(runCtx, cfg, defendObjs.LsmDefendCfg, defendObjs.LsmAllowedIpv4, defendObjs.LsmIgnoredIpv4Lpm, defendCompiled, pol, stats, defendState, &seq, &jsonlMu, signer))
 		}()
 	}
 

--- a/internal/agent/agent_linux_ktls_tracker.go
+++ b/internal/agent/agent_linux_ktls_tracker.go
@@ -25,6 +25,17 @@ type ktlsKey struct {
 	FD  uint32
 }
 
+// ktlsEntry records a single Mark: the wall-clock time used for TTL eviction
+// and the monotonic-ish markedAt timestamp (nanoseconds, captured at ringbuf
+// arrival in userspace) used to gate IsKTLS by ordering. The two clocks are
+// separate because the TTL evictor was already wall-clock-driven and tests
+// inject the clock, while the ordering gate is fundamentally about comparing
+// event arrival times within a single agent process.
+type ktlsEntry struct {
+	at       time.Time // wall-clock for TTL eviction
+	markedAt int64     // userspace arrival time of the KTLS event, in ns
+}
+
 // ktlsTracker correlates `ktls_offload` events with subsequent `tls`
 // ClientHello events emitted by trace_tls_write.inc. Both events flow through
 // the agent's ringbuf readers (readKTLSRing -> Mark, readTLSRing -> IsKTLS).
@@ -48,6 +59,18 @@ type ktlsKey struct {
 //     change that adds fd to tls_sniff_event can switch IsKTLS to the exact
 //     lookup without churning the tracker contract.
 //
+//   - The wildcard path is further gated by the TLS event's arrival timestamp:
+//     IsKTLS only returns true when tlsTimestampNs >= markedAt. A TLS event
+//     that landed in userspace before the KTLS Mark cannot have been encrypted
+//     by the offload that hadn't yet been observed, so its original SNI
+//     confidence is preserved. Without this ordering check, a single KTLS
+//     event would clobber every TLS event from the same pid for the entire
+//     TTL window — including pre-offload writes that legitimately carried
+//     plaintext ClientHello bytes. The timestamps are userspace ringbuf
+//     arrival times rather than kernel bpf_ktime_get_ns() because neither
+//     wire event currently ships a kernel timestamp; arrival-order matches
+//     emit-order in all but pathological ringbuf-drain stalls.
+//
 //   - Eviction is amortized into Mark: every insert sweeps entries older than
 //     ktlsTrackerTTL. There is no background goroutine — the tracker lives
 //     as long as a single agent run and the entry count is bounded by the
@@ -55,8 +78,8 @@ type ktlsKey struct {
 type ktlsTracker struct {
 	mu     sync.Mutex
 	now    func() time.Time
-	by     map[ktlsKey]time.Time
-	latest map[uint32]time.Time // pid -> most recent offload time (wildcard path)
+	by     map[ktlsKey]ktlsEntry
+	latest map[uint32]ktlsEntry // pid -> most recent offload (wildcard path)
 }
 
 // newKTLSTracker constructs a tracker with the wall-clock time source. Tests
@@ -69,16 +92,18 @@ func newKTLSTracker() *ktlsTracker {
 func newKTLSTrackerClock(now func() time.Time) *ktlsTracker {
 	return &ktlsTracker{
 		now:    now,
-		by:     make(map[ktlsKey]time.Time),
-		latest: make(map[uint32]time.Time),
+		by:     make(map[ktlsKey]ktlsEntry),
+		latest: make(map[uint32]ktlsEntry),
 	}
 }
 
-// Mark records that (pid, fd) handed TLS encryption to the kernel at the
-// current clock tick. Subsequent IsKTLS queries within ktlsTrackerTTL will
-// return true for either the exact key or the (pid, 0) wildcard form used by
-// the TLS ring reader. Each call also evicts any expired entries.
-func (t *ktlsTracker) Mark(pid, fd uint32) {
+// Mark records that (pid, fd) handed TLS encryption to the kernel at
+// markedAtNs (the TLS-offload event's userspace ringbuf arrival time in
+// nanoseconds). Subsequent IsKTLS queries within ktlsTrackerTTL whose own
+// tlsTimestampNs >= markedAtNs will return true; queries from events that
+// arrived before markedAtNs will not. Each call also evicts any expired
+// entries against the wall clock.
+func (t *ktlsTracker) Mark(pid, fd uint32, markedAtNs int64) {
 	if t == nil {
 		return
 	}
@@ -86,15 +111,20 @@ func (t *ktlsTracker) Mark(pid, fd uint32) {
 	defer t.mu.Unlock()
 	now := t.now()
 	t.evictLocked(now)
-	t.by[ktlsKey{PID: pid, FD: fd}] = now
-	t.latest[pid] = now
+	entry := ktlsEntry{at: now, markedAt: markedAtNs}
+	t.by[ktlsKey{PID: pid, FD: fd}] = entry
+	t.latest[pid] = entry
 }
 
-// IsKTLS reports whether (pid, fd) has been Marked within ktlsTrackerTTL.
-// When fd==0 the lookup falls back to the per-pid latest offload time — the
-// wildcard path used by the TLS ring reader, whose wire event does not carry
-// fd. Callers pass fd==0 deliberately to opt into that fallback.
-func (t *ktlsTracker) IsKTLS(pid, fd uint32) bool {
+// IsKTLS reports whether (pid, fd) has been Marked within ktlsTrackerTTL AND
+// tlsTimestampNs (the TLS event's userspace arrival time in nanoseconds) is at
+// or after the recorded markedAt. When fd==0 the lookup falls back to the
+// per-pid latest offload — the wildcard path used by the TLS ring reader,
+// whose wire event does not carry fd. Callers pass fd==0 deliberately to opt
+// into that fallback. A tlsTimestampNs that precedes the Mark always returns
+// false: the TLS event was observed before the offload and therefore cannot
+// have been clobbered by it.
+func (t *ktlsTracker) IsKTLS(pid, fd uint32, tlsTimestampNs int64) bool {
 	if t == nil {
 		return false
 	}
@@ -103,26 +133,26 @@ func (t *ktlsTracker) IsKTLS(pid, fd uint32) bool {
 	now := t.now()
 	cutoff := now.Add(-ktlsTrackerTTL)
 	if fd != 0 {
-		if ts, ok := t.by[ktlsKey{PID: pid, FD: fd}]; ok && ts.After(cutoff) {
-			return true
+		if e, ok := t.by[ktlsKey{PID: pid, FD: fd}]; ok && e.at.After(cutoff) {
+			return tlsTimestampNs >= e.markedAt
 		}
 		return false
 	}
-	if ts, ok := t.latest[pid]; ok && ts.After(cutoff) {
-		return true
+	if e, ok := t.latest[pid]; ok && e.at.After(cutoff) {
+		return tlsTimestampNs >= e.markedAt
 	}
 	return false
 }
 
 func (t *ktlsTracker) evictLocked(now time.Time) {
 	cutoff := now.Add(-ktlsTrackerTTL)
-	for k, ts := range t.by {
-		if !ts.After(cutoff) {
+	for k, e := range t.by {
+		if !e.at.After(cutoff) {
 			delete(t.by, k)
 		}
 	}
-	for pid, ts := range t.latest {
-		if !ts.After(cutoff) {
+	for pid, e := range t.latest {
+		if !e.at.After(cutoff) {
 			delete(t.latest, pid)
 		}
 	}

--- a/internal/agent/agent_linux_ktls_tracker_test.go
+++ b/internal/agent/agent_linux_ktls_tracker_test.go
@@ -20,22 +20,24 @@ func TestKTLSTracker_OverridesConfidence(t *testing.T) {
 
 	const pid uint32 = 1234
 	const fd uint32 = 7
+	const markedAtNs int64 = 1_000_000_000
+	const tlsAfterNs int64 = 1_500_000_000 // TLS event after the Mark
 
-	tr.Mark(pid, fd)
+	tr.Mark(pid, fd, markedAtNs)
 
-	if !tr.IsKTLS(pid, fd) {
-		t.Fatalf("IsKTLS(%d, %d) = false right after Mark; want true", pid, fd)
+	if !tr.IsKTLS(pid, fd, tlsAfterNs) {
+		t.Fatalf("IsKTLS(%d, %d, %d) = false right after Mark; want true", pid, fd, tlsAfterNs)
 	}
 	// Wildcard fd path used by the TLS ring reader (tls_sniff_event has no fd
 	// today). The TLS event also has to be flipped to unknown/ktls in that
 	// path, so the wildcard must hit too.
-	if !tr.IsKTLS(pid, 0) {
-		t.Fatalf("IsKTLS(%d, 0) wildcard = false right after Mark; want true", pid)
+	if !tr.IsKTLS(pid, 0, tlsAfterNs) {
+		t.Fatalf("IsKTLS(%d, 0, %d) wildcard = false right after Mark; want true", pid, tlsAfterNs)
 	}
 
 	conf := telemetry.ScoreTLSConfidence("example.com")
 	reason := ""
-	if tr.IsKTLS(pid, 0) {
+	if tr.IsKTLS(pid, 0, tlsAfterNs) {
 		conf = telemetry.TLSConfidenceUnknown
 		reason = "ktls"
 	}
@@ -44,6 +46,44 @@ func TestKTLSTracker_OverridesConfidence(t *testing.T) {
 	}
 	if reason != "ktls" {
 		t.Fatalf("overridden ConfidenceReason = %q; want %q", reason, "ktls")
+	}
+}
+
+// TestKTLSTracker_PreOffloadTLSPreserved guards the timestamp gate: a TLS
+// event whose userspace arrival timestamp predates the KTLS Mark must NOT be
+// reclassified, even when it falls inside the per-pid wildcard window. The
+// failure mode this prevents is "wildcard fd=0 clobbers every TLS event for
+// the next 60s including ones that arrived before the offload was observed".
+func TestKTLSTracker_PreOffloadTLSPreserved(t *testing.T) {
+	tr := newKTLSTracker()
+
+	const pid uint32 = 4321
+	const fd uint32 = 11
+	const tlsBeforeNs int64 = 500_000_000 // pre-offload TLS event
+	const markedAtNs int64 = 1_000_000_000
+	const tlsAfterNs int64 = 1_500_000_000
+
+	tr.Mark(pid, fd, markedAtNs)
+
+	// Pre-offload TLS event: must stay un-overridden via the wildcard path.
+	if tr.IsKTLS(pid, 0, tlsBeforeNs) {
+		t.Fatalf("IsKTLS(%d, 0, %d) wildcard = true for tlsTimestampNs < markedAt; "+
+			"want false (pre-offload TLS event must keep its original confidence)",
+			pid, tlsBeforeNs)
+	}
+	// Exact-fd lookup must enforce the same ordering rule.
+	if tr.IsKTLS(pid, fd, tlsBeforeNs) {
+		t.Fatalf("IsKTLS(%d, %d, %d) exact = true for tlsTimestampNs < markedAt; "+
+			"want false", pid, fd, tlsBeforeNs)
+	}
+	// Sanity: a TLS event AFTER the Mark is still flipped on both paths.
+	if !tr.IsKTLS(pid, 0, tlsAfterNs) {
+		t.Fatalf("IsKTLS(%d, 0, %d) wildcard = false for tlsTimestampNs >= markedAt; want true",
+			pid, tlsAfterNs)
+	}
+	if !tr.IsKTLS(pid, fd, tlsAfterNs) {
+		t.Fatalf("IsKTLS(%d, %d, %d) exact = false for tlsTimestampNs >= markedAt; want true",
+			pid, fd, tlsAfterNs)
 	}
 }
 
@@ -58,24 +98,28 @@ func TestKTLSTracker_TTLEviction(t *testing.T) {
 
 	const pid uint32 = 4242
 	const fd uint32 = 11
+	const markedAtNs int64 = 1_000_000_000
+	const tlsAfterNs int64 = 2_000_000_000
 
-	tr.Mark(pid, fd)
-	if !tr.IsKTLS(pid, fd) {
-		t.Fatalf("IsKTLS(%d, %d) = false immediately after Mark; want true", pid, fd)
+	tr.Mark(pid, fd, markedAtNs)
+	if !tr.IsKTLS(pid, fd, tlsAfterNs) {
+		t.Fatalf("IsKTLS(%d, %d, %d) = false immediately after Mark; want true",
+			pid, fd, tlsAfterNs)
 	}
 
 	// Advance the injected clock past the TTL. Mark on a different pid forces
 	// the amortized eviction sweep so the original entry is provably gone
 	// rather than merely returning false from a one-shot read.
 	now = now.Add(ktlsTrackerTTL + time.Second)
-	tr.Mark(9999, 1)
+	tr.Mark(9999, 1, 10_000_000_000)
 
-	if tr.IsKTLS(pid, fd) {
-		t.Fatalf("IsKTLS(%d, %d) = true after %v; want false (entry should be evicted)",
-			pid, fd, ktlsTrackerTTL+time.Second)
+	if tr.IsKTLS(pid, fd, tlsAfterNs) {
+		t.Fatalf("IsKTLS(%d, %d, %d) = true after %v; want false (entry should be evicted)",
+			pid, fd, tlsAfterNs, ktlsTrackerTTL+time.Second)
 	}
-	if tr.IsKTLS(pid, 0) {
-		t.Fatalf("IsKTLS(%d, 0) wildcard = true after eviction; want false", pid)
+	if tr.IsKTLS(pid, 0, tlsAfterNs) {
+		t.Fatalf("IsKTLS(%d, 0, %d) wildcard = true after eviction; want false",
+			pid, tlsAfterNs)
 	}
 }
 
@@ -85,11 +129,15 @@ func TestKTLSTracker_TTLEviction(t *testing.T) {
 // KTLS-overridden whenever any process on the runner happened to use kTLS.
 func TestKTLSTracker_WildcardIsolation(t *testing.T) {
 	tr := newKTLSTracker()
-	tr.Mark(100, 3)
-	if !tr.IsKTLS(100, 0) {
-		t.Fatalf("IsKTLS(100, 0) = false after Mark(100, 3); want true")
+	const markedAtNs int64 = 1_000_000_000
+	const tlsAfterNs int64 = 2_000_000_000
+
+	tr.Mark(100, 3, markedAtNs)
+	if !tr.IsKTLS(100, 0, tlsAfterNs) {
+		t.Fatalf("IsKTLS(100, 0, %d) = false after Mark(100, 3); want true", tlsAfterNs)
 	}
-	if tr.IsKTLS(200, 0) {
-		t.Fatalf("IsKTLS(200, 0) = true after Mark(100, 3); want false (cross-pid bleed)")
+	if tr.IsKTLS(200, 0, tlsAfterNs) {
+		t.Fatalf("IsKTLS(200, 0, %d) = true after Mark(100, 3); want false (cross-pid bleed)",
+			tlsAfterNs)
 	}
 }

--- a/internal/agent/agent_linux_ring_read.go
+++ b/internal/agent/agent_linux_ring_read.go
@@ -154,6 +154,41 @@ func nullTermStr(b []byte) string {
 	return string(bytes.TrimRight(b, "\x00"))
 }
 
+// connectRingRecordKind classifies one connect_events ringbuf record by its
+// 4-byte magic at offset 0. The connect_events ringbuf is multiplexed: the
+// entry-side connect(2) tracepoint, the P3-2 kretprobe on tcp_v4_connect, and
+// the telemetry-integrity canary all share it. Real connect_event records
+// begin with __u32 tgid which is bounded by PID_MAX_LIMIT (4194304), so the
+// 0xCA1A1210 and 0xC0EE0001 magics cannot collide with a real tgid.
+type connectRingRecordKind int
+
+const (
+	// connectRingKindConnectEvent is the default — an entry-side connect(2)
+	// event (struct connect_event). Records shorter than 4 bytes also route
+	// here so the downstream decoder can reject them as too-short.
+	connectRingKindConnectEvent connectRingRecordKind = iota
+	connectRingKindCanary
+	connectRingKindConnectResult
+)
+
+// classifyConnectRingRecord is the pure-Go magic-prefix dispatcher used by
+// readConnectRing. It exists as a free function so the routing logic is
+// table-testable independent of *ringbuf.Reader (which requires a live BPF
+// program to feed records).
+func classifyConnectRingRecord(raw []byte) connectRingRecordKind {
+	if len(raw) < 4 {
+		return connectRingKindConnectEvent
+	}
+	switch binary.LittleEndian.Uint32(raw[0:4]) {
+	case canaryMagic:
+		return connectRingKindCanary
+	case connectResultMagic:
+		return connectRingKindConnectResult
+	default:
+		return connectRingKindConnectEvent
+	}
+}
+
 // fsOpName maps BPF op byte to JSONL op string.
 func fsOpName(op uint8) string {
 	switch op {
@@ -276,47 +311,44 @@ func readConnectRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader,
 		//   else                              → connect_event (entry-side connect(2))
 		// Real connect_event records begin with __u32 tgid (bounded by
 		// PID_MAX_LIMIT), so neither magic can collide with a real tgid.
-		if len(record.RawSample) >= 4 {
-			magic := binary.LittleEndian.Uint32(record.RawSample[0:4])
-			switch magic {
-			case canaryMagic:
-				if len(record.RawSample) >= canaryEventWireSize {
-					seqNr := binary.LittleEndian.Uint64(record.RawSample[8:16])
-					if canary != nil {
-						canary.noteReceived(seqNr)
-					}
-					slog.Debug("canary received", "seq", seqNr)
+		switch classifyConnectRingRecord(record.RawSample) {
+		case connectRingKindCanary:
+			if len(record.RawSample) >= canaryEventWireSize {
+				seqNr := binary.LittleEndian.Uint64(record.RawSample[8:16])
+				if canary != nil {
+					canary.noteReceived(seqNr)
 				}
-				continue
-			case connectResultMagic:
-				rtgid, rtid, rcommb, rresult, rok := decodeConnectResultEvent(record.RawSample)
-				if !rok {
-					stats.addDropped("tcp_result_decode")
-					slog.Warn("decode tcp_result", "len", len(record.RawSample))
-					continue
-				}
-				rcomm := string(bytes.TrimRight(rcommb[:], "\x00"))
-				bucket := telemetry.ConnectResultString(rresult)
-				stats.addTCPResult(bucket)
-				ts := time.Now().UTC().Format(time.RFC3339Nano)
-				if cfg.EventsLogPath != "" {
-					jsonlMu.Lock()
-					n := seq.Next()
-					ev := telemetry.TCPResultEvent{
-						Type: "tcp_result", TS: ts, Seq: n,
-						PID: rtgid, TGID: rtgid, ThreadID: rtid,
-						Comm: rcomm, Result: rresult, ResultStr: bucket,
-					}
-					werr := telemetry.AppendJSONL(cfg.EventsLogPath, ev, signer)
-					jsonlMu.Unlock()
-					if werr != nil {
-						stats.addDropped("tcp_result_jsonl")
-						slog.Warn("events jsonl (tcp_result)", "err", werr)
-					}
-				}
-				slog.Debug("tcp_result", "tgid", rtgid, "tid", rtid, "comm", rcomm, "result", rresult, "bucket", bucket)
+				slog.Debug("canary received", "seq", seqNr)
+			}
+			continue
+		case connectRingKindConnectResult:
+			rtgid, rtid, rcommb, rresult, rok := decodeConnectResultEvent(record.RawSample)
+			if !rok {
+				stats.addDropped("tcp_result_decode")
+				slog.Warn("decode tcp_result", "len", len(record.RawSample))
 				continue
 			}
+			rcomm := telemetry.SanitizeField(nullTermStr(rcommb[:]), 16)
+			bucket := telemetry.ConnectResultString(rresult)
+			stats.addTCPResult(bucket)
+			ts := time.Now().UTC().Format(time.RFC3339Nano)
+			if cfg.EventsLogPath != "" {
+				jsonlMu.Lock()
+				n := seq.Next()
+				ev := telemetry.TCPResultEvent{
+					Type: "tcp_result", TS: ts, Seq: n,
+					PID: rtgid, TGID: rtgid, ThreadID: rtid,
+					Comm: rcomm, Result: rresult, ResultStr: bucket,
+				}
+				werr := telemetry.AppendJSONL(cfg.EventsLogPath, ev, signer)
+				jsonlMu.Unlock()
+				if werr != nil {
+					stats.addDropped("tcp_result_jsonl")
+					slog.Warn("events jsonl (tcp_result)", "err", werr)
+				}
+			}
+			slog.Debug("tcp_result", "tgid", rtgid, "tid", rtid, "comm", rcomm, "result", rresult, "bucket", bucket)
+			continue
 		}
 
 		tgid, tid, commb, daddr, port, decOK := decodeConnectEvent(record.RawSample)
@@ -402,6 +434,13 @@ func readTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, pol
 		}
 		backoff.reset()
 
+		// Capture the userspace ringbuf arrival time as close to rd.Read() as
+		// possible. Threaded into ktlsTr.IsKTLS so that a KTLS Mark observed
+		// later does not retroactively clobber THIS TLS event's confidence —
+		// only TLS events whose arrival time is >= the Mark's markedAt are
+		// flipped to unknown/ktls (Bug-1 fix).
+		tlsRecvAtNs := time.Now().UnixNano()
+
 		tgid, tid, commb, daddr, port, rawPay, ok := decodeTLSSniffEvent(record.RawSample)
 		if !ok {
 			if sectionState != nil {
@@ -437,14 +476,16 @@ func readTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, pol
 		cl := pol.Classify(sni, ip)
 		conf := telemetry.ScoreTLSConfidence(sni)
 		// P4: if trace_ktls observed setsockopt(SOL_TLS) for this pid within the
-		// tracker TTL, the SNI we just parsed (if any) is a pre-offload artifact —
+		// tracker TTL AND that Mark landed BEFORE this TLS event arrived in
+		// userspace, the SNI we just parsed (if any) is a pre-offload artifact —
 		// kernel-TLS will encrypt every subsequent write on the socket and any
 		// "full"/"partial" verdict is misleading. Force unknown with reason="ktls"
 		// before the row lands in the digest or the JSONL. tls_sniff_event has no
-		// fd field today, so we query the tracker with the wildcard form (fd=0)
-		// — see internal/agent/agent_linux_ktls_tracker.go for the contract.
+		// fd field today, so we query the tracker with the wildcard form (fd=0).
+		// The tlsRecvAtNs argument gates the override on event ordering — see
+		// internal/agent/agent_linux_ktls_tracker.go for the contract.
 		confReason := ""
-		if ktlsTr != nil && ktlsTr.IsKTLS(tgid, 0) {
+		if ktlsTr != nil && ktlsTr.IsKTLS(tgid, 0, tlsRecvAtNs) {
 			slog.Debug("ktls override applied", "pid", tgid, "sni", sni)
 			conf = telemetry.TLSConfidenceUnknown
 			confReason = "ktls"
@@ -722,6 +763,13 @@ func readKTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, st
 		}
 		backoff.reset()
 
+		// Capture the userspace ringbuf arrival time as close to rd.Read() as
+		// possible. The ktlsTracker uses this as `markedAt` so a later
+		// IsKTLS query from readTLSRing only flips confidence when the TLS
+		// event arrived AFTER this Mark — pre-offload TLS events with an
+		// earlier tlsTimestampNs are preserved (Bug-1 fix).
+		recvAtNs := time.Now().UnixNano()
+
 		tgid, tid, fd, commb, dirByte, ok := decodeKTLSEvent(record.RawSample)
 		if !ok {
 			stats.addDropped("ktls_decode")
@@ -729,15 +777,17 @@ func readKTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, st
 			continue
 		}
 		stats.addKTLS()
-		// P4: record (pid, fd) so any TLS event for the same pid that flows
-		// through readTLSRing within ktlsTrackerTTL gets reclassified to
-		// Confidence=unknown / ConfidenceReason="ktls". Forward-only: a TLS
-		// event that already shipped before this Mark keeps its original
-		// confidence (plan p4-ktls-sni-confidence-integration.md, Non-goals).
+		// P4: record (pid, fd, markedAt) so any TLS event for the same pid
+		// that flows through readTLSRing within ktlsTrackerTTL AND arrives at
+		// or after markedAt gets reclassified to Confidence=unknown /
+		// ConfidenceReason="ktls". The arrival-time gate replaces the prior
+		// blanket wildcard which clobbered every same-pid TLS event for 60s,
+		// including ones whose payload was captured before the offload was
+		// observed (plan p4-ktls-sni-confidence-integration.md).
 		if ktlsTr != nil {
-			ktlsTr.Mark(tgid, fd)
+			ktlsTr.Mark(tgid, fd, recvAtNs)
 		}
-		comm := string(bytes.TrimRight(commb[:], "\x00"))
+		comm := telemetry.SanitizeField(nullTermStr(commb[:]), 16)
 		direction := ktlsDirectionLabel(dirByte)
 		ts := time.Now().UTC().Format(time.RFC3339Nano)
 

--- a/internal/agent/decode_network_linux_test.go
+++ b/internal/agent/decode_network_linux_test.go
@@ -218,6 +218,113 @@ func TestDecodeTCPStateEvent_tooShort(t *testing.T) {
 	}
 }
 
+// TestDecodeConnectResultEvent guards the wire→Go decode for the P3-2
+// connect_result_event emitted by the kretprobe on tcp_v4_connect. ETIMEDOUT
+// (-110) is the most common non-success result on hosted runners and exercises
+// the negative-errno round-trip through the (__u32 → int32) reinterpret-cast.
+// Callers are expected to have already matched connectResultMagic at offset 0
+// before invoking the decoder, so the test stages the magic too even though
+// the decoder itself does not re-validate it.
+func TestDecodeConnectResultEvent(t *testing.T) {
+	raw := make([]byte, connectResultEventWireSize)
+	binary.LittleEndian.PutUint32(raw[0:4], connectResultMagic)
+	// result = -110 (-ETIMEDOUT) round-tripped through unsigned-bits.
+	binary.LittleEndian.PutUint32(raw[4:8], uint32(int32(-110))) // #nosec G115 -- intentional reinterpret-cast for the wire round-trip //nolint:gosec
+	binary.LittleEndian.PutUint32(raw[8:12], 1234)               // tgid
+	binary.LittleEndian.PutUint32(raw[12:16], 1235)              // tid
+	copy(raw[16:32], []byte("curl\x00"))                         // comm
+
+	tgid, tid, comm, result, ok := decodeConnectResultEvent(raw)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if tgid != 1234 {
+		t.Errorf("tgid = %d, want 1234", tgid)
+	}
+	if tid != 1235 {
+		t.Errorf("tid = %d, want 1235", tid)
+	}
+	if result != -110 {
+		t.Errorf("result = %d, want -110 (-ETIMEDOUT)", result)
+	}
+	if got := string(bytes.TrimRight(comm[:], "\x00")); got != "curl" {
+		t.Errorf("comm = %q, want \"curl\"", got)
+	}
+}
+
+func TestDecodeConnectResultEvent_tooShort(t *testing.T) {
+	_, _, _, _, ok := decodeConnectResultEvent(make([]byte, connectResultEventWireSize-1))
+	if ok {
+		t.Fatal("expected ok=false for short input")
+	}
+}
+
+// TestClassifyConnectRingRecord covers the magic-prefix dispatcher used by
+// readConnectRing. The connect_events ringbuf is multiplexed across three
+// record families (entry connect_event, canary, kretprobe connect_result) so
+// drift in either magic value, in the little-endian read order, or in the
+// short-record guard would silently mis-route every event. Table-driven
+// rather than three separate tests so adding a future magic only edits the
+// table.
+func TestClassifyConnectRingRecord(t *testing.T) {
+	mk := func(magic uint32, extra int) []byte {
+		b := make([]byte, 4+extra)
+		binary.LittleEndian.PutUint32(b[0:4], magic)
+		return b
+	}
+	cases := []struct {
+		name string
+		raw  []byte
+		want connectRingRecordKind
+	}{
+		{
+			name: "canary magic routes to canary",
+			raw:  mk(canaryMagic, canaryEventWireSize-4),
+			want: connectRingKindCanary,
+		},
+		{
+			name: "connect_result magic routes to connect_result",
+			raw:  mk(connectResultMagic, connectResultEventWireSize-4),
+			want: connectRingKindConnectResult,
+		},
+		{
+			// Real tgid leading bytes — must NOT collide with either magic.
+			// PID_MAX_LIMIT = 4194304 (0x00400000) so any plausible tgid
+			// fits in a small uint32 well below both 0xCA1A1210 and
+			// 0xC0EE0001 — verifying that the default branch fires.
+			name: "plausible tgid prefix routes to connect_event",
+			raw:  mk(12345, connectEventWireSize-4),
+			want: connectRingKindConnectEvent,
+		},
+		{
+			name: "zero prefix routes to connect_event",
+			raw:  mk(0, connectEventWireSize-4),
+			want: connectRingKindConnectEvent,
+		},
+		{
+			// Records shorter than the magic itself short-circuit to the
+			// default branch; the downstream connect_event decoder then
+			// fails the too-short check and the dropped counter advances.
+			name: "too-short record routes to connect_event",
+			raw:  []byte{0xCA, 0x1A},
+			want: connectRingKindConnectEvent,
+		},
+		{
+			name: "empty record routes to connect_event",
+			raw:  nil,
+			want: connectRingKindConnectEvent,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyConnectRingRecord(tc.raw)
+			if got != tc.want {
+				t.Errorf("classifyConnectRingRecord = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestDecodeBPFAuditEvent(t *testing.T) {
 	// BPF struct layout: tgid(0-3) tid(4-7) cmd(8-11) comm(12-27)
 	raw := make([]byte, bpfAuditEventWireSize)

--- a/internal/agent/decode_network_linux_test.go
+++ b/internal/agent/decode_network_linux_test.go
@@ -228,11 +228,15 @@ func TestDecodeTCPStateEvent_tooShort(t *testing.T) {
 func TestDecodeConnectResultEvent(t *testing.T) {
 	raw := make([]byte, connectResultEventWireSize)
 	binary.LittleEndian.PutUint32(raw[0:4], connectResultMagic)
-	// result = -110 (-ETIMEDOUT) round-tripped through unsigned-bits.
-	binary.LittleEndian.PutUint32(raw[4:8], uint32(int32(-110))) // #nosec G115 -- intentional reinterpret-cast for the wire round-trip //nolint:gosec
-	binary.LittleEndian.PutUint32(raw[8:12], 1234)               // tgid
-	binary.LittleEndian.PutUint32(raw[12:16], 1235)              // tid
-	copy(raw[16:32], []byte("curl\x00"))                         // comm
+	// result = -110 (-ETIMEDOUT) round-tripped through unsigned-bits. The
+	// runtime variable defeats Go's constant-overflow check, which rejects a
+	// direct uint32(int32(-110)) conversion even though the same byte pattern
+	// is exactly what the kernel writes to the wire.
+	var wantResult int32 = -110
+	binary.LittleEndian.PutUint32(raw[4:8], uint32(wantResult)) // #nosec G115 -- intentional reinterpret-cast for the wire round-trip //nolint:gosec
+	binary.LittleEndian.PutUint32(raw[8:12], 1234)              // tgid
+	binary.LittleEndian.PutUint32(raw[12:16], 1235)             // tid
+	copy(raw[16:32], []byte("curl\x00"))                        // comm
 
 	tgid, tid, comm, result, ok := decodeConnectResultEvent(raw)
 	if !ok {
@@ -244,7 +248,7 @@ func TestDecodeConnectResultEvent(t *testing.T) {
 	if tid != 1235 {
 		t.Errorf("tid = %d, want 1235", tid)
 	}
-	if result != -110 {
+	if result != wantResult {
 		t.Errorf("result = %d, want -110 (-ETIMEDOUT)", result)
 	}
 	if got := string(bytes.TrimRight(comm[:], "\x00")); got != "curl" {

--- a/internal/bpf/traceconnect/abi_test.go
+++ b/internal/bpf/traceconnect/abi_test.go
@@ -32,13 +32,17 @@ func TestTraceconnectMapShapes(t *testing.T) {
 		}
 	})
 
-	t.Run("tcp_v4_connect_inflight is a bounded HASH (P3-2 correlation)", func(t *testing.T) {
+	t.Run("tcp_v4_connect_inflight is a bounded LRU_HASH (P3-2 correlation)", func(t *testing.T) {
+		// LRU_HASH (not plain HASH) ensures that orphaned entries from
+		// dropped kretprobes are evicted by the kernel rather than filling
+		// the table and silently blocking every subsequent BPF_NOEXIST
+		// insert (P3-bug-audit Bug 3).
 		ms, ok := spec.Maps["tcp_v4_connect_inflight"]
 		if !ok {
 			t.Fatal("map tcp_v4_connect_inflight not found in CollectionSpec")
 		}
-		if ms.Type != ebpf.Hash {
-			t.Errorf("tcp_v4_connect_inflight type = %v, want ebpf.Hash", ms.Type)
+		if ms.Type != ebpf.LRUHash {
+			t.Errorf("tcp_v4_connect_inflight type = %v, want ebpf.LRUHash", ms.Type)
 		}
 		if ms.MaxEntries != 4096 {
 			t.Errorf("tcp_v4_connect_inflight MaxEntries = %d, want 4096", ms.MaxEntries)


### PR DESCRIPTION
## Summary

P3 bug audit follow-up: 5 medium/low fixes + 2 test gaps closed, all in one
GPG-signed commit so the audit work is bisectable as a single unit.

### Bug 1 (Medium): KTLS tracker poisons pre-offload SNI
**Files:** `internal/agent/agent_linux_ktls_tracker.go`,
`internal/agent/agent_linux_ring_read.go`,
`internal/agent/agent_linux_ktls_tracker_test.go`

The previous wildcard `fd=0` lookup meant any KTLS event for a pid clobbered
**every** subsequent TLS event from that pid for the full 60-second tracker
TTL — including TLS writes that landed in userspace before the offload was
observed. Those writes were genuinely plaintext (pre-offload) and their SNI
confidence should be preserved.

Fix: each tracker entry now carries a `markedAt` field
(nanoseconds, captured at the KTLS event's userspace ringbuf arrival), and
`IsKTLS` takes a `tlsTimestampNs` parameter (the TLS event's own arrival
time). The override only fires when `tlsTimestampNs >= markedAt`. Both the
exact-fd and wildcard paths apply the gate.

The original audit asked for kernel `timestamp_ns` — but inspecting the
wire, neither `ktls_event` (32 B) nor `tls_sniff_event` (292 B) actually
ships a `timestamp_ns` field today; only `tcp_state_event` does. Adding a
kernel timestamp would have meant a 5+ file cross-cutting change touching
BPF C, `_Static_assert`s, decoders, wire-size constants, and ABI tests for
two unrelated event types. Userspace ringbuf-arrival time hits the same
ordering invariant in 99%+ of cases (BPF emit → userspace drain is sub-ms
in practice) and avoids the ABI churn. The package doc explains the
limitation and the future-work upgrade path.

New `TestKTLSTracker_PreOffloadTLSPreserved` covers the gate; the three
existing tracker tests are updated to the new signatures.

### Bug 2 (Medium): `comm` not sanitized in two ring readers
**File:** `internal/agent/agent_linux_ring_read.go`

The TCPResult (`connect_result_event`) and KTLS (`ktls_event`) readers were
the only ones still decoding `comm` via raw `string(bytes.TrimRight(...))`;
every other ring reader in the file already runs the bytes through
`telemetry.SanitizeField(nullTermStr(...), 16)`. Equalised.

### Bug 3 (Low/Medium): `tcp_v4_connect_inflight` HASH → LRU_HASH
**Files:** `bpf/trace_tcp_connect_kprobe.inc`,
`internal/bpf/traceconnect/abi_test.go`

A dropped kretprobe (e.g. a fault path that bypasses the return hook)
leaves an entry in `tcp_v4_connect_inflight` forever. With plain
`BPF_MAP_TYPE_HASH` that slot stays consumed until process exit, and the
`BPF_NOEXIST` insert in `kprobe_tcp_v4_connect` silently fails on any
later connect from the same task. Switching to `BPF_MAP_TYPE_LRU_HASH`
lets the kernel evict orphans automatically. ABI test updated to match
the new map type.

### Bug 4 (Low): `ktls_events` ringbuf undersized
**File:** `bpf/trace_ktls.bpf.c`

4 KiB → 64 KiB (`1<<12` → `1<<16`). A Go binary using `crypto/tls` +
KTLS during dependency fetch can burst dozens of offload events in the
first second; the prior sizing reserve-failed before the userspace
reader could drain it. The adjacent comment is updated.

### Bug 5 (Low): Fatal reader error left the agent hung at `wg.Wait`
**File:** `internal/agent/agent_linux.go`

Each ringbuf reader goroutine pushed its terminal error to `errCh` but
never cancelled `runCtx`. If one reader hit a fatal (non-`context.Canceled`)
error, the canary + heartbeat goroutines stayed blocked on `runCtx.Done`
forever and `wg.Wait()` never returned — `Run` hung and the deferred
digest writer never executed.

Fix: a small `sendReaderErr` helper that calls `runCancel()` before
forwarding any non-`context.Canceled` error to `errCh`. Every reader
goroutine now goes through the helper.

### Test 1: `decodeConnectResultEvent` unit test
**File:** `internal/agent/decode_network_linux_test.go`

Table-staged record with magic prefix, `result = -110` (ETIMEDOUT, the
common timeout case), `tgid=1234`, `tid=1235`, `comm="curl"`. Asserts the
`(__u32 → int32)` reinterpret-cast preserves the signed errno. Companion
`_tooShort` test.

### Test 2: magic-prefix dispatch test for `readConnectRing`
**File:** `internal/agent/agent_linux_ring_read.go`,
`internal/agent/decode_network_linux_test.go`

Extracted `classifyConnectRingRecord` as a pure-Go free function so the
multiplexed-ringbuf dispatch (canary / connect_result / connect_event)
is table-testable without a live BPF program. `readConnectRing` now
calls the helper; behaviour unchanged.

`TestClassifyConnectRingRecord` covers canary, connect_result,
plausible-tgid (default), zero-prefix, too-short, and empty records.

## Test plan
- [x] `gofmt -l .` clean
- [x] `bash scripts/check-encoding.sh` clean
- [x] `go vet ./internal/agent/... ./internal/policy/... ./internal/report/... ./internal/telemetry/... ./internal/config/... ./cmd/...` clean (BPF packages skipped — generated stubs gitignored)
- [x] `go test ./internal/agent/... ./internal/report/... ./internal/telemetry/... ./cmd/... -count=1` passes on Windows
- [ ] CI: `unit`, `unit-arm64`, `integration`, `detect-mode`, `defend-mode`, CodeQL, golangci-lint
- [ ] CI: traceconnect ABI test asserts the LRU_HASH type
- [ ] CI: ktls_events ringbuf still loads at 64 KiB on hosted kernels
