### PR TITLE
fix: P3-2b/P4 second bug audit — 5 fixes + 3 test gaps

### DIFF
--- a/bpf/trace_connect_obs.h
+++ b/bpf/trace_connect_obs.h
@@ -243,8 +243,8 @@ struct tcp_state_event {
 	__u32 pid;
 	__u32 saddr; /* network byte order */
 	__u32 daddr; /* network byte order */
-	__u16 sport; /* network byte order */
-	__u16 dport; /* network byte order */
+	__u16 sport; /* host byte order — kernel pre-converts */
+	__u16 dport; /* host byte order — kernel pre-converts */
 	__s32 old_state;
 	__s32 new_state;
 	__u8 comm[16];

--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -957,7 +957,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			sendReaderErr(readTCPStateRing(runCtx, cfg, tcpStateRd.R, stats, &seq, &jsonlMu, signer))
+			sendReaderErr(readTCPStateRing(runCtx, cfg, tcpStateRd.R, stats, &seq, &jsonlMu, sectionState, signer))
 		}()
 	}
 	if denyRd.R != nil {

--- a/internal/agent/agent_linux_digest.go
+++ b/internal/agent/agent_linux_digest.go
@@ -170,6 +170,7 @@ func buildDigestInput(
 		TCPStateTotal:                  tcpStateTotal,
 		TCPStateConfirmed:              tcpStateConfirmed,
 		TCPStateRefused:                tcpStateRefused,
+		TCPStateReaderErrors:           sectionState.tcpStateReadErrors + sectionState.tcpStateDecodeErrors,
 		TCPStateRingbufReserveFailures: stats.tcpStateRingbufReserveFailures(),
 		FSGate:                         fsGate,
 		FSTotal:                        fsN,

--- a/internal/agent/agent_linux_ktls_tracker.go
+++ b/internal/agent/agent_linux_ktls_tracker.go
@@ -103,6 +103,17 @@ func newKTLSTrackerClock(now func() time.Time) *ktlsTracker {
 // tlsTimestampNs >= markedAtNs will return true; queries from events that
 // arrived before markedAtNs will not. Each call also evicts any expired
 // entries against the wall clock.
+//
+// For the per-(pid, fd) entry the most recent Mark wins — that record is
+// keyed by fd, so the second offload genuinely supersedes the first. The
+// per-pid `latest` map is the wildcard fallback (for TLS events whose wire
+// format does not carry fd) and tracks the *earliest* surviving Mark for
+// the pid: when two fds on the same pid both offload, a pre-offload TLS
+// write captured between the two Marks must still gate against the
+// earlier offload's markedAt, not the later one — otherwise the
+// arrival-order ordering check (`tlsTimestampNs >= markedAt`) would be
+// evaluated against the wrong reference and the TLS event could be
+// misclassified as pre-offload plaintext.
 func (t *ktlsTracker) Mark(pid, fd uint32, markedAtNs int64) {
 	if t == nil {
 		return
@@ -113,7 +124,9 @@ func (t *ktlsTracker) Mark(pid, fd uint32, markedAtNs int64) {
 	t.evictLocked(now)
 	entry := ktlsEntry{at: now, markedAt: markedAtNs}
 	t.by[ktlsKey{PID: pid, FD: fd}] = entry
-	t.latest[pid] = entry
+	if existing, ok := t.latest[pid]; !ok || markedAtNs < existing.markedAt {
+		t.latest[pid] = entry
+	}
 }
 
 // IsKTLS reports whether (pid, fd) has been Marked within ktlsTrackerTTL AND

--- a/internal/agent/agent_linux_ktls_tracker_test.go
+++ b/internal/agent/agent_linux_ktls_tracker_test.go
@@ -123,6 +123,52 @@ func TestKTLSTracker_TTLEviction(t *testing.T) {
 	}
 }
 
+// TestKTLSTracker_MultiFDPerPidEarliestMarkWins guards Bug 2 from the second
+// audit: when two fds on the same pid both offload to kTLS, the per-pid
+// wildcard `latest[pid]` must reference the *earliest* Mark, not the latest.
+// A TLS event whose arrival timestamp falls between the two Marks otherwise
+// gates against the wrong reference: the wildcard would compare
+// `tlsTimestampNs >= secondMark` and incorrectly return false, leaving the
+// TLS row at full confidence even though it was already captured on a
+// kTLS-offloaded socket.
+func TestKTLSTracker_MultiFDPerPidEarliestMarkWins(t *testing.T) {
+	tr := newKTLSTracker()
+	const pid uint32 = 7777
+	const fd1 uint32 = 3
+	const fd2 uint32 = 5
+	const firstMarkNs int64 = 1_000_000_000
+	const tlsBetweenNs int64 = 1_500_000_000
+	const secondMarkNs int64 = 2_000_000_000
+
+	tr.Mark(pid, fd1, firstMarkNs)
+	tr.Mark(pid, fd2, secondMarkNs)
+
+	// A TLS event that arrived AFTER the first Mark must be classified as
+	// kTLS via the wildcard path. With the old code, latest[pid] would hold
+	// secondMark (2s) and the gate `tlsBetweenNs (1.5s) >= 2s` would be
+	// false, returning a false-negative.
+	if !tr.IsKTLS(pid, 0, tlsBetweenNs) {
+		t.Fatalf("IsKTLS(%d, 0, %d) wildcard = false; want true "+
+			"(TLS event arrived after the earliest Mark — must be flipped)",
+			pid, tlsBetweenNs)
+	}
+
+	// The exact-fd path is unaffected: it still tracks the per-(pid,fd)
+	// Mark precisely.
+	if !tr.IsKTLS(pid, fd1, tlsBetweenNs) {
+		t.Fatalf("IsKTLS(%d, %d, %d) exact-fd = false; want true", pid, fd1, tlsBetweenNs)
+	}
+	// Order-independence: marking the later fd first must give the same
+	// wildcard semantics.
+	tr2 := newKTLSTracker()
+	tr2.Mark(pid, fd2, secondMarkNs)
+	tr2.Mark(pid, fd1, firstMarkNs)
+	if !tr2.IsKTLS(pid, 0, tlsBetweenNs) {
+		t.Fatalf("IsKTLS wildcard after reversed Mark order = false; want true " +
+			"(earliest-mark semantics must hold regardless of insertion order)")
+	}
+}
+
 // TestKTLSTracker_WildcardIsolation guards the per-pid wildcard against
 // cross-pid bleed: marking pid=A must not make IsKTLS(pid=B, 0) return true.
 // Without this property the digest would falsely tag unrelated TLS events as

--- a/internal/agent/agent_linux_ring_read.go
+++ b/internal/agent/agent_linux_ring_read.go
@@ -154,6 +154,24 @@ func nullTermStr(b []byte) string {
 	return string(bytes.TrimRight(b, "\x00"))
 }
 
+// classifyTCPStateTransition turns a kernel tcp_state newstate string (the
+// destination of a SYN_SENT→X transition) into the two counters surfaced in
+// the digest: `confirmed` for a completed handshake and `refused` for a
+// terminal failure state. Intermediate or non-failure states (SYN_RECV,
+// FIN_WAIT*, etc.) are intentionally counted in neither bucket — they
+// represent the kernel still working the handshake or peer-initiated close
+// flows that have nothing to do with policy-relevant failure.
+func classifyTCPStateTransition(newStr string) (confirmed, refused bool) {
+	if newStr == telemetry.TCPStateEstablished {
+		return true, false
+	}
+	switch newStr {
+	case telemetry.TCPStateClose, telemetry.TCPStateCloseWait, telemetry.TCPStateTimeWait:
+		return false, true
+	}
+	return false, false
+}
+
 // connectRingRecordKind classifies one connect_events ringbuf record by its
 // 4-byte magic at offset 0. The connect_events ringbuf is multiplexed: the
 // entry-side connect(2) tracepoint, the P3-2 kretprobe on tcp_v4_connect, and
@@ -819,7 +837,7 @@ func readKTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, st
 // context; downstream tooling correlates by tuple (saddr:sport→daddr:dport)
 // with the preceding `tcp` connect_event when reliable attribution is needed.
 func readTCPStateRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader,
-	stats *runStats, seq *telemetry.SeqGen, jsonlMu *sync.Mutex, signer *telemetry.Signer) error {
+	stats *runStats, seq *telemetry.SeqGen, jsonlMu *sync.Mutex, sectionState *networkSectionState, signer *telemetry.Signer) error {
 	backoff := newRingReadRetryBackoff()
 	for {
 		record, err := rd.Read()
@@ -830,6 +848,9 @@ func readTCPStateRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
+			if sectionState != nil {
+				sectionState.addTCPStateReaderError()
+			}
 			delay := backoff.sleep()
 			slog.Warn("ringbuf read (tcp_state)", "err", err, "backoff", delay)
 			continue
@@ -838,6 +859,9 @@ func readTCPStateRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader
 
 		timestampNS, pid, saddr, daddr, sport, dport, oldState, newState, commb, ok := decodeTCPStateEvent(record.RawSample)
 		if !ok {
+			if sectionState != nil {
+				sectionState.addTCPStateDecodeError()
+			}
 			stats.addDropped("tcp_state_decode")
 			slog.Warn("decode tcp_state", "len", len(record.RawSample))
 			continue
@@ -845,11 +869,7 @@ func readTCPStateRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader
 
 		oldStr := telemetry.TCPStateName(oldState)
 		newStr := telemetry.TCPStateName(newState)
-		confirmed := newStr == telemetry.TCPStateEstablished
-		// Anything else after SYN_SENT (CLOSE, CLOSE_WAIT, FIN_WAIT1, etc.) is
-		// a failed or short-circuited handshake from the policy POV; CLOSE is
-		// by far the common case (RST / unreachable / timeout).
-		refused := !confirmed
+		confirmed, refused := classifyTCPStateTransition(newStr)
 		stats.addTCPState(confirmed, refused)
 
 		dstIP := net.IP(daddr[:]).To4()
@@ -857,7 +877,7 @@ func readTCPStateRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader
 			continue
 		}
 		srcIP := net.IP(saddr[:]).To4()
-		comm := string(bytes.TrimRight(commb[:], "\x00"))
+		comm := telemetry.SanitizeField(nullTermStr(commb[:]), 16)
 
 		ts := time.Now().UTC().Format(time.RFC3339Nano)
 		slog.Debug("tcp_state", "pid", pid, "comm", comm,

--- a/internal/agent/agent_linux_state_sections.go
+++ b/internal/agent/agent_linux_state_sections.go
@@ -110,25 +110,29 @@ func (b *forkEdgeBuffer) snapshot() ([]proctree.Edge, bool) {
 type networkSectionState struct {
 	mu sync.Mutex
 
-	tcpReadErrors    int
-	tcpDecodeErrors  int
-	udpReadErrors    int
-	udpDecodeErrors  int
-	httpReadErrors   int
-	httpDecodeErrors int
-	tlsReadErrors    int
-	tlsDecodeErrors  int
+	tcpReadErrors        int
+	tcpDecodeErrors      int
+	udpReadErrors        int
+	udpDecodeErrors      int
+	httpReadErrors       int
+	httpDecodeErrors     int
+	tlsReadErrors        int
+	tlsDecodeErrors      int
+	tcpStateReadErrors   int
+	tcpStateDecodeErrors int
 }
 
 type networkSectionSnapshot struct {
-	tcpReadErrors    int
-	tcpDecodeErrors  int
-	udpReadErrors    int
-	udpDecodeErrors  int
-	httpReadErrors   int
-	httpDecodeErrors int
-	tlsReadErrors    int
-	tlsDecodeErrors  int
+	tcpReadErrors        int
+	tcpDecodeErrors      int
+	udpReadErrors        int
+	udpDecodeErrors      int
+	httpReadErrors       int
+	httpDecodeErrors     int
+	tlsReadErrors        int
+	tlsDecodeErrors      int
+	tcpStateReadErrors   int
+	tcpStateDecodeErrors int
 }
 
 const (
@@ -344,17 +348,31 @@ func (s *networkSectionState) addTLSDecodeError() {
 	s.tlsDecodeErrors++
 }
 
+func (s *networkSectionState) addTCPStateReaderError() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tcpStateReadErrors++
+}
+
+func (s *networkSectionState) addTCPStateDecodeError() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tcpStateDecodeErrors++
+}
+
 func (s *networkSectionState) snapshot() networkSectionSnapshot {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return networkSectionSnapshot{
-		tcpReadErrors:    s.tcpReadErrors,
-		tcpDecodeErrors:  s.tcpDecodeErrors,
-		udpReadErrors:    s.udpReadErrors,
-		udpDecodeErrors:  s.udpDecodeErrors,
-		httpReadErrors:   s.httpReadErrors,
-		httpDecodeErrors: s.httpDecodeErrors,
-		tlsReadErrors:    s.tlsReadErrors,
-		tlsDecodeErrors:  s.tlsDecodeErrors,
+		tcpReadErrors:        s.tcpReadErrors,
+		tcpDecodeErrors:      s.tcpDecodeErrors,
+		udpReadErrors:        s.udpReadErrors,
+		udpDecodeErrors:      s.udpDecodeErrors,
+		httpReadErrors:       s.httpReadErrors,
+		httpDecodeErrors:     s.httpDecodeErrors,
+		tlsReadErrors:        s.tlsReadErrors,
+		tlsDecodeErrors:      s.tlsDecodeErrors,
+		tcpStateReadErrors:   s.tcpStateReadErrors,
+		tcpStateDecodeErrors: s.tcpStateDecodeErrors,
 	}
 }

--- a/internal/agent/decode_network_linux_test.go
+++ b/internal/agent/decode_network_linux_test.go
@@ -6,6 +6,8 @@ import (
 	"bytes"
 	"encoding/binary"
 	"testing"
+
+	"github.com/coldstep-io/coldstep/internal/telemetry"
 )
 
 func TestDecodeUDPSendEvent(t *testing.T) {
@@ -215,6 +217,99 @@ func TestDecodeTCPStateEvent_tooShort(t *testing.T) {
 	_, _, _, _, _, _, _, _, _, ok := decodeTCPStateEvent(make([]byte, tcpStateEventWireSize-1))
 	if ok {
 		t.Fatal("expected false for short input")
+	}
+}
+
+// TestDecodeTCPStateEvent_CommSanitization guards Bug 1 from the second audit:
+// the TCPState ring reader must run the comm field through
+// telemetry.SanitizeField (matching every other ring reader) so a malicious or
+// corrupted argv[0] cannot inject JSONL control bytes when serialized into the
+// events log. We stage a comm buffer with embedded control bytes and invalid
+// UTF-8, decode it via the wire path, and then exercise the same sanitization
+// pipeline that readTCPStateRing uses.
+func TestDecodeTCPStateEvent_CommSanitization(t *testing.T) {
+	raw := make([]byte, tcpStateEventWireSize)
+	binary.LittleEndian.PutUint64(raw[0:8], 1)
+	binary.LittleEndian.PutUint32(raw[8:12], 1)
+	raw[12], raw[13], raw[14], raw[15] = 10, 0, 0, 1
+	raw[16], raw[17], raw[18], raw[19] = 10, 0, 0, 2
+	binary.LittleEndian.PutUint16(raw[20:22], 1234)
+	binary.LittleEndian.PutUint16(raw[22:24], 80)
+	binary.LittleEndian.PutUint32(raw[24:28], 2) // SYN_SENT
+	binary.LittleEndian.PutUint32(raw[28:32], 1) // ESTABLISHED
+	// comm: "ev\nil\x01\xff\xff" (newline + control + invalid UTF-8) padded
+	// with NULs out to 16 bytes. Invalid UTF-8 must come out as U+FFFD; the
+	// newline and 0x01 control must be stripped.
+	commIn := []byte{'e', 'v', '\n', 'i', 'l', 0x01, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+	copy(raw[32:48], commIn)
+
+	_, _, _, _, _, _, _, _, commBytes, ok := decodeTCPStateEvent(raw)
+	if !ok {
+		t.Fatal("decode expected to succeed")
+	}
+
+	// Pipeline matches readTCPStateRing exactly so any drift between this
+	// test and the production sanitization choice fails here.
+	sanitized := telemetry.SanitizeField(nullTermStr(commBytes[:]), 16)
+
+	// SanitizeField removes \n and 0x01 entirely. The invalid 0xFF pair is
+	// not valid UTF-8 so SanitizeField replaces it with U+FFFD. Result must
+	// contain no control bytes and no raw 0xFF.
+	if bytes.ContainsRune([]byte(sanitized), '\n') {
+		t.Errorf("sanitized comm still contains newline: %q", sanitized)
+	}
+	if bytes.IndexByte([]byte(sanitized), 0x01) >= 0 {
+		t.Errorf("sanitized comm still contains 0x01 control byte: %q", sanitized)
+	}
+	if bytes.IndexByte([]byte(sanitized), 0xFF) >= 0 {
+		t.Errorf("sanitized comm still contains raw 0xFF (invalid UTF-8 not replaced): %q", sanitized)
+	}
+	// And critically: the raw, un-sanitized prefix would still have the
+	// newline. If the production code ever drops the SanitizeField call we
+	// want this assertion to catch it.
+	if got := nullTermStr(commBytes[:]); !bytes.Contains([]byte(got), []byte{'\n'}) {
+		t.Fatalf("test setup wrong: pre-sanitize comm should still contain \\n; got %q", got)
+	}
+}
+
+// TestClassifyTCPStateTransition guards Bug 4 from the second audit. The
+// classifier must call ESTABLISHED a confirmed handshake, count Close /
+// CloseWait / TimeWait as terminal failures (refused), and leave every other
+// transition (SYN_RECV, FIN_WAIT*, etc.) out of *both* buckets so they are
+// not misattributed as policy-relevant refusals.
+func TestClassifyTCPStateTransition(t *testing.T) {
+	cases := []struct {
+		newStr         string
+		wantConfirmed  bool
+		wantRefused    bool
+		wantInBuckets  bool // confirmed or refused must be set
+		describeReason string
+	}{
+		{telemetry.TCPStateEstablished, true, false, true, "handshake succeeded"},
+		{telemetry.TCPStateClose, false, true, true, "RST / timeout / unreachable"},
+		{telemetry.TCPStateCloseWait, false, true, true, "peer-initiated close after partial connect"},
+		{telemetry.TCPStateTimeWait, false, true, true, "connection terminated, waiting out 2*MSL"},
+		// Bug 4: SYN_RECV is an intermediate handshake state, not a refusal.
+		{telemetry.TCPStateSynRecv, false, false, false, "intermediate handshake state, not failure"},
+		{telemetry.TCPStateFinWait1, false, false, false, "active-close intermediate, not a refusal"},
+		{telemetry.TCPStateFinWait2, false, false, false, "active-close intermediate, not a refusal"},
+		{telemetry.TCPStateLastAck, false, false, false, "active-close intermediate, not a refusal"},
+		{telemetry.TCPStateClosing, false, false, false, "simultaneous-close intermediate, not a refusal"},
+		{"UNKNOWN", false, false, false, "unknown newstate falls through both buckets"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.newStr, func(t *testing.T) {
+			gotConfirmed, gotRefused := classifyTCPStateTransition(tc.newStr)
+			if gotConfirmed != tc.wantConfirmed {
+				t.Errorf("confirmed = %v, want %v (%s)", gotConfirmed, tc.wantConfirmed, tc.describeReason)
+			}
+			if gotRefused != tc.wantRefused {
+				t.Errorf("refused = %v, want %v (%s)", gotRefused, tc.wantRefused, tc.describeReason)
+			}
+			if (gotConfirmed || gotRefused) != tc.wantInBuckets {
+				t.Errorf("inBuckets = %v, want %v", gotConfirmed || gotRefused, tc.wantInBuckets)
+			}
+		})
 	}
 }
 

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -351,6 +351,9 @@ func writeFullKPITable(b *strings.Builder, in DigestInput) {
 	if in.TCPStateRingbufReserveFailures > 0 {
 		fmt.Fprintf(b, "| **tcp_state_events ringbuf reserve failures** | %d |\n", in.TCPStateRingbufReserveFailures)
 	}
+	if in.TCPStateReaderErrors > 0 {
+		fmt.Fprintf(b, "| **tcp_state_events reader errors** | %d |\n", in.TCPStateReaderErrors)
+	}
 	if in.Connect4TupleUpdateFailures > 0 {
 		fmt.Fprintf(b, "| **connect4 (tgid,fd)→tuple map update failures** | %d |\n", in.Connect4TupleUpdateFailures)
 	}

--- a/internal/report/digest_types.go
+++ b/internal/report/digest_types.go
@@ -276,13 +276,17 @@ type DigestInput struct {
 	// oldstate == SYN_SENT so it represents resolved outgoing connects.
 	// TCPStateConfirmed counts the subset that transitioned to ESTABLISHED
 	// (handshake succeeded); TCPStateRefused counts the subset that
-	// transitioned to CLOSE (RST / timeout / unreach). Non-zero
-	// TCPStateTotal adds a "TCP handshakes (kernel-confirmed)" row to the
-	// Full KPI table — complementary to the P3-2-derived TCPResultCounts,
-	// which is the kretprobe-captured `tcp_v4_connect()` return value.
+	// transitioned to a terminal failure state (CLOSE / CLOSE_WAIT /
+	// TIME_WAIT — RST, timeout, unreachable, or peer-initiated close).
+	// Other intermediate transitions (e.g. SYN_RECV) are not counted in
+	// either bucket. Non-zero TCPStateTotal adds a "TCP handshakes
+	// (kernel-confirmed)" row to the Full KPI table — complementary to
+	// the P3-2-derived TCPResultCounts, which is the kretprobe-captured
+	// `tcp_v4_connect()` return value.
 	TCPStateTotal                  int
 	TCPStateConfirmed              int
 	TCPStateRefused                int
+	TCPStateReaderErrors           int
 	TCPStateRingbufReserveFailures int
 	BPFAuditTotal                  int
 	BPFAuditRows                   []BPFAuditDigestRow


### PR DESCRIPTION
## Summary

Five low-severity bugs found in a second pass over the P3-2b (inet_sock_set_state TCPState) and P4 (KTLS→SNI confidence) code that landed in #182/#183. None affect detection correctness, but a couple are JSONL hygiene and one is a degraded-hook accounting gap.

- **Bug 1 — sanitize `comm` in `readTCPStateRing`**: the TCPState ring reader was the only ring reader still using `bytes.TrimRight(commb, "\x00")` without `telemetry.SanitizeField`. A process with newlines or control bytes in `argv[0]` could splice forged records into `.coldstep-events.jsonl`. Now matches every other reader (KTLS, HTTP, TLS, etc.).
- **Bug 2 — KTLS tracker `latest[pid]` clobber**: when two fds on the same pid both offload to kTLS, `Mark()` was overwriting `latest[pid]` with the newer `markedAt`. A TLS event that arrived *between* the two Marks then gated against the wrong reference and was mis-classified as plaintext. `latest[pid]` now stores the *earliest* surviving Mark; the per-`(pid, fd)` map keeps last-write-wins for exact-fd lookups.
- **Bug 3 — TCPState reader errors not counted**: `readTCPStateRing` logged `rd.Read()` and decode errors via `slog.Warn` but never reached the digest's degraded-hook verdict. New `tcpStateReadErrors` / `tcpStateDecodeErrors` counters on `networkSectionState`, surfaced as `TCPStateReaderErrors` and a `tcp_state_events reader errors` digest row.
- **Bug 4 — narrow `refused` classification**: `refused := !confirmed` over-counted intermediate kernel states (SYN_RECV, FIN_WAIT*, LAST_ACK, CLOSING) as refusals. Now scoped to `CLOSE | CLOSE_WAIT | TIME_WAIT`; the rest fall in neither bucket. Classification extracted to `classifyTCPStateTransition()` and table-driven tested.
- **Bug 5 — docs-only**: `tcp_state_event` `sport`/`dport` comments in `bpf/trace_connect_obs.h` corrected from `network byte order` to `host byte order — kernel pre-converts`. The wire decoder already reads little-endian (host order), matching what the kernel emits.

## Test plan

- [x] `TestDecodeTCPStateEvent_CommSanitization` — stages newline + `0x01` + invalid UTF-8 in `comm`, asserts full `SanitizeField` pipeline scrubs the JSONL-relevant bytes
- [x] `TestKTLSTracker_MultiFDPerPidEarliestMarkWins` — two fds on the same pid, TLS event between the Marks, asserts wildcard hit; also asserts order-independence for reversed insertion
- [x] `TestClassifyTCPStateTransition` — table-driven across `ESTABLISHED` / `CLOSE` / `CLOSE_WAIT` / `TIME_WAIT` / `SYN_RECV` / `FIN_WAIT*` / `LAST_ACK` / `CLOSING` / `UNKNOWN`, asserts SYN_RECV is in neither bucket
- [x] `go test ./... -count=1` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] encoding scan clean

## Files

- `bpf/trace_connect_obs.h` (Bug 5, docs only)
- `internal/agent/agent_linux.go` (wire `sectionState` into `readTCPStateRing` call)
- `internal/agent/agent_linux_digest.go` (set `TCPStateReaderErrors` in `DigestInput`)
- `internal/agent/agent_linux_ktls_tracker.go` (Bug 2: earliest-mark semantics)
- `internal/agent/agent_linux_ktls_tracker_test.go` (Bug 2 test)
- `internal/agent/agent_linux_ring_read.go` (Bugs 1, 3, 4: sanitize + counters + classifier extract)
- `internal/agent/agent_linux_state_sections.go` (new `tcpStateReadErrors` / `tcpStateDecodeErrors` fields + methods)
- `internal/agent/decode_network_linux_test.go` (Bug 1 + Bug 4 tests)
- `internal/report/digest.go` (new "tcp_state_events reader errors" digest row)
- `internal/report/digest_types.go` (new `TCPStateReaderErrors` field; refused-classification docstring updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
