### PR TITLE
feat(bpf): P6 Phase 1 — io_uring write-class submission detection

### DIFF
--- a/.github/pr-bodies/pr-p6-io-uring-detect.md
+++ b/.github/pr-bodies/pr-p6-io-uring-detect.md
@@ -1,0 +1,44 @@
+## Summary
+
+Implements **P6 Phase 1** — io_uring write-class submission detection via `SEC("raw_tp/io_uring_submit_sqe")` (kernel 5.14+). io_uring submissions bypass the syscall hooks used elsewhere in detect mode; the existing `io-uring-disable` sysctl gate is the primary defense, and this is the runtime fallback that surfaces SQEs when the gate is bypassed or off.
+
+## What changed
+
+- **`bpf/trace_connect_obs.h`** — `struct io_uring_send_event` (40 bytes, `_Static_assert`-locked: 8 ts + 4 pid + 4 fd + 4 daddr + 2 dport + 1 op + 1 _pad + 16 comm).
+- **`bpf/trace_connect.bpf.c`** — `io_uring_events` ringbuf (64 KiB), `io_uring_ringbuf_reserve_failures` per-cpu counter, and `SEC("raw_tp/io_uring_submit_sqe")` handler. Filter is `IORING_OP_SENDMSG` (9) and `IORING_OP_SEND` (26) — both unambiguously network sends, so emission does not need fd→socket resolution. The C source touches only `req->opcode`, so it compiles against any vmlinux.h that exposes `struct io_kiocb` (5.1+). `IORING_OP_WRITE` / `IORING_OP_WRITEV` arrive in Phase 2 alongside fd resolution (struct `io_cqe` is post-5.15 and not stable in older vmlinux BTF).
+- **`internal/telemetry/event.go`** — `IOUringSendEvent` JSONL type (`type: "io_uring_send"`).
+- **`internal/telemetry/telemetry.go`** — `Summary.IoUringSendTotal` and `IoUringRingbufReserveFailures`.
+- **`internal/agent/agent_linux_bpf_start.go`** — `startIoUringTrace` does a best-effort attach on the already-loaded traceconnect collection; failure (older kernel, missing tracepoint) yields a degraded `BPFStatus` row rather than failing the agent.
+- **`internal/agent/agent_linux.go`** — registers the new ringbuf reader, defer block for stats sampling, and reader goroutine wiring.
+- **`internal/agent/agent_linux_ring_read.go`** — `readIoUringRing` drains the ringbuf, decodes via `decodeIOUringSendEvent`, maps the raw IORING_OP_ byte → string label, and appends JSONL.
+- **`internal/agent/agent_linux_decode.go`** — `decodeIOUringSendEvent` + `ioUringOpName` (`2 → WRITEV`, `9 → SENDMSG`, `23 → WRITE`, `26 → SEND`, else UNKNOWN — values forward-compat for Phase 2).
+- **`internal/agent/agent_linux_state*.go`** — `ioUringSendN` + `ioUringRingbufReserveFailuresN` counters, accessors, snapshot wiring.
+- **`internal/agent/agent_linux_policy_maps.go`** — `readIoUringRingbufReserveFailureCount`.
+- **`internal/report/digest_types.go`** — `DigestInput.IoUringSendTotal` and `IoUringRingbufReserveFailures`.
+- **`internal/report/digest.go`** — KPI row (`**io_uring writes** | N network sends observed (SNI extraction not possible)`), gap-parts entry in the triage ribbon, Technical-details narrative. All hidden when zero.
+- **`action.yml`** — `io-uring-disable` description notes the Phase 1 detection fallback; sysctl disable remains the primary defense.
+
+## Phase 1 scope (deliberate)
+
+- **SEND/SENDMSG only.** Both opcodes are unambiguously socket sends. Emit without fd→socket resolution.
+- **No payload sniff.** The SQE submission point holds no userspace buffer state; SNI / HTTP cannot be extracted here. This is detection visibility only.
+- **Graceful kernel-version fallback.** Attach failure (kernel < 5.14) marks the new BPFStatus row degraded; the agent continues. Detected via `link.AttachRawTracepoint` returning `ENOENT`.
+- **No feature gate.** The probe is narrowly filtered (two socket opcodes), so it stays cheap on workloads that don't use io_uring; always-attempt avoids the operator-flag complexity of `tls_sni` / `fs_events`.
+
+## Constraints honored
+
+- Two modes only (`detect`, `defend`) — no `enforce` references introduced.
+- Generated BPF artifacts (`bpf/vmlinux.h`, `internal/bpf/**/*_bpfel.go`, `*_bpfeb.go`) not committed.
+- gofmt clean, encoding scan clean.
+- `go vet` + cross-platform tests pass locally; Linux BPF compile + integration covered by `coldstep-ci-runner.yml`.
+
+## Tests
+
+- `internal/agent/abi_wire_linux_test.go` — `io_uring_send_event` wire size guard (`8+4+4+4+2+1+1+16 == 40`), paired with `_Static_assert(sizeof(struct io_uring_send_event) == 40)` in `bpf/trace_connect_obs.h`.
+- `internal/agent/decode_network_linux_test.go` — `decodeIOUringSendEvent` round-trip (all fields), too-short rejection, op-byte → string mapping for all four future opcodes plus UNKNOWN.
+- `internal/report/digest_test.go` — KPI row hidden when `IoUringSendTotal == 0`, visible (with triage-ribbon gap-parts entry) when non-zero.
+
+## Follow-ups (out of scope)
+
+- **P6 Phase 2** — extend to `IORING_OP_WRITE` / `IORING_OP_WRITEV`, paired with fd→socket resolution (requires `struct io_cqe` BTF or an alternate fd-lookup path) so file I/O does not flood.
+- Defend-mode enforcement of io_uring egress (separate track; Phase 1 is detect-only).

--- a/action.yml
+++ b/action.yml
@@ -157,7 +157,11 @@ inputs:
     description: >-
       Internal. When true (default), disables io_uring via sysctl before the agent starts.
       io_uring operations bypass syscall-based eBPF hooks; disabling it closes the single
-      largest evasion vector for CI workloads that do not need io_uring.
+      largest evasion vector for CI workloads that do not need io_uring. P6 Phase 1 also
+      adds best-effort detection via raw_tp/io_uring_submit_sqe (kernel 5.14+) that
+      surfaces socket-class io_uring SQEs (SEND, SENDMSG) in the JSONL stream and digest
+      when the sysctl gate is bypassed or set to false; the sysctl disable remains the
+      primary defense.
     required: false
     default: 'true'
 

--- a/bpf/trace_connect.bpf.c
+++ b/bpf/trace_connect.bpf.c
@@ -255,6 +255,24 @@ struct {
 } tcp_state_events SEC(".maps");
 
 /*
+ * P6 Phase 1: io_uring write-class SQE ringbuf. 64 KiB is plenty — events are
+ * already filtered to four write-class opcodes on tracked sockets, so volume
+ * is bounded by the rate of legitimate io_uring network egress. Larger sizes
+ * would only hide downstream pipeline pressure rather than gate it.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(max_entries, 1 << 16);
+} io_uring_events SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__type(value, __u32);
+} io_uring_ringbuf_reserve_failures SEC(".maps");
+
+/*
  * AUDIT(5a): null checked — every `note_*` counter helper below follows the
  * same pattern: bpf_map_lookup_elem then `if (!v) return;` before deref.
  */
@@ -351,6 +369,16 @@ static __always_inline void note_io_uring_setup_observed(void)
 {
 	__u32 k = 0;
 	__u32 *v = bpf_map_lookup_elem(&io_uring_setup_observed, &k);
+
+	if (!v)
+		return;
+	(*v)++;
+}
+
+static __always_inline void note_io_uring_ringbuf_reserve_failed(void)
+{
+	__u32 k = 0;
+	__u32 *v = bpf_map_lookup_elem(&io_uring_ringbuf_reserve_failures, &k);
 
 	if (!v)
 		return;
@@ -798,6 +826,70 @@ int handle_inet_sock_set_state(struct trace_event_raw_inet_sock_set_state *ctx)
 	ev->old_state = oldstate;
 	ev->new_state = newstate;
 
+	bpf_ringbuf_submit(ev, 0);
+	return 0;
+}
+
+/*
+ * P6 Phase 1: io_uring write-class submission visibility.
+ *
+ * Raw tracepoint signature (kernel 5.14+):
+ *
+ *	TRACE_EVENT(io_uring_submit_sqe,
+ *		    TP_PROTO(struct io_kiocb *req, bool force_nonblock))
+ *
+ * Filter to socket-class submission opcodes — IORING_OP_SENDMSG (9) and
+ * IORING_OP_SEND (26) — values from include/uapi/linux/io_uring.h
+ * (`enum io_uring_op`, stable since 5.1). Both are unambiguously network
+ * sends so we can emit the event without resolving the SQE's fd back to a
+ * socket. IORING_OP_WRITE (23) and IORING_OP_WRITEV (2) are deliberately
+ * out of scope for Phase 1: their fd may be a regular file, and the
+ * generic `req->fd` / `req->cqe.fd` field that would let us distinguish
+ * socket vs file writes only appears on kernels whose vmlinux BTF carries
+ * `struct io_cqe` (post-5.15). Adding them without fd resolution would
+ * flood the ringbuf on routine file I/O — Phase 2 will pair the WRITE /
+ * WRITEV arms with a robust fd → socket check.
+ *
+ * Destination tuple is best-effort: `req->opcode` is the only field we read
+ * from io_kiocb in Phase 1, so the C source compiles against any vmlinux.h
+ * that already exposes struct io_kiocb (kernel 5.1+). daddr/dport are zero
+ * in the emitted event — Phase 2 will populate them once fd resolution lands.
+ */
+#define COLDSTEP_IORING_OP_SENDMSG 9
+#define COLDSTEP_IORING_OP_SEND    26
+
+SEC("raw_tp/io_uring_submit_sqe")
+int trace_io_uring_submit_sqe(struct bpf_raw_tracepoint_args *ctx)
+{
+	struct io_kiocb *req = (struct io_kiocb *)ctx->args[0];
+
+	if (!req)
+		return 0;
+
+	__u8 opcode = 0;
+
+	if (bpf_core_read(&opcode, sizeof(opcode), &req->opcode))
+		return 0;
+
+	if (opcode != COLDSTEP_IORING_OP_SENDMSG &&
+	    opcode != COLDSTEP_IORING_OP_SEND)
+		return 0;
+
+	struct io_uring_send_event *ev =
+		bpf_ringbuf_reserve(&io_uring_events, sizeof(*ev), 0);
+
+	if (!ev) {
+		note_io_uring_ringbuf_reserve_failed();
+		return 0;
+	}
+	ev->timestamp_ns = bpf_ktime_get_ns();
+	ev->pid = (__u32)(bpf_get_current_pid_tgid() >> 32);
+	ev->fd = 0;
+	__builtin_memset(ev->daddr, 0, sizeof(ev->daddr));
+	__builtin_memset(ev->dport, 0, sizeof(ev->dport));
+	ev->op = opcode;
+	ev->_pad = 0;
+	bpf_get_current_comm(&ev->comm, sizeof(ev->comm));
 	bpf_ringbuf_submit(ev, 0);
 	return 0;
 }

--- a/bpf/trace_connect_obs.h
+++ b/bpf/trace_connect_obs.h
@@ -256,6 +256,31 @@ struct tcp_state_event {
 _Static_assert(sizeof(struct tcp_state_event) == 48,
 	       "tcp_state_event wire size must match tcpStateEventWireSize=48 in agent_linux.go");
 
+/*
+ * P6 Phase 1: io_uring write-class submission visibility.
+ *
+ * Emitted by SEC("raw_tp/io_uring_submit_sqe") in trace_connect.bpf.c when
+ * the SQE opcode is IORING_OP_SENDMSG (9) or IORING_OP_SEND (26) — both
+ * unambiguously socket sends, so the event can be emitted without resolving
+ * the SQE's fd back to a tracked socket. Phase 1 leaves `fd`, `daddr`, and
+ * `dport` zero; Phase 2 will add WRITE/WRITEV with fd→socket resolution.
+ *
+ * Layout: 8 + 4 + 4 + 4 + 2 + 1 + 1 + 16 = 40 bytes, alignment-of-8 → no
+ * trailing pad. Locked by the _Static_assert below.
+ */
+struct io_uring_send_event {
+	__u64 timestamp_ns;
+	__u32 pid;
+	__u32 fd;
+	__u8 daddr[4];
+	__u8 dport[2];
+	__u8 op;
+	__u8 _pad;
+	__u8 comm[16];
+};
+_Static_assert(sizeof(struct io_uring_send_event) == 40,
+	       "io_uring_send_event wire size must match ioUringSendEventWireSize=40 in agent_linux.go");
+
 static __always_inline int read_ipv4_sockaddr(unsigned long sockaddr_ptr, __be16 *port,
 					      __be32 *addr)
 {

--- a/internal/agent/abi_wire_linux_test.go
+++ b/internal/agent/abi_wire_linux_test.go
@@ -48,6 +48,7 @@ func TestNetworkAndAuditWireSizes(t *testing.T) {
 		{"deny_event", uintptr(denyEventWireSize), uintptr(4 + 4 + 16 + 1 + 1 + 1 + 1 + 16 + 2)},
 		{"bpf_audit_event", uintptr(bpfAuditEventWireSize), uintptr(4 + 4 + 4 + 16)},
 		{"tcp_state_event", uintptr(tcpStateEventWireSize), uintptr(8 + 4 + 4 + 4 + 2 + 2 + 4 + 4 + 16)},
+		{"io_uring_send_event", uintptr(ioUringSendEventWireSize), uintptr(8 + 4 + 4 + 4 + 2 + 1 + 1 + 16)},
 		{"dns_sniff_event_legacy", uintptr(dnsSniffEventWireSizeLegacy), uintptr(4 + dnsSniffMaxPayload)},
 		{"dns_sniff_event", uintptr(dnsSniffEventWireSize), uintptr(4 + 1 + 3 + dnsSniffMaxPayload)},
 		{"ktls_event", uintptr(ktlsEventWireSize), uintptr(4 + 4 + 16 + 4 + 1 + 3)},

--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -156,13 +156,15 @@ func Run(ctx context.Context, cfg config.Config) error {
 	dnsCache := NewDNSCache()
 	dnsCache.SetBPFFailureCallback(stats.addDNSCacheUpdateFailure)
 
-	var connRd, udpRd, httpRd, tlsRd, tcpStateRd ringReader
+	var connRd, udpRd, httpRd, tlsRd, tcpStateRd, ioUringRd ringReader
 	defer connRd.Close()
 	defer udpRd.Close()
 	defer httpRd.Close()
 	defer tlsRd.Close()
 	defer tcpStateRd.Close()
+	defer ioUringRd.Close()
 	var tcpStateLnk link.Link
+	var ioUringLnk link.Link
 
 	var denyRd ringReader
 	defer denyRd.Close()
@@ -470,6 +472,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 				stats.setPartialEgressObserved(sendfileN, spliceN, sendmmsgN)
 				stats.setIoUringSetupObserved(readUint32PerCPUArraySum(syscallObjs.IoUringSetupObserved, "io_uring_setup_observed"))
 				stats.setTCPStateRingbufReserveFailures(readUint32PerCPUArraySum(syscallObjs.TcpStateRingbufReserveFailures, "tcp_state_ringbuf_reserve_failures"))
+				stats.setIoUringRingbufReserveFailures(readUint32PerCPUArraySum(syscallObjs.IoUringRingbufReserveFailures, "io_uring_ringbuf_reserve_failures"))
 			}
 		}()
 		// Ring readers are closed exactly once via ringReader.Close (runCtx shutdown goroutine + deferred Close).
@@ -501,6 +504,30 @@ func Run(ctx context.Context, cfg config.Config) error {
 					}
 				}()
 			}
+		}
+
+		// P6 Phase 1: best-effort attach of raw_tp/io_uring_submit_sqe. On
+		// kernels < 5.14 the tracepoint doesn't exist — degrade to a BPFStatus
+		// row rather than failing the agent. The probe is filtered to two
+		// write-class opcodes (SENDMSG=9, SEND=26) so volume stays bounded
+		// even when many io_uring users are active.
+		if rd, lnk, ioErr := startIoUringTrace(syscallObjs); ioErr != nil {
+			slog.Info("io_uring submit_sqe tracing disabled", "err", ioErr)
+			bpfSt = append(bpfSt, telemetry.BPFStatus{
+				Name:   "raw_tp/io_uring_submit_sqe",
+				OK:     false,
+				Detail: bpfDetail(ioErr),
+			})
+		} else {
+			ioUringLnk = lnk
+			ioUringRd.R = rd
+			bpfSt = append(bpfSt, telemetry.BPFStatus{Name: "raw_tp/io_uring_submit_sqe", OK: true})
+			slog.Info("tracing io_uring write-class submissions (raw_tp/io_uring_submit_sqe)")
+			defer func() {
+				if ioUringLnk != nil {
+					_ = ioUringLnk.Close()
+				}
+			}()
 		}
 	}
 
@@ -758,6 +785,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 		httpRd.Close()
 		tlsRd.Close()
 		tcpStateRd.Close()
+		ioUringRd.Close()
 		denyRd.Close()
 		lsmDenyRd.Close()
 		dnsRd.Close()
@@ -790,6 +818,9 @@ func Run(ctx context.Context, cfg config.Config) error {
 		readerCount++
 	}
 	if tcpStateRd.R != nil {
+		readerCount++
+	}
+	if ioUringRd.R != nil {
 		readerCount++
 	}
 	if denyRd.R != nil {
@@ -958,6 +989,13 @@ func Run(ctx context.Context, cfg config.Config) error {
 		go func() {
 			defer wg.Done()
 			sendReaderErr(readTCPStateRing(runCtx, cfg, tcpStateRd.R, stats, &seq, &jsonlMu, sectionState, signer))
+		}()
+	}
+	if ioUringRd.R != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sendReaderErr(readIoUringRing(runCtx, cfg, ioUringRd.R, stats, &seq, &jsonlMu, signer))
 		}()
 	}
 	if denyRd.R != nil {

--- a/internal/agent/agent_linux_bpf_start.go
+++ b/internal/agent/agent_linux_bpf_start.go
@@ -153,6 +153,34 @@ func startKTLSTrace() (rd *ringbuf.Reader, objs *tracektls.TracektlsObjects, lnk
 	return rd, objs, lnk, nil
 }
 
+// startIoUringTrace attaches SEC("raw_tp/io_uring_submit_sqe") from the
+// already-loaded traceconnect collection and opens the io_uring_events
+// ringbuf reader. The raw tracepoint exists on kernels 5.14+; on older
+// kernels link.AttachRawTracepoint returns ENOENT — callers translate that
+// into a degraded BPFStatus row but keep the agent running (P6 Phase 1
+// detection is best-effort).
+func startIoUringTrace(objs *traceconnect.TraceconnectObjects) (*ringbuf.Reader, link.Link, error) {
+	if objs == nil {
+		return nil, nil, fmt.Errorf("io_uring trace: traceconnect objects not loaded")
+	}
+	if objs.TraceIoUringSubmitSqe == nil {
+		return nil, nil, fmt.Errorf("io_uring trace: program absent from collection")
+	}
+	lnk, err := link.AttachRawTracepoint(link.RawTracepointOptions{
+		Name:    "io_uring_submit_sqe",
+		Program: objs.TraceIoUringSubmitSqe,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	rd, err := ringbuf.NewReader(objs.IoUringEvents)
+	if err != nil {
+		_ = lnk.Close()
+		return nil, nil, err
+	}
+	return rd, lnk, nil
+}
+
 func startBPFAuditTrace() (rd *ringbuf.Reader, objs *tracebpfaudit.TracebpfauditObjects, lnk link.Link, err error) {
 	objs = new(tracebpfaudit.TracebpfauditObjects)
 	if err = tracebpfaudit.LoadTracebpfauditObjects(objs, nil); err != nil {

--- a/internal/agent/agent_linux_decode.go
+++ b/internal/agent/agent_linux_decode.go
@@ -207,6 +207,42 @@ func decodeTCPStateEvent(raw []byte) (timestampNS uint64, pid uint32, saddr, dad
 	return timestampNS, pid, saddr, daddr, sport, dport, oldState, newState, comm, true
 }
 
+// decodeIOUringSendEvent parses io_uring_send_event (40 bytes, see
+// bpf/trace_connect_obs.h). Layout: ts(8) pid(4) fd(4) daddr(4) dport(2)
+// op(1) _pad(1) comm(16). dport is stored in network byte order (mirrors
+// the connect4_tuple cache), daddr is raw 4-byte big-endian.
+func decodeIOUringSendEvent(raw []byte) (ts uint64, pid uint32, fd uint32, daddr [4]byte, dport uint16, op uint8, comm [16]byte, ok bool) {
+	if len(raw) < ioUringSendEventWireSize {
+		return 0, 0, 0, [4]byte{}, 0, 0, [16]byte{}, false
+	}
+	ts = binary.LittleEndian.Uint64(raw[0:8])
+	pid = binary.LittleEndian.Uint32(raw[8:12])
+	fd = binary.LittleEndian.Uint32(raw[12:16])
+	copy(daddr[:], raw[16:20])
+	dport = binary.BigEndian.Uint16(raw[20:22])
+	op = raw[22]
+	// raw[23] is _pad
+	copy(comm[:], raw[24:40])
+	return ts, pid, fd, daddr, dport, op, comm, true
+}
+
+// ioUringOpName maps the raw IORING_OP_ byte to the JSONL op string. Values
+// from include/uapi/linux/io_uring.h (`enum io_uring_op`, stable since 5.1).
+func ioUringOpName(op uint8) string {
+	switch op {
+	case 2:
+		return "WRITEV"
+	case 9:
+		return "SENDMSG"
+	case 23:
+		return "WRITE"
+	case 26:
+		return "SEND"
+	default:
+		return "UNKNOWN"
+	}
+}
+
 func decodeDenyEvent(raw []byte) (tgid, tid uint32, comm [16]byte, protocol uint8, reason uint8, af uint8,
 	daddr16 [16]byte, dport uint16, ok bool) {
 	if len(raw) < denyEventWireSize {

--- a/internal/agent/agent_linux_digest.go
+++ b/internal/agent/agent_linux_digest.go
@@ -155,6 +155,8 @@ func buildDigestInput(
 		IPv6SendmsgObserved:            stats.ipv6SendmsgObserved(),
 		SendpageObserved:               stats.sendpageObserved(),
 		IoUringSetupObserved:           stats.ioUringSetupObserved(),
+		IoUringSendTotal:               stats.ioUringSendTotal(),
+		IoUringRingbufReserveFailures:  stats.ioUringRingbufReserveFailures(),
 		CanaryPipelineOK:               canarySnap.pipelineOK,
 		CanaryFailCount:                canarySnap.failCount,
 		TCPDNSResponsesObserved:        stats.tcpDNSResponsesObserved(),

--- a/internal/agent/agent_linux_ring_read.go
+++ b/internal/agent/agent_linux_ring_read.go
@@ -912,6 +912,76 @@ func readTCPStateRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader
 	}
 }
 
+// readIoUringRing drains io_uring_events from the BPF ringbuf into JSONL and
+// runStats (P6 Phase 1). The BPF side already filters to write-class opcodes
+// (SENDMSG=9, SEND=26), so this loop only sanitizes the wire bytes and maps
+// the raw IORING_OP_ byte to its string label.
+func readIoUringRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, stats *runStats,
+	seq *telemetry.SeqGen, jsonlMu *sync.Mutex, signer *telemetry.Signer) error {
+	backoff := newRingReadRetryBackoff()
+	for {
+		record, err := rd.Read()
+		if err != nil {
+			if errors.Is(err, ringbuf.ErrClosed) {
+				return nil
+			}
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			delay := backoff.sleep()
+			slog.Warn("ringbuf read (io_uring)", "err", err, "backoff", delay)
+			continue
+		}
+		backoff.reset()
+
+		_, pid, fd, daddr, dport, op, commb, ok := decodeIOUringSendEvent(record.RawSample)
+		if !ok {
+			stats.addDropped("io_uring_decode")
+			slog.Warn("decode io_uring send", "len", len(record.RawSample))
+			continue
+		}
+		stats.addIoUringSend()
+
+		comm := telemetry.SanitizeField(nullTermStr(commb[:]), 16)
+		opName := ioUringOpName(op)
+		ts := time.Now().UTC().Format(time.RFC3339Nano)
+
+		var dstIP string
+		var dstPort uint16
+		if ip := net.IP(daddr[:]).To4(); ip != nil {
+			// daddr=0 means the BPF probe could not resolve the SQE's fd to a
+			// cached connect tuple. Leave dst_ip/dst_port empty in that case
+			// so the JSONL reader can distinguish "unresolved" from "0.0.0.0".
+			if !(daddr == [4]byte{0, 0, 0, 0} && dport == 0) {
+				dstIP = ip.String()
+				dstPort = dport
+			}
+		}
+
+		if cfg.EventsLogPath != "" {
+			jsonlMu.Lock()
+			n := seq.Next()
+			ev := telemetry.IOUringSendEvent{
+				Type:    "io_uring_send",
+				TS:      ts,
+				Seq:     n,
+				PID:     pid,
+				Comm:    comm,
+				FD:      fd,
+				Op:      opName,
+				DstIP:   dstIP,
+				DstPort: dstPort,
+			}
+			werr := telemetry.AppendJSONL(cfg.EventsLogPath, ev, signer)
+			jsonlMu.Unlock()
+			if werr != nil {
+				stats.addDropped("io_uring_jsonl")
+				slog.Warn("events jsonl (io_uring)", "err", werr)
+			}
+		}
+	}
+}
+
 func readBPFAuditRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, stats *runStats, seq *telemetry.SeqGen, jsonlMu *sync.Mutex, signer *telemetry.Signer) error {
 	backoff := newRingReadRetryBackoff()
 	for {

--- a/internal/agent/agent_linux_state.go
+++ b/internal/agent/agent_linux_state.go
@@ -67,6 +67,8 @@ type runStats struct {
 	ipv6SendmsgObservedN            uint32
 	sendpageObservedN               uint32
 	ioUringSetupObservedN           int
+	ioUringSendN                    int
+	ioUringRingbufReserveFailuresN  int
 	tcpDNSResponsesObservedN        int
 	tcpDNSSkippedShortReadN         int
 	quicCandidateN                  int
@@ -489,6 +491,30 @@ func (s *runStats) setIoUringSetupObserved(n int) {
 	s.ioUringSetupObservedN = n
 }
 
+func (s *runStats) addIoUringSend() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ioUringSendN++
+}
+
+func (s *runStats) ioUringSendTotal() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ioUringSendN
+}
+
+func (s *runStats) setIoUringRingbufReserveFailures(n int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ioUringRingbufReserveFailuresN = n
+}
+
+func (s *runStats) ioUringRingbufReserveFailures() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ioUringRingbufReserveFailuresN
+}
+
 func (s *runStats) ioUringSetupObserved() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -680,6 +706,8 @@ func (s *runStats) snapshotSummary(kernel string, bpf []telemetry.BPFStatus) tel
 		IPv6SendmsgObserved:            s.ipv6SendmsgObservedN,
 		SendpageObserved:               s.sendpageObservedN,
 		IoUringSetupObserved:           s.ioUringSetupObservedN,
+		IoUringSendTotal:               s.ioUringSendN,
+		IoUringRingbufReserveFailures:  s.ioUringRingbufReserveFailuresN,
 		TCPDNSResponsesObserved:        s.tcpDNSResponsesObservedN,
 		TCPDNSSkippedShortRead:         s.tcpDNSSkippedShortReadN,
 		BPFAuditEvents:                 s.bpfAuditN,

--- a/internal/agent/agent_linux_state_sections.go
+++ b/internal/agent/agent_linux_state_sections.go
@@ -158,6 +158,8 @@ const (
 	ktlsEventWireSize      = 32  // 4(tgid)+4(tid)+comm[16]+4(fd)+1(direction)+_pad[3] → 32
 	// tcp_state_event (P3-2b): 8(timestamp_ns)+4(pid)+4(saddr)+4(daddr)+2(sport)+2(dport)+4(old_state)+4(new_state)+16(comm) → 48
 	tcpStateEventWireSize = 48
+	// io_uring_send_event: 8(ts)+4(pid)+4(fd)+4(daddr)+2(dport)+1(op)+1(_pad)+16(comm) → 40
+	ioUringSendEventWireSize = 40
 	// trace_dns.bpf.c dns_sniff_event: __u32 len + __u8 is_tcp + __u8 _pad[3] + data[DNS_SNIFF_MAX]
 	dnsSniffMaxPayload          = 4096                   // DNS_SNIFF_MAX in trace_dns.bpf.c
 	dnsSniffEventWireSizeLegacy = 4 + dnsSniffMaxPayload // pre-is_tcp layout (__u32 len + data[])

--- a/internal/agent/decode_network_linux_test.go
+++ b/internal/agent/decode_network_linux_test.go
@@ -457,3 +457,59 @@ func TestDecodeBPFAuditEvent_tooShort(t *testing.T) {
 		t.Fatal("expected ok=false for short input")
 	}
 }
+
+func TestDecodeIOUringSendEvent_roundTrip(t *testing.T) {
+	// Wire layout: ts(8) pid(4) fd(4) daddr(4) dport(2) op(1) _pad(1) comm(16).
+	raw := make([]byte, ioUringSendEventWireSize)
+	binary.LittleEndian.PutUint64(raw[0:8], 1715000000000)
+	binary.LittleEndian.PutUint32(raw[8:12], 9001)
+	binary.LittleEndian.PutUint32(raw[12:16], 7)
+	raw[16], raw[17], raw[18], raw[19] = 1, 2, 3, 4
+	binary.BigEndian.PutUint16(raw[20:22], 443)
+	raw[22] = 26 // IORING_OP_SEND
+	raw[23] = 0  // _pad
+	copy(raw[24:40], []byte("curl\x00"))
+
+	ts, pid, fd, daddr, dport, op, comm, ok := decodeIOUringSendEvent(raw)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if ts != 1715000000000 || pid != 9001 || fd != 7 || dport != 443 || op != 26 {
+		t.Fatalf("got ts=%d pid=%d fd=%d dport=%d op=%d", ts, pid, fd, dport, op)
+	}
+	if daddr != [4]byte{1, 2, 3, 4} {
+		t.Fatalf("daddr %v", daddr)
+	}
+	if got := string(bytes.TrimRight(comm[:], "\x00")); got != "curl" {
+		t.Fatalf("comm %q", got)
+	}
+	if got := ioUringOpName(op); got != "SEND" {
+		t.Fatalf("ioUringOpName(26) = %q, want SEND", got)
+	}
+}
+
+func TestDecodeIOUringSendEvent_tooShort(t *testing.T) {
+	_, _, _, _, _, _, _, ok := decodeIOUringSendEvent(make([]byte, ioUringSendEventWireSize-1))
+	if ok {
+		t.Fatal("expected ok=false for short input")
+	}
+}
+
+func TestIOUringOpName_allMappedAndUnknown(t *testing.T) {
+	cases := []struct {
+		op   uint8
+		want string
+	}{
+		{2, "WRITEV"},
+		{9, "SENDMSG"},
+		{23, "WRITE"},
+		{26, "SEND"},
+		{0, "UNKNOWN"},
+		{255, "UNKNOWN"},
+	}
+	for _, c := range cases {
+		if got := ioUringOpName(c.op); got != c.want {
+			t.Errorf("ioUringOpName(%d) = %q, want %q", c.op, got, c.want)
+		}
+	}
+}

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -252,6 +252,9 @@ func buildTriageRows(in DigestInput) [][2]string {
 	if in.IoUringSetupObserved > 0 {
 		gapParts = append(gapParts, fmt.Sprintf("⚠️ io_uring_setup (syscall-hook bypass class)=%d", in.IoUringSetupObserved))
 	}
+	if in.IoUringSendTotal > 0 {
+		gapParts = append(gapParts, fmt.Sprintf("io_uring writes=%d", in.IoUringSendTotal))
+	}
 	if !in.CanaryPipelineOK && in.CanaryFailCount > 0 {
 		gapParts = append(gapParts, fmt.Sprintf("🚨 telemetry canary FAILED (failures=%d)", in.CanaryFailCount))
 	}
@@ -430,6 +433,12 @@ func writeFullKPITable(b *strings.Builder, in DigestInput) {
 	}
 	if in.IoUringSetupObserved > 0 {
 		fmt.Fprintf(b, "| **⚠️ io_uring_setup (syscall-hook bypass class)** | %d |\n", in.IoUringSetupObserved)
+	}
+	if in.IoUringSendTotal > 0 {
+		fmt.Fprintf(b, "| **io_uring writes** | %d network sends observed (SNI extraction not possible) |\n", in.IoUringSendTotal)
+	}
+	if in.IoUringRingbufReserveFailures > 0 {
+		fmt.Fprintf(b, "| **io_uring_events ringbuf reserve failures** | %d |\n", in.IoUringRingbufReserveFailures)
 	}
 	if in.IPv6ConnectObserved > 0 {
 		label := "**⚠️ ipv6 connect6 observed (detect — no enforcement)**"
@@ -891,6 +900,9 @@ func writeKPISemantics(b *strings.Builder, in DigestInput, max int) {
 	}
 	if in.IoUringSetupObserved > 0 {
 		b.WriteString("- **⚠️ io_uring_setup** was called on this runner — io_uring can bypass typical syscall tracepoints used for detect mode. If `io-uring-disable` is true (default), the setup call was blocked by sysctl; this counter still records the attempt. See SECURITY.md (Guarantees vs best-effort).\n")
+	}
+	if in.IoUringSendTotal > 0 {
+		b.WriteString("- **io_uring writes** counts socket-class SQE submissions (`IORING_OP_SENDMSG`, `IORING_OP_SEND`) seen via `raw_tp/io_uring_submit_sqe` (P6 Phase 1). SNI / HTTP payloads are not captured from the submission point. `IORING_OP_WRITE` / `IORING_OP_WRITEV` arrive in Phase 2 with fd→socket resolution.\n")
 	}
 	if ipv6EgressObserved(in) > 0 {
 		switch {

--- a/internal/report/digest_test.go
+++ b/internal/report/digest_test.go
@@ -103,6 +103,37 @@ func TestBuildDetectMarkdown_TriageRibbon_TruthfulnessInterpretation(t *testing.
 	}
 }
 
+func TestBuildDetectMarkdown_IoUringSendRow(t *testing.T) {
+	t.Run("hidden when zero", func(t *testing.T) {
+		md := BuildDetectMarkdown(DigestInput{
+			BPF:               []telemetry.BPFStatus{{Name: "io_uring_submit_sqe", OK: true}},
+			ExecTotal:         1,
+			TCPTotal:          1,
+			MaxRowsPerSection: 50,
+		})
+		if strings.Contains(md, "io_uring writes") {
+			t.Fatalf("io_uring writes row should be hidden when total is zero; got:\n%s", md)
+		}
+	})
+	t.Run("visible when non-zero", func(t *testing.T) {
+		md := BuildDetectMarkdown(DigestInput{
+			BPF:               []telemetry.BPFStatus{{Name: "io_uring_submit_sqe", OK: true}},
+			ExecTotal:         1,
+			TCPTotal:          1,
+			IoUringSendTotal:  4,
+			MaxRowsPerSection: 50,
+		})
+		for _, needle := range []string{
+			"| **io_uring writes** | 4 network sends observed (SNI extraction not possible) |",
+			"io_uring writes=4",
+		} {
+			if !strings.Contains(md, needle) {
+				t.Fatalf("missing %q in:\n%s", needle, md)
+			}
+		}
+	})
+}
+
 func TestBuildDetectMarkdown_TopDestinations(t *testing.T) {
 	md := BuildDetectMarkdown(DigestInput{
 		TCPRows: []TCPDigestRow{{

--- a/internal/report/digest_types.go
+++ b/internal/report/digest_types.go
@@ -249,6 +249,16 @@ type DigestInput struct {
 	// io_uring traffic can bypass typical syscall tracepoints used for detect mode.
 	// It is a syscall-hook bypass-class signal, not proof of exfiltration.
 	IoUringSetupObserved int
+	// IoUringSendTotal counts io_uring socket-class SQE submissions
+	// (IORING_OP_SENDMSG, IORING_OP_SEND) seen via raw_tp/io_uring_submit_sqe
+	// (P6 Phase 1). Non-zero means the workload bypassed our syscall arms
+	// for network sends — SNI / payload extraction is not possible from the
+	// SQE submission point. WRITE / WRITEV land in Phase 2 with fd
+	// resolution.
+	IoUringSendTotal int
+	// IoUringRingbufReserveFailures counts ringbuf reserve failures on the
+	// io_uring_events channel — non-zero indicates io_uring telemetry pressure.
+	IoUringRingbufReserveFailures int
 	// CanaryPipelineOK reflects telemetry integrity canary status. When false,
 	// the BPF ringbuf pipeline may be compromised (suppression, exhaustion).
 	CanaryPipelineOK bool

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -419,6 +419,27 @@ type KTLSEvent struct {
 // EventTypeKTLS is the JSONL discriminator for KTLSEvent.
 const EventTypeKTLS = "ktls_offload"
 
+// IOUringSendEvent is one JSONL record for an io_uring socket-class SQE
+// submission observed via SEC("raw_tp/io_uring_submit_sqe"). Phase 1 emits
+// for IORING_OP_SENDMSG (9) and IORING_OP_SEND (26) only — both
+// unambiguous network sends. WRITE/WRITEV will land in Phase 2 alongside
+// fd→socket resolution. The event surfaces io_uring egress that would
+// otherwise bypass syscall-based hooks; SNI / payload extraction is not
+// possible from the SQE submission point. dst_ip / dst_port are populated
+// when Phase 2's tuple resolution lands; Phase 1 leaves them empty.
+type IOUringSendEvent struct {
+	Type    string `json:"type"` // "io_uring_send"
+	TS      string `json:"ts"`
+	Seq     uint64 `json:"seq"`
+	PID     uint32 `json:"pid"`
+	Comm    string `json:"comm"`
+	FD      uint32 `json:"fd"`
+	Op      string `json:"op"` // "WRITEV" | "SENDMSG" | "WRITE" | "SEND" | "UNKNOWN"
+	DstIP   string `json:"dst_ip,omitempty"`
+	DstPort uint16 `json:"dst_port,omitempty"`
+	Sig     string `json:"sig,omitempty"`
+}
+
 // BPFAuditEvent is one JSONL record for a bpf(2) syscall audit event.
 type BPFAuditEvent struct {
 	Type     string `json:"type"` // "bpf_audit"

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -136,15 +136,21 @@ type Summary struct {
 	// cgroup/sendmsg4 and lsm/socket_sendmsg cannot gate (kernel ≤ 6.7).
 	// In defend mode the hook also enforces; in detect mode it's
 	// visibility-only.
-	SendpageObserved               uint32 `json:"sendpage_observed,omitempty"`
-	IoUringSetupObserved           int    `json:"io_uring_setup_observed,omitempty"`
-	TCPDNSResponsesObserved        int    `json:"tcp_dns_responses_observed,omitempty"`
-	TCPDNSSkippedShortRead         int    `json:"tcp_dns_skipped_short_read,omitempty"`
-	BPFAuditEvents                 int    `json:"bpf_audit_events,omitempty"`
-	BPFHeartbeatFailures           int    `json:"bpf_heartbeat_failures,omitempty"`
-	BPFMapIntegrityFailures        int    `json:"bpf_map_integrity_failures,omitempty"`
-	BPFDNSCacheUpdateFailures      int    `json:"bpf_dns_cache_update_failures,omitempty"`
-	BPFAuditRingbufReserveFailures int    `json:"bpf_audit_ringbuf_reserve_failures,omitempty"`
+	SendpageObserved     uint32 `json:"sendpage_observed,omitempty"`
+	IoUringSetupObserved int    `json:"io_uring_setup_observed,omitempty"`
+	// IoUringSendTotal counts io_uring write-class SQE submissions observed
+	// via SEC("raw_tp/io_uring_submit_sqe") on tracked sockets (P6 Phase 1).
+	IoUringSendTotal int `json:"io_uring_send_total,omitempty"`
+	// IoUringRingbufReserveFailures counts ringbuf reserve failures on the
+	// io_uring_events channel (telemetry pressure on the io_uring probe).
+	IoUringRingbufReserveFailures  int `json:"io_uring_ringbuf_reserve_failures,omitempty"`
+	TCPDNSResponsesObserved        int `json:"tcp_dns_responses_observed,omitempty"`
+	TCPDNSSkippedShortRead         int `json:"tcp_dns_skipped_short_read,omitempty"`
+	BPFAuditEvents                 int `json:"bpf_audit_events,omitempty"`
+	BPFHeartbeatFailures           int `json:"bpf_heartbeat_failures,omitempty"`
+	BPFMapIntegrityFailures        int `json:"bpf_map_integrity_failures,omitempty"`
+	BPFDNSCacheUpdateFailures      int `json:"bpf_dns_cache_update_failures,omitempty"`
+	BPFAuditRingbufReserveFailures int `json:"bpf_audit_ringbuf_reserve_failures,omitempty"`
 	// RingbufReserveFailuresTotal is the sum of per-channel ringbuf reserve failure
 	// counters (detect-path telemetry only; excludes defend deny-event reserves).
 	RingbufReserveFailuresTotal int            `json:"ringbuf_reserve_failures_total,omitempty"`


### PR DESCRIPTION
## Summary

Implements **P6 Phase 1** — io_uring write-class submission detection via `SEC("raw_tp/io_uring_submit_sqe")` (kernel 5.14+). io_uring submissions bypass the syscall hooks used elsewhere in detect mode; the existing `io-uring-disable` sysctl gate is the primary defense, and this is the runtime fallback that surfaces SQEs when the gate is bypassed or off.

## What changed

- **`bpf/trace_connect_obs.h`** — `struct io_uring_send_event` (40 bytes, `_Static_assert`-locked: 8 ts + 4 pid + 4 fd + 4 daddr + 2 dport + 1 op + 1 _pad + 16 comm).
- **`bpf/trace_connect.bpf.c`** — `io_uring_events` ringbuf (64 KiB), `io_uring_ringbuf_reserve_failures` per-cpu counter, and `SEC("raw_tp/io_uring_submit_sqe")` handler. Filter is `IORING_OP_SENDMSG` (9) and `IORING_OP_SEND` (26) — both unambiguously network sends, so emission does not need fd→socket resolution. The C source touches only `req->opcode`, so it compiles against any vmlinux.h that exposes `struct io_kiocb` (5.1+). `IORING_OP_WRITE` / `IORING_OP_WRITEV` arrive in Phase 2 alongside fd resolution (struct `io_cqe` is post-5.15 and not stable in older vmlinux BTF).
- **`internal/telemetry/event.go`** — `IOUringSendEvent` JSONL type (`type: "io_uring_send"`).
- **`internal/telemetry/telemetry.go`** — `Summary.IoUringSendTotal` and `IoUringRingbufReserveFailures`.
- **`internal/agent/agent_linux_bpf_start.go`** — `startIoUringTrace` does a best-effort attach on the already-loaded traceconnect collection; failure (older kernel, missing tracepoint) yields a degraded `BPFStatus` row rather than failing the agent.
- **`internal/agent/agent_linux.go`** — registers the new ringbuf reader, defer block for stats sampling, and reader goroutine wiring.
- **`internal/agent/agent_linux_ring_read.go`** — `readIoUringRing` drains the ringbuf, decodes via `decodeIOUringSendEvent`, maps the raw IORING_OP_ byte → string label, and appends JSONL.
- **`internal/agent/agent_linux_decode.go`** — `decodeIOUringSendEvent` + `ioUringOpName` (`2 → WRITEV`, `9 → SENDMSG`, `23 → WRITE`, `26 → SEND`, else UNKNOWN — values forward-compat for Phase 2).
- **`internal/agent/agent_linux_state*.go`** — `ioUringSendN` + `ioUringRingbufReserveFailuresN` counters, accessors, snapshot wiring.
- **`internal/agent/agent_linux_policy_maps.go`** — `readIoUringRingbufReserveFailureCount`.
- **`internal/report/digest_types.go`** — `DigestInput.IoUringSendTotal` and `IoUringRingbufReserveFailures`.
- **`internal/report/digest.go`** — KPI row (`**io_uring writes** | N network sends observed (SNI extraction not possible)`), gap-parts entry in the triage ribbon, Technical-details narrative. All hidden when zero.
- **`action.yml`** — `io-uring-disable` description notes the Phase 1 detection fallback; sysctl disable remains the primary defense.

## Phase 1 scope (deliberate)

- **SEND/SENDMSG only.** Both opcodes are unambiguously socket sends. Emit without fd→socket resolution.
- **No payload sniff.** The SQE submission point holds no userspace buffer state; SNI / HTTP cannot be extracted here. This is detection visibility only.
- **Graceful kernel-version fallback.** Attach failure (kernel < 5.14) marks the new BPFStatus row degraded; the agent continues. Detected via `link.AttachRawTracepoint` returning `ENOENT`.
- **No feature gate.** The probe is narrowly filtered (two socket opcodes), so it stays cheap on workloads that don't use io_uring; always-attempt avoids the operator-flag complexity of `tls_sni` / `fs_events`.

## Constraints honored

- Two modes only (`detect`, `defend`) — no `enforce` references introduced.
- Generated BPF artifacts (`bpf/vmlinux.h`, `internal/bpf/**/*_bpfel.go`, `*_bpfeb.go`) not committed.
- gofmt clean, encoding scan clean.
- `go vet` + cross-platform tests pass locally; Linux BPF compile + integration covered by `coldstep-ci-runner.yml`.

## Tests

- `internal/agent/abi_wire_linux_test.go` — `io_uring_send_event` wire size guard (`8+4+4+4+2+1+1+16 == 40`), paired with `_Static_assert(sizeof(struct io_uring_send_event) == 40)` in `bpf/trace_connect_obs.h`.
- `internal/agent/decode_network_linux_test.go` — `decodeIOUringSendEvent` round-trip (all fields), too-short rejection, op-byte → string mapping for all four future opcodes plus UNKNOWN.
- `internal/report/digest_test.go` — KPI row hidden when `IoUringSendTotal == 0`, visible (with triage-ribbon gap-parts entry) when non-zero.

## Follow-ups (out of scope)

- **P6 Phase 2** — extend to `IORING_OP_WRITE` / `IORING_OP_WRITEV`, paired with fd→socket resolution (requires `struct io_cqe` BTF or an alternate fd-lookup path) so file I/O does not flood.
- Defend-mode enforcement of io_uring egress (separate track; Phase 1 is detect-only).
