### PR TITLE
feat(bpf): P5 IPv6 SNI sniffer

### DIFF
--- a/bpf/coldstep_pure.h
+++ b/bpf/coldstep_pure.h
@@ -20,6 +20,10 @@ typedef uint32_t __be32;
 #define AF_INET 2
 #endif
 
+#ifndef AF_INET6
+#define AF_INET6 10
+#endif
+
 #ifndef __always_inline
 #define __always_inline inline __attribute__((__always_inline__))
 #endif
@@ -84,6 +88,28 @@ static __always_inline int coldstep_parse_ipv4_sockaddr16(const __u8 scratch[16]
 	}
 	__builtin_memcpy(port, scratch + 2, sizeof(*port));
 	__builtin_memcpy(addr, scratch + 4, sizeof(*addr));
+	return 0;
+}
+
+/*
+ * Parse the first 24 bytes of a Linux struct sockaddr_in6 image (AF_INET6 only).
+ * Layout: sin6_family(2) sin6_port(2) sin6_flowinfo(4) sin6_addr(16) [sin6_scope_id(4) skipped].
+ * Used by read_ipv6_sockaddr after bpf_probe_read_user(scratch, 24, ...).
+ */
+static __always_inline int coldstep_parse_ipv6_sockaddr24(const __u8 scratch[24], __be16 *port,
+							  __u8 addr[16])
+{
+	if (!scratch || !port || !addr)
+		return -1;
+	{
+		__u16 family;
+
+		__builtin_memcpy(&family, scratch, sizeof(family));
+		if (family != (__u16)AF_INET6)
+			return -1;
+	}
+	__builtin_memcpy(port, scratch + 2, sizeof(*port));
+	__builtin_memcpy(addr, scratch + 8, 16);
 	return 0;
 }
 

--- a/bpf/host_test/test_coldstep_pure.c
+++ b/bpf/host_test/test_coldstep_pure.c
@@ -88,6 +88,37 @@ int main(void)
 			       "sockaddr reject non inet");
 	}
 
+	/* coldstep_parse_ipv6_sockaddr24 (P5) */
+	{
+		__u8 scratch[24];
+		__be16 port = 0;
+		__u8 addr[16];
+
+		memset(scratch, 0, sizeof(scratch));
+		memset(addr, 0, sizeof(addr));
+		scratch[0] = (unsigned char)(AF_INET6 & 0xff);
+		scratch[1] = (unsigned char)((AF_INET6 >> 8) & 0xff);
+		scratch[2] = 0x01;
+		scratch[3] = 0xbb; /* port 443, network byte order */
+		/* sin6_flowinfo @4..8 stays zero */
+		/* sin6_addr @8..24: 2001:db8::1 */
+		scratch[8] = 0x20;
+		scratch[9] = 0x01;
+		scratch[10] = 0x0d;
+		scratch[11] = 0xb8;
+		scratch[23] = 0x01;
+		EXPECT_ZERO(coldstep_parse_ipv6_sockaddr24(scratch, &port, addr), "sockaddr6 ok");
+		EXPECT_EQ((unsigned long)port, 0xbb01UL, "port6 LE");
+		EXPECT_EQ((unsigned long)addr[0], 0x20UL, "addr6 byte0");
+		EXPECT_EQ((unsigned long)addr[3], 0xb8UL, "addr6 byte3");
+		EXPECT_EQ((unsigned long)addr[15], 0x01UL, "addr6 byte15");
+
+		scratch[0] = (unsigned char)(AF_INET & 0xff);
+		scratch[1] = 0;
+		EXPECT_NE_ZERO(coldstep_parse_ipv6_sockaddr24(scratch, &port, addr),
+			       "sockaddr6 reject non inet6");
+	}
+
 	/* coldstep_http_prefix_is_request */
 	EXPECT_NE_ZERO(coldstep_http_prefix_is_request("GET "), "GET ");
 	EXPECT_NE_ZERO(coldstep_http_prefix_is_request("POST"), "POST");

--- a/bpf/trace_connect.bpf.c
+++ b/bpf/trace_connect.bpf.c
@@ -437,7 +437,18 @@ int handle_raw_sys_enter(struct bpf_raw_tracepoint_args *ctx)
 			return 0;
 		if (ns_read_syscall_arg(regs, 1, &si_ul))
 			return 0;
-		return handle_tcp_obs_connect((__u32)di_ul, si_ul);
+		/*
+		 * Call IPv4 and IPv6 handlers unconditionally — each parser
+		 * validates sa_family up front and returns -1 on mismatch, so
+		 * only one of the two actually emits/updates per call. The
+		 * IPv6 path doesn't write a connect_events ringbuf record
+		 * (`connect_event` has an IPv4-only wire shape), but it
+		 * populates the (tgid,fd) tuple map so a subsequent TLS
+		 * ClientHello write can attribute its destination.
+		 */
+		handle_tcp_obs_connect((__u32)di_ul, si_ul);
+		handle_tcp_obs_connect6((__u32)di_ul, si_ul);
+		return 0;
 	}
 
 	if (id == (long)COLDSTEP_NR_SENDTO) {
@@ -473,6 +484,18 @@ int handle_raw_sys_enter(struct bpf_raw_tracepoint_args *ctx)
 		if (len > 0x00100000)
 			len = 0x00100000;
 
+		/*
+		 * P5: when the connected-sendto path resolves an IPv6 tuple,
+		 * skip UDP/HTTP emit (both records have IPv4-only wire shapes
+		 * and would otherwise carry daddr=0.0.0.0). TLS sniff below
+		 * still runs against the IPv6 tuple via the v6-aware emit
+		 * helper.
+		 */
+		if (!addr_ul && ct.is_ipv6) {
+			try_emit_tls_clienthello_from_tuple(&ct, buf_ptr, len, tuple_pt);
+			return 0;
+		}
+
 		if (!addr_ul)
 			handle_udp_obs_emit_pt(tuple_pt, sin_port, sin_addr, len);
 		else
@@ -498,7 +521,7 @@ int handle_raw_sys_enter(struct bpf_raw_tracepoint_args *ctx)
 			struct connect4_tuple st = {};
 
 			st.in_use = 1;
-			st._pad = 0;
+			st.is_ipv6 = 0;
 			__builtin_memcpy(st.daddr, &sin_addr, sizeof(st.daddr));
 			__builtin_memcpy(st.dport, &sin_port, sizeof(st.dport));
 			try_emit_tls_clienthello_from_tuple(&st, buf_ptr, len,

--- a/bpf/trace_connect_obs.h
+++ b/bpf/trace_connect_obs.h
@@ -147,12 +147,18 @@ struct coldstep_iovec {
 	unsigned long iov_len;
 };
 
-/* Last IPv4 connect tuple observed for (tgid, fd); used to attribute TLS ClientHello writes. */
+/*
+ * Last IPv4/IPv6 connect tuple observed for (tgid, fd); used to attribute TLS ClientHello writes.
+ * IPv4 path zeroes daddr6 and sets is_ipv6=0; IPv6 path zeroes daddr and sets is_ipv6=1.
+ * Name kept (`connect4_tuple`, `connect4_by_tgid_fd`) for wire-compat with the existing
+ * userspace counter map names (`Connect4TupleUpdateFailures`).
+ */
 struct connect4_tuple {
 	__u8 daddr[4];
 	__u8 dport[2];
 	__u8 in_use;
-	__u8 _pad;
+	__u8 is_ipv6;
+	__u8 daddr6[16];
 };
 
 struct tls_sniff_event {
@@ -164,13 +170,24 @@ struct tls_sniff_event {
 	__u8 _pad[2];
 	__u16 capture_len;
 	__u8 payload[TLS_PAYLOAD_MAX];
+	/*
+	 * IPv6 trailer (P5). Appended at the end so the IPv4 wire layout
+	 * (offsets 0..289) is byte-for-byte unchanged: any IPv4-only consumer
+	 * reading the legacy header + payload stays correct.
+	 */
+	__u8 daddr6[16];
+	__u8 is_ipv6;
+	__u8 _pad_v6[3];
 };
 /*
- * Layout: header(34) + payload[256]; alignment-of-4 trailing pad → sizeof = 292.
- * Go decoder caps capture_len at 256 and never touches the trailing pad.
+ * Layout: header(34) + payload[256] + ipv6-trailer(20) → sizeof = 312.
+ * IPv6 trailer breakdown: daddr6[16] + is_ipv6(1) + _pad_v6[3]. The trailing
+ * 3-byte pad keeps the next struct on a 4-byte boundary (alignment-of-4 for
+ * the leading __u32 fields), so there is no implicit tail pad.
+ * Go decoder caps capture_len at 256 and never touches the trailing pad bytes.
  */
-_Static_assert(sizeof(struct tls_sniff_event) == 292,
-	       "tls_sniff_event wire size must match tlsSniffEventWireSize=292 in agent_linux.go");
+_Static_assert(sizeof(struct tls_sniff_event) == 312,
+	       "tls_sniff_event wire size must match tlsSniffEventWireSize=312 in agent_linux.go");
 
 struct connect_event {
 	__u32 tgid;
@@ -272,6 +289,24 @@ static __always_inline int read_ipv4_sockaddr(unsigned long sockaddr_ptr, __be16
 	if (bpf_probe_read_user(scratch, sizeof(scratch), (void *)sockaddr_ptr))
 		return -1;
 	return coldstep_parse_ipv4_sockaddr16(scratch, port, addr);
+}
+
+/*
+ * One bounded userspace read (Linux struct sockaddr_in6 first 24 bytes:
+ * family/port/flowinfo/addr; sin6_scope_id is skipped). Same single-probe
+ * style as read_ipv4_sockaddr — chained probes are rejected on strict 6.x
+ * verifiers.
+ */
+static __always_inline int read_ipv6_sockaddr(unsigned long sockaddr_ptr, __be16 *port,
+					      __u8 addr[16])
+{
+	__u8 scratch[24];
+
+	if (!sockaddr_ptr || !port || !addr)
+		return -1;
+	if (bpf_probe_read_user(scratch, sizeof(scratch), (void *)sockaddr_ptr))
+		return -1;
+	return coldstep_parse_ipv6_sockaddr24(scratch, port, addr);
 }
 
 static __always_inline int http_prefix_looks_like_request(unsigned long buf_ptr, __u32 cap)

--- a/bpf/trace_tcp_obs.inc
+++ b/bpf/trace_tcp_obs.inc
@@ -37,6 +37,7 @@ static __always_inline int handle_tcp_obs_connect(__u32 fd32, unsigned long sock
 			__builtin_memcpy(tup.daddr, &sin_addr, sizeof(sin_addr));
 			__builtin_memcpy(tup.dport, &sin_port, sizeof(sin_port));
 			tup.in_use = 1;
+			tup.is_ipv6 = 0;
 			{
 				__u32 tgid = (__u32)(pt >> 32);
 				__u64 mkey = ((__u64)tgid << 32) | (__u64)fd32;
@@ -44,6 +45,43 @@ static __always_inline int handle_tcp_obs_connect(__u32 fd32, unsigned long sock
 				if (bpf_map_update_elem(&connect4_by_tgid_fd, &mkey, &tup, BPF_ANY))
 					note_connect4_tuple_update_failed();
 			}
+		}
+	}
+	return 0;
+}
+
+/*
+ * IPv6 connect observability (P5): mirrors handle_tcp_obs_connect but reads
+ * sockaddr_in6 and stores the v6 address into the tuple LRU map so the TLS
+ * sniff path can attribute ClientHello writes on the same fd. No IPv6
+ * connect_events ringbuf record is emitted — `connect_event` has an IPv4-only
+ * wire shape and TCP-IPv6 events would need a separate ringbuf to surface
+ * (out of scope for the SNI-only P5 increment).
+ */
+static __always_inline int handle_tcp_obs_connect6(__u32 fd32, unsigned long sockaddr_ptr)
+{
+	__be16 sin6_port;
+	__u8 sin6_addr[16];
+
+	if (!sockaddr_ptr)
+		return 0;
+	if (read_ipv6_sockaddr(sockaddr_ptr, &sin6_port, sin6_addr))
+		return 0;
+
+	{
+		__u64 pt = bpf_get_current_pid_tgid();
+		struct connect4_tuple tup = {};
+
+		__builtin_memcpy(tup.daddr6, sin6_addr, sizeof(tup.daddr6));
+		__builtin_memcpy(tup.dport, &sin6_port, sizeof(tup.dport));
+		tup.in_use = 1;
+		tup.is_ipv6 = 1;
+		{
+			__u32 tgid = (__u32)(pt >> 32);
+			__u64 mkey = ((__u64)tgid << 32) | (__u64)fd32;
+
+			if (bpf_map_update_elem(&connect4_by_tgid_fd, &mkey, &tup, BPF_ANY))
+				note_connect4_tuple_update_failed();
 		}
 	}
 	return 0;

--- a/bpf/trace_tls_write.inc
+++ b/bpf/trace_tls_write.inc
@@ -75,6 +75,22 @@ static __always_inline void try_emit_tls_clienthello_from_tuple(struct connect4_
 		__builtin_memcpy(ev->dport, tup->dport, sizeof(ev->dport));
 		ev->_pad[0] = 0;
 		ev->_pad[1] = 0;
+		/*
+		 * IPv6 trailer (P5). ringbuf_reserve memory is uninitialized,
+		 * so zero unconditionally then overwrite on the IPv6 path.
+		 * IPv4 callers leave daddr6 zeroed and is_ipv6=0, preserving
+		 * the legacy IPv4 wire content; IPv6 carries the v6 address
+		 * in the trailer.
+		 */
+		__builtin_memset(ev->daddr6, 0, sizeof(ev->daddr6));
+		ev->is_ipv6 = 0;
+		ev->_pad_v6[0] = 0;
+		ev->_pad_v6[1] = 0;
+		ev->_pad_v6[2] = 0;
+		if (tup->is_ipv6) {
+			__builtin_memcpy(ev->daddr6, tup->daddr6, sizeof(ev->daddr6));
+			ev->is_ipv6 = 1;
+		}
 		{
 			/*
 			 * Constant read size for strict verifiers (same pattern as HTTP sniff —
@@ -106,6 +122,13 @@ static __always_inline void try_emit_buffer_sniff_from_tuple(struct connect4_tup
 	try_emit_tls_clienthello_from_tuple(tup, buf_ptr, len, pt);
 
 	if (!tup || !tup->in_use)
+		return;
+	/*
+	 * P5: HTTP sniff (http_events / http_sniff_event) only carries an IPv4
+	 * daddr; bail on IPv6 tuples to avoid emitting `0.0.0.0:80` records
+	 * with the wrong destination.
+	 */
+	if (tup->is_ipv6)
 		return;
 
 	{

--- a/bpf/trace_udp_obs.inc
+++ b/bpf/trace_udp_obs.inc
@@ -66,6 +66,8 @@ static __always_inline int coldstep_connect_tuple_fetch(__u32 fd32, struct conne
 
 /*
  * Resolve IPv4 dst from tuple map — sendfile/splice and sendmsg fallback paths.
+ * P5: callers expect an IPv4 sin_addr; refuse IPv6 tuples so they don't emit
+ * udp_events / http_events records with daddr=0.0.0.0.
  */
 static __always_inline int coldstep_tuple_dst_for_fd(__u32 fd32, __be16 *sin_port,
 						     __be32 *sin_addr, __u64 *pt_out)
@@ -73,6 +75,8 @@ static __always_inline int coldstep_tuple_dst_for_fd(__u32 fd32, __be16 *sin_por
 	struct connect4_tuple t;
 
 	if (coldstep_connect_tuple_fetch(fd32, &t, pt_out))
+		return -1;
+	if (t.is_ipv6)
 		return -1;
 	__builtin_memcpy(sin_port, t.dport, sizeof(*sin_port));
 	__builtin_memcpy(sin_addr, t.daddr, sizeof(*sin_addr));

--- a/bpf/trace_udp_sendmsg.inc
+++ b/bpf/trace_udp_sendmsg.inc
@@ -122,7 +122,7 @@ have_dest:
 				if (tls_len > TLS_PAYLOAD_MAX)
 					tls_len = TLS_PAYLOAD_MAX;
 				st.in_use = 1;
-				st._pad = 0;
+				st.is_ipv6 = 0;
 				__builtin_memcpy(st.daddr, &sin_addr, sizeof(st.daddr));
 				__builtin_memcpy(st.dport, &sin_port, sizeof(st.dport));
 				try_emit_tls_clienthello_from_tuple(&st, iov1.iov_base,

--- a/internal/agent/abi_wire_linux_test.go
+++ b/internal/agent/abi_wire_linux_test.go
@@ -42,7 +42,11 @@ func TestNetworkAndAuditWireSizes(t *testing.T) {
 		{"connect_result_event", uintptr(connectResultEventWireSize), uintptr(4 + 4 + 4 + 4 + 16)},
 		{"udp_send_event", uintptr(udpSendEventWireSize), uintptr(4 + 4 + 16 + 4 + 2 + 2 + 4)},
 		{"http_sniff_event", uintptr(httpSniffEventWireSize), uintptr(httpSniffEventHeaderSize + httpPayloadMax + 2)},
-		{"tls_sniff_event", uintptr(tlsSniffEventWireSize), uintptr(tlsSniffEventHeaderSize + tlsPayloadMax + 2)},
+		// tls_sniff_event = header(34) + payload[256] + IPv6 trailer
+		// (daddr6[16] + is_ipv6(1) + _pad_v6[3]) + 2-byte struct align tail → 312.
+		// The IPv6 trailer was added by P5; pre-P5 size was 292
+		// (header+payload+2-byte tail pad).
+		{"tls_sniff_event", uintptr(tlsSniffEventWireSize), uintptr(tlsSniffEventHeaderSize + tlsPayloadMax + 16 + 1 + 3 + 2)},
 		{"http_sniff_event_header", uintptr(httpSniffEventHeaderSize), uintptr(4 + 4 + 16 + 4 + 2 + 2 + 2)},
 		{"tls_sniff_event_header", uintptr(tlsSniffEventHeaderSize), uintptr(4 + 4 + 16 + 4 + 2 + 2 + 2)},
 		{"deny_event", uintptr(denyEventWireSize), uintptr(4 + 4 + 16 + 1 + 1 + 1 + 1 + 16 + 2)},

--- a/internal/agent/agent_linux_decode.go
+++ b/internal/agent/agent_linux_decode.go
@@ -89,10 +89,13 @@ func decodeHTTPSniffEvent(raw []byte) (tgid, tid uint32, comm [16]byte, daddr [4
 
 const tlsPayloadMax = 256
 
-// decodeTLSSniffEvent parses tls_sniff_event (same wire layout as http_sniff_event with TLS_PAYLOAD_MAX).
-func decodeTLSSniffEvent(raw []byte) (tgid, tid uint32, comm [16]byte, daddr [4]byte, dport uint16, payload []byte, ok bool) {
+// decodeTLSSniffEvent parses tls_sniff_event (header + payload[256] + IPv6 trailer).
+// IPv4 path: isIPv6=false, daddr6 zeroed. IPv6 path: isIPv6=true, daddr zeroed
+// in BPF and the v6 address is carried in daddr6. The wire layout preserves
+// pre-P5 IPv4 byte positions; the IPv6 trailer is appended after payload.
+func decodeTLSSniffEvent(raw []byte) (tgid, tid uint32, comm [16]byte, daddr [4]byte, dport uint16, payload []byte, daddr6 [16]byte, isIPv6 bool, ok bool) {
 	if len(raw) < tlsSniffEventWireSize {
-		return 0, 0, [16]byte{}, [4]byte{}, 0, nil, false
+		return 0, 0, [16]byte{}, [4]byte{}, 0, nil, [16]byte{}, false, false
 	}
 	tgid = binary.LittleEndian.Uint32(raw[0:4])
 	tid = binary.LittleEndian.Uint32(raw[4:8])
@@ -103,11 +106,13 @@ func decodeTLSSniffEvent(raw []byte) (tgid, tid uint32, comm [16]byte, daddr [4]
 	// capLen is derived from Uint16 and cast to int on a 64-bit system;
 	// it is always in [0, 65535]. Only the upper bound needs checking.
 	if capLen > tlsPayloadMax {
-		return 0, 0, [16]byte{}, [4]byte{}, 0, nil, false
+		return 0, 0, [16]byte{}, [4]byte{}, 0, nil, [16]byte{}, false, false
 	}
 	payload = make([]byte, capLen)
 	copy(payload, raw[tlsSniffEventHeaderSize:tlsSniffEventHeaderSize+capLen])
-	return tgid, tid, comm, daddr, dport, payload, true
+	copy(daddr6[:], raw[tlsSniffEventIPv6Offset:tlsSniffEventIPv6Offset+16])
+	isIPv6 = raw[tlsSniffEventIPv6Offset+16] != 0
+	return tgid, tid, comm, daddr, dport, payload, daddr6, isIPv6, true
 }
 
 // decodeDNSSniffSample parses dns_sniff_event (trace_dns.bpf.c): len, is_tcp, pad, payload.

--- a/internal/agent/agent_linux_ring_read.go
+++ b/internal/agent/agent_linux_ring_read.go
@@ -459,7 +459,7 @@ func readTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, pol
 		// flipped to unknown/ktls (Bug-1 fix).
 		tlsRecvAtNs := time.Now().UnixNano()
 
-		tgid, tid, commb, daddr, port, rawPay, ok := decodeTLSSniffEvent(record.RawSample)
+		tgid, tid, commb, daddr, port, rawPay, daddr6, isIPv6, ok := decodeTLSSniffEvent(record.RawSample)
 		if !ok {
 			if sectionState != nil {
 				sectionState.addTLSDecodeError()
@@ -468,9 +468,20 @@ func readTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, pol
 			slog.Warn("decode tls sniff", "len", len(record.RawSample))
 			continue
 		}
-		ip := net.IP(daddr[:]).To4()
-		if ip == nil {
-			continue
+		var ip net.IP
+		var remote string
+		if isIPv6 {
+			ip = net.IP(daddr6[:])
+			if len(ip) != net.IPv6len {
+				continue
+			}
+			remote = fmt.Sprintf("`[%s]:%d`", ip.String(), port)
+		} else {
+			ip = net.IP(daddr[:]).To4()
+			if ip == nil {
+				continue
+			}
+			remote = fmt.Sprintf("`%s:%d`", ip.String(), port)
 		}
 		comm := telemetry.SanitizeField(nullTermStr(commb[:]), 16)
 		sni, parsed := telemetry.ParseClientHelloSNI(rawPay)
@@ -481,6 +492,16 @@ func readTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, pol
 			// and retry. This recovers the Go crypto/tls and rustls header/body
 			// split where the 5-byte record header lands in one write() and the
 			// handshake body lands in the next.
+			//
+			// P5: skip reassembly for IPv6 — tlsReassemblyKey keys on the v4
+			// daddr ([4]byte), which would collapse to {0,0,0,0} for every
+			// IPv6 stream and cause cross-connection collisions. Extending
+			// the key shape is out of scope for the SNI-only P5 increment;
+			// fragmented v6 handshakes fall through to tls_sni_parse drop.
+			if isIPv6 {
+				stats.addDropped("tls_sni_parse")
+				continue
+			}
 			res := reasm.appendAndParse(tlsReassemblyKey{PID: tgid, Dst: daddr, Dport: port}, rawPay)
 			if !res.parsed {
 				stats.addDropped("tls_sni_parse")
@@ -514,7 +535,7 @@ func readTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, pol
 		rows.addTLS(report.TLSDigestRow{
 			TS: ts, PID: tgid, Comm: comm,
 			SNI:              sni,
-			Remote:           fmt.Sprintf("`%s:%d`", ip.String(), port),
+			Remote:           remote,
 			Policy:           cl.Display(),
 			Confidence:       conf,
 			ConfidenceReason: confReason,
@@ -535,6 +556,7 @@ func readTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, pol
 				ConfidenceReason: confReason,
 				ReassembledSNI:   reassembled,
 				Dst:              ip.String(), Dport: port,
+				IsIPv6: isIPv6,
 				Policy: string(cl),
 				Note:   note,
 			}

--- a/internal/agent/agent_linux_state_sections.go
+++ b/internal/agent/agent_linux_state_sections.go
@@ -149,13 +149,16 @@ const (
 	connectEventWireSize   = 32  // 4+4+16+4+2 fields, aligned to 4 → 32
 	udpSendEventWireSize   = 36  // 4+4+16+4+2+_pad[2]+4 datagram_len → 36
 	httpSniffEventWireSize = 228 // 4+4+16+4+2+_pad[2]+2+payload[192] → 228
-	tlsSniffEventWireSize  = 292 // 4+4+16+4+2+_pad[2]+2+payload[256] → 292
-	execEventWireSize      = 280 // 4+4+16+exe_path[256] → 280
-	forkEventWireSize      = 48  // 4+4+parent_comm[16]+child_comm[16]+4(sid)+4(pidns) → 48
-	fsEventWireSize        = 284 // 4+4+16+1+path[256]+_pad[3] → 284
-	denyEventWireSize      = 46  // packed: 4+4+16+1+1+1+_pad+daddr[16]+dport[2] → 46
-	bpfAuditEventWireSize  = 28  // 4(tgid)+4(tid)+4(cmd)+comm[16] → 28
-	ktlsEventWireSize      = 32  // 4(tgid)+4(tid)+comm[16]+4(fd)+1(direction)+_pad[3] → 32
+	// tlsSniffEventWireSize: legacy v4 header(34) + payload[256] + ipv6 trailer(20) → 312.
+	// IPv6 trailer = daddr6[16] + is_ipv6(1) + _pad_v6[3]. Layout chosen so the
+	// IPv4 bytes (offsets 0..289) stay byte-identical to the pre-P5 wire format.
+	tlsSniffEventWireSize = 312
+	execEventWireSize     = 280 // 4+4+16+exe_path[256] → 280
+	forkEventWireSize     = 48  // 4+4+parent_comm[16]+child_comm[16]+4(sid)+4(pidns) → 48
+	fsEventWireSize       = 284 // 4+4+16+1+path[256]+_pad[3] → 284
+	denyEventWireSize     = 46  // packed: 4+4+16+1+1+1+_pad+daddr[16]+dport[2] → 46
+	bpfAuditEventWireSize = 28  // 4(tgid)+4(tid)+4(cmd)+comm[16] → 28
+	ktlsEventWireSize     = 32  // 4(tgid)+4(tid)+comm[16]+4(fd)+1(direction)+_pad[3] → 32
 	// tcp_state_event (P3-2b): 8(timestamp_ns)+4(pid)+4(saddr)+4(daddr)+2(sport)+2(dport)+4(old_state)+4(new_state)+16(comm) → 48
 	tcpStateEventWireSize = 48
 	// trace_dns.bpf.c dns_sniff_event: __u32 len + __u8 is_tcp + __u8 _pad[3] + data[DNS_SNIFF_MAX]
@@ -167,6 +170,9 @@ const (
 	// out the payload window. Pair these with the respective WireSize above.
 	httpSniffEventHeaderSize = 34 // 4+4+16+4+2+_pad[2]+2 capture_len
 	tlsSniffEventHeaderSize  = 34 // same layout
+	// Offset of the IPv6 trailer (daddr6[16] + is_ipv6 + _pad_v6[3]) inside a
+	// tls_sniff_event. Equals tlsSniffEventHeaderSize + tlsPayloadMax.
+	tlsSniffEventIPv6Offset = tlsSniffEventHeaderSize + tlsPayloadMax
 
 	// After the first defend deny, read additional deny ringbuf records briefly so JSONL/digest
 	// capture a burst (e.g. TCP + UDP) before fail-fast shutdown.

--- a/internal/agent/decode_network_linux_test.go
+++ b/internal/agent/decode_network_linux_test.go
@@ -5,6 +5,8 @@ package agent
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"net"
 	"testing"
 
 	"github.com/coldstep-io/coldstep/internal/telemetry"
@@ -140,19 +142,25 @@ func TestDecodeTLSSniffEvent_captureLenAtMax(t *testing.T) {
 		raw[tlsSniffEventHeaderSize+i] = byte(i)
 	}
 
-	_, _, _, _, _, pay, ok := decodeTLSSniffEvent(raw)
+	_, _, _, daddr, _, pay, _, isIPv6, ok := decodeTLSSniffEvent(raw)
 	if !ok {
 		t.Fatal("expected ok when capture_len == tlsPayloadMax")
 	}
 	if len(pay) != tlsPayloadMax {
 		t.Fatalf("payload len %d", len(pay))
 	}
+	if isIPv6 {
+		t.Fatal("isIPv6 should be false for zeroed trailer")
+	}
+	if daddr != [4]byte{9, 9, 9, 9} {
+		t.Fatalf("daddr %v", daddr)
+	}
 }
 
 func TestDecodeTLSSniffEvent_captureLenTooLarge(t *testing.T) {
 	raw := make([]byte, tlsSniffEventWireSize)
 	binary.LittleEndian.PutUint16(raw[32:34], tlsPayloadMax+1)
-	_, _, _, _, _, _, ok := decodeTLSSniffEvent(raw)
+	_, _, _, _, _, _, _, _, ok := decodeTLSSniffEvent(raw)
 	if ok {
 		t.Fatal("expected false for capLen > tlsPayloadMax")
 	}
@@ -421,6 +429,51 @@ func TestClassifyConnectRingRecord(t *testing.T) {
 				t.Errorf("classifyConnectRingRecord = %d, want %d", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestDecodeTLSSniffEvent_IPv6 exercises the P5 IPv6 trailer: a hand-crafted
+// wire event with is_ipv6=1 + a v6 address in daddr6 must decode with
+// isIPv6==true and daddr6 populated.
+func TestDecodeTLSSniffEvent_IPv6(t *testing.T) {
+	raw := make([]byte, tlsSniffEventWireSize)
+	binary.LittleEndian.PutUint32(raw[0:4], 400)
+	binary.LittleEndian.PutUint32(raw[4:8], 401)
+	copy(raw[8:24], []byte("curl6\x00"))
+	// IPv6 path: BPF zeroes daddr; v6 address lives in the trailer.
+	binary.BigEndian.PutUint16(raw[28:30], 443)
+	binary.LittleEndian.PutUint16(raw[32:34], 0)
+	// 2001:db8::1
+	v6 := [16]byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01}
+	copy(raw[tlsSniffEventIPv6Offset:tlsSniffEventIPv6Offset+16], v6[:])
+	raw[tlsSniffEventIPv6Offset+16] = 1 // is_ipv6
+
+	_, _, _, daddr, dport, _, daddr6, isIPv6, ok := decodeTLSSniffEvent(raw)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if !isIPv6 {
+		t.Fatal("expected isIPv6=true")
+	}
+	if daddr != [4]byte{} {
+		t.Fatalf("expected zeroed daddr on IPv6 path, got %v", daddr)
+	}
+	if daddr6 != v6 {
+		t.Fatalf("daddr6 %v != %v", daddr6, v6)
+	}
+	if dport != 443 {
+		t.Fatalf("dport %d", dport)
+	}
+
+	// readTLSRing formats the rendered remote string using bracket notation
+	// for IPv6 — exercise the same path so digest rendering is locked in.
+	ip := net.IP(daddr6[:])
+	if ip.To4() != nil {
+		t.Fatalf("v6 address must not coerce to To4: %s", ip)
+	}
+	remote := fmt.Sprintf("`[%s]:%d`", ip.String(), dport)
+	if remote != "`[2001:db8::1]:443`" {
+		t.Fatalf("bracketed remote = %q, want `[2001:db8::1]:443`", remote)
 	}
 }
 

--- a/internal/bpf/traceconnect/abi_test.go
+++ b/internal/bpf/traceconnect/abi_test.go
@@ -69,8 +69,11 @@ func TestTraceconnectMapShapes(t *testing.T) {
 		if ms.KeySize != 8 {
 			t.Errorf("connect4_by_tgid_fd KeySize = %d, want 8", ms.KeySize)
 		}
-		if ms.ValueSize != 8 {
-			t.Errorf("connect4_by_tgid_fd ValueSize = %d, want 8", ms.ValueSize)
+		// P5: connect4_tuple grew from 8 → 24 bytes
+		// (daddr[4] + dport[2] + in_use + is_ipv6 + daddr6[16]) so the LRU
+		// map value carries the v6 address for IPv6 TLS attribution.
+		if ms.ValueSize != 24 {
+			t.Errorf("connect4_by_tgid_fd ValueSize = %d, want 24", ms.ValueSize)
 		}
 	})
 

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -307,6 +307,9 @@ func ScoreTLSConfidence(sni string) TLSConfidence {
 }
 
 // TLSEvent is one JSONL record for TLS ClientHello SNI observed on egress (detect).
+// Dst holds either a dotted-quad IPv4 (e.g. "1.2.3.4") or a plain IPv6 string
+// (e.g. "2001:db8::1") with no brackets — IsIPv6 distinguishes the two. The
+// markdown digest applies "[…]:port" bracket notation when rendering IPv6.
 type TLSEvent struct {
 	Type       string        `json:"type"` // "tls"
 	TS         string        `json:"ts"`
@@ -336,6 +339,7 @@ type TLSEvent struct {
 	ReassembledSNI bool   `json:"reassembled_sni,omitempty"`
 	Dst            string `json:"dst"`
 	Dport          uint16 `json:"dport"`
+	IsIPv6         bool   `json:"ipv6,omitempty"`
 	Policy         string `json:"policy"`
 	Note           string `json:"note,omitempty"`
 	Sig            string `json:"sig,omitempty"`


### PR DESCRIPTION
## Summary

- Wire IPv6 destinations through the TLS ClientHello sniff path so IPv6 connects no longer land with `confidence=unknown`. Pre-P5 the connect hook only parsed `AF_INET` sockaddrs, so IPv6 entries never reached the `(tgid,fd)` tuple LRU and the ringbuf event carried no v6 fields.
- BPF side: `connect4_tuple` grows 8 → 24 bytes (adds `daddr6[16]` + `is_ipv6`); `tls_sniff_event` grows 292 → 312 bytes by **appending** a 20-byte IPv6 trailer after `payload` so the legacy IPv4 wire layout (offsets 0..289) is byte-identical. New `coldstep_parse_ipv6_sockaddr24` + `handle_tcp_obs_connect6`. Both v4 and v6 handlers fire on every `NR_CONNECT` and bail on family mismatch.
- Go side: `decodeTLSSniffEvent` returns `daddr6` + `isIPv6`; `readTLSRing` brackets IPv6 as `[2001:db8::1]:port` in the digest; `TLSEvent.IsIPv6` (new) marks the JSONL row. `Dst` carries the plain v6 string (no brackets) in JSONL.
- Defend / HTTP / UDP are unchanged (out of scope — they use IPv4-only wire shapes); explicit guards in `try_emit_buffer_sniff_from_tuple` and `coldstep_tuple_dst_for_fd` skip v6 tuples so HTTP / sendfile / splice fallback paths don't emit `0.0.0.0` records.
- Tests: new host C test for `coldstep_parse_ipv6_sockaddr24`; new Go test `TestDecodeTLSSniffEvent_IPv6` hand-crafts an `is_ipv6=1` wire event and asserts the v6 trailer decodes and renders as `` `[v6]:port` ``. Updated wire-size constants + `connect4_by_tgid_fd` ValueSize ABI guard (8 → 24).

## Test plan

- [x] `bash scripts/build-agent-linux.sh` (Linux via WSL) — agent/action/report binaries + BPF objects + host C unit tests build clean
- [x] `go test ./... -count=1` — all packages green
- [x] `go test -race ./internal/agent/...` — green
- [x] `gofmt -l internal/agent internal/telemetry internal/report bpf` — clean
- [ ] CI: unit (ubuntu-latest + ubuntu-22.04 amd64), unit-arm64 matrix, integration (root + BPF), action_bundle, detect-mode, defend-mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
