### PR TITLE
docs: H6 — state IPv4-only coverage boundaries

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -11,7 +11,7 @@ Coldstep exposes **two** mode names in `with:` and env **`CI_GUARD_MODE`**: **`d
 | Observe-only telemetry (default) | `mode: detect` or omit `mode` |
 | Block egress not on the allowlist | `mode: defend` + non-empty **`allow`** / **`allow-file`** |
 
-**IPv6:** Both modes observe IPv6 egress via `cgroup/connect6`/`cgroup/sendmsg6` (Phase 1, observe-only). IPv6 blocking is not yet implemented.
+> **Coverage scope:** coldstep observes and enforces **IPv4 TCP/UDP**. **IPv6, QUIC/HTTP3, and Unix socket traffic are not covered** (silently bypassed in both detect and defend). See **[SECURITY.md → Coverage Boundaries](SECURITY.md#coverage-boundaries)** for the full matrix.
 
 If you still have `mode: enforce` or `CI_GUARD_MODE: enforce`, replace with **`defend`**. See **[CHANGELOG — Breaking](CHANGELOG.md)**.
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Using Coldstep in **your** workflow does **not** require **Python** or **`pip in
 
 | Mode | What it does | Allowlist |
 | :--- | :------------- | :-------- |
-| **`detect`** (default) | Observe and log IPv4-focused egress; no blocking. | Optional (policy labels only). |
-| **`defend`** | Block IPv4 egress not on the allowlist (cgroup programs). | **Required** — non-empty effective allowlist. |
+| **`detect`** (default) | Observe and log IPv4-focused TCP/UDP egress activity (IPv6 and QUIC not observed); no blocking. | Optional (policy labels only). |
+| **`defend`** | Block IPv4 egress not on the allowlist (IPv4 TCP/UDP only — IPv6 and QUIC not blocked; cgroup programs). | **Required** — non-empty effective allowlist. |
 
 **Upgrading from old workflows**
 
@@ -59,7 +59,7 @@ The single `uses:` block is enough — node24 pre/post hooks start the agent bef
 
 | Topic | Detail |
 | :---- | :----- |
-| **IP versions** | **Defend is IPv4 + IPv6.** Allowlists resolve both **A** and **AAAA** records and program two LPM tries: `allowed_ipv4` (4-byte keys) and `allowed_ipv6` (16-byte keys). cgroup hooks block on both families — `connect4` / `sendmsg4` for IPv4, `connect6` / `sendmsg6` for IPv6 — denying any destination not on the allowlist with `EPERM`. `::1` (loopback) and `fe80::/10` (link-local) always bypass enforcement. Detect mode observes both families without enforcing. |
+| **IP versions** | Coldstep observes and enforces **IPv4 TCP/UDP only**. **IPv6 is not supported** — IPv6 egress is silently bypassed in both detect and defend modes. QUIC/HTTP3 traffic is observed as UDP/443 events but the inner framing is not inspected. See **[Coverage Boundaries](SECURITY.md#coverage-boundaries)** for the full matrix (Unix sockets, io_uring, service containers, Docker-in-Docker). |
 | **Runner OS** | **Linux only** for the agent. **v1 supports `ubuntu-latest` only** (GitHub-hosted Ubuntu x64). Not supported on macOS, Windows, self-hosted, or other `runs-on` labels until explicitly documented in a later release. |
 | **Build on runner** | The action runs [`scripts/build-agent-linux.sh`](scripts/build-agent-linux.sh) (clang, libbpf, **bpftool** against `/sys/kernel/btf/vmlinux` → `bpf/vmlinux.h`, `go generate` / bpf2go, then **`go build`** → **`bin/coldstep`**). |
 | **Privileges** | The agent runs under **`sudo`** to load BPF. |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,6 +17,30 @@ Include: affected component (composite shell / Go agent vs BPF), reproduction or
 
 Security fixes are applied to the **default development branch** (`main`) first. Released tags are cut from that line; use a **pinned tag** in workflows (see **README** / **QUICK_START**) rather than **`@main`** for production-style consumption.
 
+## Coverage Boundaries
+
+coldstep observes and enforces a **deliberately scoped** subset of egress. Trust decisions — promoting detect output to a defend allowlist, treating a clean digest as proof of no exfiltration, gating a release on a passing defend run — must account for the boundaries below. **Absence of evidence is not evidence of absence.**
+
+| Traffic class | Detect (observe) | Defend (block) | Notes |
+|:---|:---:|:---:|:---|
+| IPv4 TCP | ✓ | ✓ | Via `connect4` tracepoint + cgroup hook |
+| IPv4 UDP (`sendmsg`) | ✓ | ✓ | Via `sendmsg4` tracepoint + cgroup hook |
+| IPv4 UDP (`write` on connected socket) | partial | ✓ | `write(2)` on a connected UDP socket may not emit a per-message event; cgroup `sendmsg4` still enforces |
+| IPv6 (all) | ✗ | ✗ | No IPv6 hooks; silent bypass in all modes |
+| QUIC / HTTP3 (UDP/443) | UDP event only | ✓ (port/IP) | Inner QUIC framing not inspected; SNI not extracted |
+| TLS via io_uring | partial (enhanced) | ✗ | io_uring detection gated behind `detect-profile: enhanced` (raw_tp/io_uring_submit_sqe); the sysctl `io-uring-disable` remains the primary defense |
+| Unix domain sockets | ✗ | ✗ | AF_UNIX not tracked |
+| Docker-in-Docker inner containers | ✗ | ✗ | Separate cgroup/network namespace |
+| GitHub Actions service containers | ✗ | ✗ | Docker networking, separate namespace |
+
+**Why IPv4-only.** Defend hooks attach to the kernel-side BPF program types `cgroup/connect4` and `cgroup/sendmsg4`. These hook types are address-family-specific by ABI — the analogous `connect6` / `sendmsg6` slots would have to be implemented, attached, and verified separately, and require parallel IPv6 LPM map machinery on the userspace side. Until those land, IPv6 egress is not observed by coldstep tracepoints and is not gated by coldstep cgroup hooks. Treat any IPv6-capable destination as an uncovered path.
+
+**Operational implications.**
+
+- **Detect-mode allowlist promotion** (`suggested-allow` output) reflects IPv4 destinations only. A workload that exfiltrates over IPv6, QUIC inner payload, or AF_UNIX → host-proxy will appear clean in detect and will not contribute to the suggested allowlist.
+- **Defend-mode enforcement** does not bar IPv6 destinations even when an IPv4 entry of the "same" host exists; if the runner resolves AAAA and prefers IPv6, the connection is unenforced.
+- **Service containers and DinD** run in separate network namespaces from the job's primary cgroup. Egress originating inside those namespaces is outside coldstep's hook scope; route them through the job container or rely on organizational network controls.
+
 ## GitHub Actions: threat model and mitigations
 
 Coldstep is commonly used in **GitHub-hosted Ubuntu** jobs. This section summarizes **what the composite action can and cannot guarantee** for consumers hardening CI egress visibility or **defend** (blocking) mode.

--- a/action.yml
+++ b/action.yml
@@ -12,11 +12,10 @@ inputs:
   mode:
     description: >-
       Runtime mode: detect (default) or defend (blocking, requires allowlist).
-      defend resolves A and AAAA records for every domain in the allowlist and
-      programs both the BPF allowed_ipv4 and allowed_ipv6 LPM tries. cgroup
-      hooks block non-allowlisted egress on both IPv4 (connect4/sendmsg4) and
-      IPv6 (connect6/sendmsg6); ::1 and fe80::/10 always bypass. The enforce
-      spelling is not supported; use defend.
+      defend blocks IPv4 TCP/UDP egress not on the allowlist (cgroup
+      connect4/sendmsg4 + BPF LSM where available). IPv6, QUIC/HTTP3, Unix
+      sockets, and io_uring connect are not blocked. See SECURITY.md for full
+      coverage boundaries. The enforce spelling is not supported; use defend.
     required: false
     default: detect
 


### PR DESCRIPTION
## Summary

Implements **H6** from the v0.2.9 hardening roadmap — accurately state coldstep's coverage boundaries so consumers don't make trust decisions based on capabilities the tool doesn't ship.

The defend cgroup programs are bound to `connect4`/`sendmsg4` by kernel ABI. Until parallel `connect6`/`sendmsg6` hooks and an `allowed_ipv6` LPM trie are implemented, IPv6 egress is **not** observed by coldstep tracepoints and **not** gated by coldstep cgroup hooks. Three consumer-facing surfaces (`action.yml`, `README.md`, `QUICK_START.md`) previously implied otherwise.

### Changes

- **`action.yml`** — `mode` description now names the actual hook scope (IPv4 TCP/UDP via cgroup `connect4`/`sendmsg4` + BPF LSM where available) and the explicit non-coverage list (IPv6, QUIC/HTTP3, Unix sockets, io_uring connect). Points to `SECURITY.md` for the full matrix.
- **`README.md`** — At-a-glance detect/defend rows are qualified ("IPv6 and QUIC not observed", "IPv4 TCP/UDP only — IPv6 and QUIC not blocked"). The Requirements **IP versions** row no longer claims `Defend is IPv4 + IPv6`; instead it states the IPv4-only scope and links to the new `SECURITY.md#coverage-boundaries` anchor.
- **`QUICK_START.md`** — replaces the (incorrect) "IPv6 observe-only" callout with a `> Coverage scope` blockquote that lists IPv6, QUIC/HTTP3, and Unix sockets as not covered, with a link to `SECURITY.md`.
- **`SECURITY.md`** — new top-level `## Coverage Boundaries` section with a per-traffic-class matrix (IPv4 TCP, IPv4 UDP sendmsg, IPv4 UDP write-on-connected, IPv6, QUIC/HTTP3, TLS via io_uring, AF_UNIX, DinD, service containers), a **Why IPv4-only** paragraph explaining the BPF `cgroup/connect4`/`cgroup/sendmsg4` kernel ABI, and operational implications for `suggested-allow` promotion, defend gaps, and sibling-namespace containers.

### Scope

- Documentation only — no Go code, BPF C, generated stubs, or CI workflow changes.
- No removals from `README.md` other than the two qualified rows above.
- `SECURITY.md` structure preserved; new section inserted between `## Supported versions` and `## GitHub Actions: threat model and mitigations` so the existing `Guarantees vs best-effort` / `Defend hooks` subsections continue to read coherently.

### Validation

- `bash scripts/check-encoding.sh` — passes (no mojibake, no U+FFFD).
- `git diff --stat`: `QUICK_START.md` 2 lines, `README.md` 6 lines, `SECURITY.md` 24 lines, `action.yml` 9 lines.
- Anchor cross-check: `SECURITY.md#coverage-boundaries` is referenced from `README.md` (At-a-glance link target) and `QUICK_START.md` (blockquote link target).

## Test plan

- [ ] CI green (`coldstep-ci.yml` → `coldstep-ci-runner.yml` — gofmt, encoding, unit, integration, action_bundle, detect-mode, defend-mode).
- [ ] Render `README.md`, `QUICK_START.md`, and `SECURITY.md` on GitHub; confirm the `SECURITY.md#coverage-boundaries` anchor resolves from both link sources.
