### PR TITLE
feat(digest): H1 — descriptive badge text + Coverage scope table

### DIFF
--- a/.github/pr-bodies/pr-h1-digest-coverage-scope.md
+++ b/.github/pr-bodies/pr-h1-digest-coverage-scope.md
@@ -1,0 +1,21 @@
+## Summary
+
+H1 from the v0.2.9 hardening roadmap: make the digest honest about what was and wasn't observed.
+
+- **Headline badge text** spells out what each emoji means so operators do not mistake ✅ for "every byte of egress observed":
+  - ✅ **No anomalies detected (IPv4 TCP/UDP in scope)**
+  - ⚠️ **Partial observation or coverage gaps — review required**
+  - 🚨 **BPF failure or canary pipeline issue**
+- **Coverage scope table** replaces the one-line "Coverage this run:" with a 7-row table that names each traffic class and its observation status (IPv4 TCP, IPv4 UDP, IPv6, QUIC/HTTP3, io_uring, Unix sockets, payloads beyond iov[0]). The io_uring row reflects the actual BPF probe status — `⚠ partial` when loaded, `✗ not loaded` when absent/failed — and annotates the enhanced-profile TLS ClientHello peek.
+- **`runner_has_ipv6` wiring**: new `MetaEvent.RunnerHasIPv6` + `DigestInput.RunnerHasIPv6` + `config.Config.RunnerHasIPv6` (env: `COLDSTEP_RUNNER_HAS_IPV6`). When the runner advertises IPv6 connectivity and no IPv6 hooks are loaded (today: detect mode), the verdict downgrades ✅ → ⚠️ so the headline reflects the partial envelope. The `/proc/net/if_inet6` detection itself lives in the action layer (separate concern).
+
+The visible-line budget for the above-the-fold portion is bumped 30 → 40 — an intentional H1 trade of compactness for honesty.
+
+## Test plan
+
+- [x] `go test ./...` clean on Linux (WSL)
+- [x] `go test -race ./internal/report/... ./internal/agent/... ./internal/telemetry/...`
+- [x] `gofmt -l internal/ cmd/` clean
+- [x] `go vet ./...` clean
+- [x] New tests cover the three verdict labels, the io_uring row state machine, the Unix-sockets always-not-observed invariant, the QUIC candidate flip, and the RunnerHasIPv6 ✅→⚠️ downgrade
+- [ ] All 22 CI checks pass

--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -784,6 +784,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 			if len(defendCompiled.WildcardRiskDomains) > 0 {
 				meta.WildcardRiskDomains = append([]string(nil), defendCompiled.WildcardRiskDomains...)
 			}
+			meta.RunnerHasIPv6 = cfg.RunnerHasIPv6
 			if err := telemetry.AppendJSONL(cfg.EventsLogPath, meta, signer); err != nil {
 				slog.Warn("meta jsonl", "err", err)
 			}

--- a/internal/agent/agent_linux_digest.go
+++ b/internal/agent/agent_linux_digest.go
@@ -94,6 +94,7 @@ func buildDigestInput(
 	in := report.DigestInput{
 		DetectProfile:                  cfg.DetectProfile,
 		BPF:                            bpfSt,
+		RunnerHasIPv6:                  cfg.RunnerHasIPv6,
 		ExecTotal:                      execN,
 		TCPTotal:                       tcpN,
 		UDPTotal:                       udpN,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,13 @@ type Config struct {
 	// CgroupAttachPath is the unified cgroup2 path for link.AttachCgroup (from COLDSTEP_CGROUP_PATH or /proc/self/cgroup).
 	CgroupAttachPath string
 	SigningKey       string
+	// RunnerHasIPv6 reflects COLDSTEP_RUNNER_HAS_IPV6 (set by the action layer
+	// from /proc/net/if_inet6 at start). When true, the runner advertises at
+	// least one non-loopback / non-link-local IPv6 address — the digest uses
+	// this to downgrade ✅ to ⚠️ when no IPv6 hooks are loaded (H1 honesty).
+	// The detection itself lives in the action layer; the agent just forwards
+	// the flag to the digest.
+	RunnerHasIPv6 bool
 }
 
 func defaultUnderWorkspace(rel string) string {
@@ -135,6 +142,7 @@ func LoadFromEnv() (Config, error) {
 		DetectProfile:        profile,
 		CgroupAttachPath:     cgPath,
 		SigningKey:           os.Getenv("COLDSTEP_SIGNING_KEY"),
+		RunnerHasIPv6:        envBoolTrue("COLDSTEP_RUNNER_HAS_IPV6"),
 	}, nil
 }
 

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -61,6 +61,16 @@ func ipv6DefendActive(in DigestInput) bool {
 	return isBlockingDigestMode(in.DefendMode) && in.DefendIPv6AllowlistSize > 0
 }
 
+// ipv6HooksLoaded reports whether the IPv6 enforcement hooks
+// (cgroup/connect6, cgroup/sendmsg6) are loaded for this run. Today the
+// IPv6 hooks are only attached in defend mode — detect mode never attaches
+// them, so detect mode is treated as "no IPv6 hooks". When the runner has
+// IPv6 connectivity (MetaEvent.RunnerHasIPv6) and no IPv6 hooks are loaded,
+// the verdict is downgraded so the headline reflects the partial coverage.
+func ipv6HooksLoaded(in DigestInput) bool {
+	return isBlockingDigestMode(in.DefendMode)
+}
+
 // verdictEmoji returns ✅ / ⚠️ / 🚨 for the headline. Mirrors the prior
 // blockquote badge logic but is now embedded directly in the `##` heading.
 func verdictEmoji(in DigestInput) string {
@@ -95,6 +105,11 @@ func verdictEmoji(in DigestInput) string {
 	// allowed_ipv6 trie the traffic was actually checked, so it's no
 	// longer a review trigger on its own.
 	ipv6Review := ipv6EgressObserved(in) > 0 && !ipv6DefendActive(in) && !isBlockingDigestMode(in.DefendMode)
+	// H1: a runner that advertises IPv6 connectivity with no IPv6 hooks
+	// loaded is a coverage gap on its own, even without observed events.
+	// The agent could simply have missed unobserved IPv6 traffic; downgrade
+	// ✅ to ⚠️ so the headline matches what was actually in scope.
+	runnerIPv6Gap := in.RunnerHasIPv6 && !ipv6HooksLoaded(in)
 	review := totalDetectRingbufReserveFailures(in) > 0 ||
 		in.UDPSendmsgMultiIovecObserved > 0 ||
 		in.TLSWritevMultiIovecObserved > 0 ||
@@ -105,46 +120,134 @@ func verdictEmoji(in DigestInput) string {
 		in.DefendDenyReserveFailures > 0 ||
 		droppedTotal(in) > 0 ||
 		in.IoUringSetupObserved > 0 ||
-		ipv6Review
+		ipv6Review ||
+		runnerIPv6Gap
 	if review {
 		return "⚠️"
 	}
 	return "✅"
 }
 
-// writeHeader renders the single-line `## <emoji> coldstep — <mode>` heading.
+// verdictBadgeText returns the descriptive label rendered next to the
+// emoji in the headline. H1 (digest honesty): the badge no longer reads
+// "Clean run / Review / Alert" — each label calls out exactly what the
+// verdict means so operators do not mistake ✅ for "every byte of egress
+// observed".
+func verdictBadgeText(emoji string) string {
+	switch emoji {
+	case "🚨":
+		return "BPF failure or canary pipeline issue"
+	case "⚠️":
+		return "Partial observation or coverage gaps — review required"
+	default:
+		return "No anomalies detected (IPv4 TCP/UDP in scope)"
+	}
+}
+
+// writeHeader renders the `## <emoji> coldstep — <mode>` heading and a
+// descriptive verdict blockquote naming the scope of the verdict (H1).
 // When partial-coverage signals fired (ringbuf drops or partial-observe
-// counters), a blockquote note steers the reader to the Coverage block — the ✅
-// badge alone would otherwise imply complete observation.
+// counters), a secondary blockquote steers the reader to the Coverage
+// block — the ✅ badge alone would otherwise imply complete observation.
 func writeHeader(b *strings.Builder, in DigestInput) {
 	mode := "detect"
 	if isBlockingDigestMode(in.DefendMode) {
 		mode = "defend"
 	}
-	fmt.Fprintf(b, "## %s coldstep — %s\n\n", verdictEmoji(in), mode)
+	emoji := verdictEmoji(in)
+	fmt.Fprintf(b, "## %s coldstep — %s\n\n", emoji, mode)
+	fmt.Fprintf(b, "> %s **%s**\n\n", emoji, verdictBadgeText(emoji))
 	if hasPartialCoverageSignals(in) {
 		b.WriteString("> ⚠️ Partial coverage — see Coverage block below.\n\n")
 	}
 }
 
-// writeCoverage emits a one-line scope statement so users do not misread ✅ as
-// "every byte of egress observed". IPv6 coverage flips state per run:
-//   - detect or defend without allowed_ipv6: "observed" (cgroup/connect6 +
-//     sendmsg6 always counts; defend with empty trie still gates by denying).
-//   - defend with allowed_ipv6 entries: "gated" (Phase 2 active).
-//
-// QUIC/HTTP3 remains statically out of scope (no BPF coverage). The
-// "Payloads beyond iov[0]" cell flips to ⚠️ partial when BG-01
-// partial-observe counters fired this run.
-func writeCoverage(b *strings.Builder, in DigestInput) {
-	ipv6State := "observed (detect — no enforcement)"
-	if ipv6DefendActive(in) {
-		ipv6State = "gated (defend allowed_ipv6 active)"
-	} else if isBlockingDigestMode(in.DefendMode) {
-		ipv6State = "denied (defend block-all — empty allowed_ipv6)"
+// ipv6CoverageCell returns the IPv6 row text in the Coverage scope table.
+// IPv6 state is per-run: defend with a populated allowed_ipv6 trie is "✓
+// gated"; defend without is "✓ gated (block-all)"; detect mode is "✗ not
+// observed" by default but flips to "⚠ observed (no enforcement)" when
+// the cgroup/connect6+sendmsg6 hooks reported egress.
+func ipv6CoverageCell(in DigestInput) string {
+	switch {
+	case ipv6DefendActive(in):
+		return "✓ gated (defend allowed_ipv6 active)"
+	case isBlockingDigestMode(in.DefendMode):
+		return "✓ gated (defend block-all — empty allowed_ipv6)"
+	case ipv6EgressObserved(in) > 0:
+		return "⚠ observed (detect — no enforcement)"
+	case in.RunnerHasIPv6:
+		return "✗ not observed (runner has IPv6 — coverage gap)"
+	default:
+		return "✗ not observed"
 	}
-	fmt.Fprintf(b, "**Coverage this run:** IPv4 TCP/UDP ✓ observed | IPv6 %s | QUIC/HTTP3 ✗ not observed | Payloads beyond iov[0]: %s\n\n",
-		ipv6State, coveragePayloadState(in))
+}
+
+// quicCoverageCell returns the QUIC/HTTP3 row text. QUIC payloads are
+// always encrypted at the transport layer so the row is structurally "✗
+// not observed"; when port-443 UDP candidates were seen the cell flips to
+// "⚠" so operators know flows fell into this gap on this run.
+func quicCoverageCell(in DigestInput) string {
+	if in.QUICCandidateCount > 0 {
+		return "⚠ candidates observed (payload encrypted, not inspected)"
+	}
+	return "✗ not observed"
+}
+
+// ioUringCoverageCell returns the io_uring row text. The cell is "⚠
+// partial" when the raw_tp/io_uring_submit_sqe probe loaded — coldstep
+// observes the submission point but cannot extract HTTP/TLS payloads from
+// the SQE alone. When the probe is absent or attach failed the cell reads
+// "✗ not loaded".
+func ioUringCoverageCell(in DigestInput) string {
+	for _, row := range in.BPF {
+		if row.Name == "raw_tp/io_uring_submit_sqe" {
+			if !row.OK {
+				return "✗ not loaded"
+			}
+			if strings.EqualFold(strings.TrimSpace(in.DetectProfile), "enhanced") {
+				return "⚠ partial (SQE submission + TLS ClientHello peek)"
+			}
+			return "⚠ partial (SQE submission only)"
+		}
+	}
+	return "✗ not loaded"
+}
+
+// ipv4TCPCoverageCell returns the IPv4 TCP row text. Cgroup connect4 is
+// always loaded in detect+defend; if the shared raw_tp/sys_enter hook is
+// degraded the row degrades with it because TCP attempts route through
+// that path for syscall-side telemetry.
+func ipv4TCPCoverageCell(in DigestInput) string {
+	if in.TCPDegradedHook {
+		return "✗ probe degraded"
+	}
+	return "✓ observed"
+}
+
+// ipv4UDPCoverageCell returns the IPv4 UDP row text — same shared
+// raw_tp/sys_enter degradation rule as IPv4 TCP.
+func ipv4UDPCoverageCell(in DigestInput) string {
+	if in.UDPDegradedHook {
+		return "✗ probe degraded"
+	}
+	return "✓ observed"
+}
+
+// writeCoverage emits the H1 Coverage scope table so operators see the
+// observation envelope at a glance — what was in-scope, what was outside
+// it. The table is rendered for every digest (detect + defend) so the
+// verdict can be cross-referenced against the actually-observed traffic
+// classes.
+func writeCoverage(b *strings.Builder, in DigestInput) {
+	b.WriteString("**Coverage scope**\n\n")
+	b.WriteString("| Traffic class | Status |\n|:---|:---|\n")
+	fmt.Fprintf(b, "| IPv4 TCP | %s |\n", ipv4TCPCoverageCell(in))
+	fmt.Fprintf(b, "| IPv4 UDP (sendmsg) | %s |\n", ipv4UDPCoverageCell(in))
+	fmt.Fprintf(b, "| IPv6 | %s |\n", ipv6CoverageCell(in))
+	fmt.Fprintf(b, "| QUIC / HTTP3 | %s |\n", quicCoverageCell(in))
+	fmt.Fprintf(b, "| io_uring (enhanced profile only) | %s |\n", ioUringCoverageCell(in))
+	b.WriteString("| Unix sockets | ✗ not observed |\n")
+	fmt.Fprintf(b, "| Payloads beyond iov[0] | %s |\n\n", coveragePayloadState(in))
 }
 
 // writeCompactKPI emits a single-row 5-column KPI table. The full per-channel

--- a/internal/report/digest_test.go
+++ b/internal/report/digest_test.go
@@ -298,6 +298,167 @@ func TestBuildDetectMarkdown_HeaderEmojiVerdicts(t *testing.T) {
 	}
 }
 
+// TestBuildDetectMarkdown_HeadlineBadgeText pins the H1 verdict labels — the
+// digest now spells out what each emoji means so operators do not mistake ✅
+// for "every byte of egress observed". Each emoji must surface with its
+// descriptive blockquote line right under the heading.
+func TestBuildDetectMarkdown_HeadlineBadgeText(t *testing.T) {
+	t.Parallel()
+
+	clean := BuildDetectMarkdown(DigestInput{
+		BPF:       []telemetry.BPFStatus{{Name: "exec", OK: true}},
+		ExecTotal: 1,
+	})
+	if !strings.Contains(clean, "> ✅ **No anomalies detected (IPv4 TCP/UDP in scope)**") {
+		t.Fatalf("clean-run badge text missing:\n%s", clean)
+	}
+
+	review := BuildDetectMarkdown(DigestInput{
+		BPF:                       []telemetry.BPFStatus{{Name: "exec", OK: true}},
+		UDPRingbufReserveFailures: 1,
+	})
+	if !strings.Contains(review, "> ⚠️ **Partial observation or coverage gaps — review required**") {
+		t.Fatalf("review-state badge text missing:\n%s", review)
+	}
+
+	alert := BuildDetectMarkdown(DigestInput{
+		BPF: []telemetry.BPFStatus{{Name: "exec", OK: false}},
+	})
+	if !strings.Contains(alert, "> 🚨 **BPF failure or canary pipeline issue**") {
+		t.Fatalf("alert-state badge text missing:\n%s", alert)
+	}
+}
+
+// TestBuildDetectMarkdown_RunnerHasIPv6_DowngradesVerdict covers the H1 IPv6
+// gating: a runner with IPv6 connectivity but no IPv6 hooks loaded (today:
+// detect mode) downgrades a ✅ run to ⚠️ so the headline reflects the
+// partial observation envelope.
+func TestBuildDetectMarkdown_RunnerHasIPv6_DowngradesVerdict(t *testing.T) {
+	t.Parallel()
+
+	// Detect mode with RunnerHasIPv6 must downgrade to ⚠️.
+	withIPv6 := BuildDetectMarkdown(DigestInput{
+		BPF:           []telemetry.BPFStatus{{Name: "exec", OK: true}},
+		ExecTotal:     1,
+		RunnerHasIPv6: true,
+	})
+	if !strings.Contains(withIPv6, "## ⚠️ coldstep — detect") {
+		t.Fatalf("RunnerHasIPv6 + detect should downgrade to ⚠️:\n%s", withIPv6)
+	}
+	if !strings.Contains(withIPv6, "| IPv6 | ✗ not observed (runner has IPv6 — coverage gap) |") {
+		t.Fatalf("IPv6 coverage row should call out the runner-has-IPv6 gap:\n%s", withIPv6)
+	}
+
+	// Without RunnerHasIPv6 the same input remains ✅.
+	withoutIPv6 := BuildDetectMarkdown(DigestInput{
+		BPF:       []telemetry.BPFStatus{{Name: "exec", OK: true}},
+		ExecTotal: 1,
+	})
+	if !strings.Contains(withoutIPv6, "## ✅ coldstep — detect") {
+		t.Fatalf("baseline detect run should stay ✅:\n%s", withoutIPv6)
+	}
+
+	// Defend mode with RunnerHasIPv6 does NOT downgrade — the IPv6 hooks
+	// are loaded under defend regardless of allowed_ipv6 size.
+	defend := BuildDetectMarkdown(DigestInput{
+		BPF:                 []telemetry.BPFStatus{{Name: "exec", OK: true}},
+		DefendMode:          "defend",
+		DefendAllowlistSize: 1,
+		RunnerHasIPv6:       true,
+	})
+	if !strings.Contains(defend, "## ✅ coldstep — defend") {
+		t.Fatalf("defend mode with IPv6 hooks attached should stay ✅:\n%s", defend)
+	}
+}
+
+// TestBuildDetectMarkdown_CoverageScopeTable_IoUringRow covers the io_uring
+// row in the Coverage scope table: probe loaded → "⚠ partial"; probe absent
+// or attach failed → "✗ not loaded". The enhanced profile adds a TLS peek
+// note to the partial cell.
+func TestBuildDetectMarkdown_CoverageScopeTable_IoUringRow(t *testing.T) {
+	t.Parallel()
+
+	loadedStandard := BuildDetectMarkdown(DigestInput{
+		BPF: []telemetry.BPFStatus{
+			{Name: "exec", OK: true},
+			{Name: "raw_tp/io_uring_submit_sqe", OK: true},
+		},
+		ExecTotal: 1,
+	})
+	if !strings.Contains(loadedStandard, "| io_uring (enhanced profile only) | ⚠ partial (SQE submission only) |") {
+		t.Fatalf("standard profile + loaded io_uring should be ⚠ partial:\n%s", loadedStandard)
+	}
+
+	loadedEnhanced := BuildDetectMarkdown(DigestInput{
+		BPF: []telemetry.BPFStatus{
+			{Name: "exec", OK: true},
+			{Name: "raw_tp/io_uring_submit_sqe", OK: true},
+		},
+		DetectProfile: "enhanced",
+		ExecTotal:     1,
+	})
+	if !strings.Contains(loadedEnhanced, "| io_uring (enhanced profile only) | ⚠ partial (SQE submission + TLS ClientHello peek) |") {
+		t.Fatalf("enhanced profile + loaded io_uring should call out TLS peek:\n%s", loadedEnhanced)
+	}
+
+	failed := BuildDetectMarkdown(DigestInput{
+		BPF: []telemetry.BPFStatus{
+			{Name: "exec", OK: true},
+			{Name: "raw_tp/io_uring_submit_sqe", OK: false, Detail: "tracepoint not present"},
+		},
+		ExecTotal: 1,
+	})
+	if !strings.Contains(failed, "| io_uring (enhanced profile only) | ✗ not loaded |") {
+		t.Fatalf("failed io_uring probe should show ✗ not loaded:\n%s", failed)
+	}
+
+	absent := BuildDetectMarkdown(DigestInput{
+		BPF:       []telemetry.BPFStatus{{Name: "exec", OK: true}},
+		ExecTotal: 1,
+	})
+	if !strings.Contains(absent, "| io_uring (enhanced profile only) | ✗ not loaded |") {
+		t.Fatalf("absent io_uring probe should show ✗ not loaded:\n%s", absent)
+	}
+}
+
+// TestBuildDetectMarkdown_CoverageScopeTable_UnixSocketsAlwaysNotObserved
+// pins the Unix sockets row: coldstep has no AF_UNIX probe today, so the
+// row is structurally "✗ not observed" on every digest.
+func TestBuildDetectMarkdown_CoverageScopeTable_UnixSocketsAlwaysNotObserved(t *testing.T) {
+	t.Parallel()
+	for _, in := range []DigestInput{
+		{},
+		{BPF: []telemetry.BPFStatus{{Name: "exec", OK: true}}, ExecTotal: 5},
+		{DefendMode: "defend", DefendAllowlistSize: 2, BPF: []telemetry.BPFStatus{{Name: "exec", OK: true}}},
+	} {
+		md := BuildDetectMarkdown(in)
+		if !strings.Contains(md, "| Unix sockets | ✗ not observed |") {
+			t.Fatalf("missing Unix sockets coverage row in:\n%s", md)
+		}
+	}
+}
+
+// TestBuildDetectMarkdown_CoverageScopeTable_QUICRowFlipsOnCandidate verifies
+// the QUIC row pivots from "✗ not observed" to a ⚠ cell when port-443 UDP
+// candidates fired this run — the payload is still encrypted, but the row
+// must signal that flows fell into the gap.
+func TestBuildDetectMarkdown_CoverageScopeTable_QUICRowFlipsOnCandidate(t *testing.T) {
+	t.Parallel()
+	withQUIC := BuildDetectMarkdown(DigestInput{
+		BPF:                []telemetry.BPFStatus{{Name: "exec", OK: true}},
+		QUICCandidateCount: 4,
+	})
+	if !strings.Contains(withQUIC, "| QUIC / HTTP3 | ⚠ candidates observed (payload encrypted, not inspected) |") {
+		t.Fatalf("QUIC candidates should flip the coverage cell to ⚠:\n%s", withQUIC)
+	}
+	withoutQUIC := BuildDetectMarkdown(DigestInput{
+		BPF: []telemetry.BPFStatus{{Name: "exec", OK: true}},
+	})
+	if !strings.Contains(withoutQUIC, "| QUIC / HTTP3 | ✗ not observed |") {
+		t.Fatalf("default QUIC cell should be ✗ not observed:\n%s", withoutQUIC)
+	}
+}
+
 func TestBuildDetectMarkdown_NoForbiddenGFMTags(t *testing.T) {
 	// Job Summaries render GFM; <font>, <p align>, <sub>, <center> are not in
 	// the allowlist and would appear as literal text. This guards against
@@ -874,40 +1035,42 @@ func TestBuildDetectMarkdown_DroppedEventCounters(t *testing.T) {
 func TestBuildDetectMarkdown_CoverageScopeBlock_AlwaysPresent(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name       string
-		in         DigestInput
-		ipv6Cell   string
-		extraCells []string
+		name     string
+		in       DigestInput
+		ipv6Cell string
 	}{
 		{"clean detect", DigestInput{
 			BPF:       []telemetry.BPFStatus{{Name: "exec", OK: true}},
 			ExecTotal: 1,
-		}, "IPv6 observed (detect — no enforcement)", nil},
+		}, "| IPv6 | ✗ not observed |"},
 		{"defend gated", DigestInput{
 			DefendMode:              "defend",
 			DefendAllowlistSize:     1,
 			DefendIPv6AllowlistSize: 2,
 			DefendDenyCount:         0,
 			BPF:                     []telemetry.BPFStatus{{Name: "connect", OK: true}},
-		}, "IPv6 gated (defend allowed_ipv6 active)", nil},
+		}, "| IPv6 | ✓ gated (defend allowed_ipv6 active) |"},
 		{"defend block-all", DigestInput{
 			DefendMode:              "defend",
 			DefendAllowlistSize:     1,
 			DefendIPv6AllowlistSize: 0,
 			DefendDenyCount:         0,
 			BPF:                     []telemetry.BPFStatus{{Name: "connect", OK: true}},
-		}, "IPv6 denied (defend block-all — empty allowed_ipv6)", nil},
+		}, "| IPv6 | ✓ gated (defend block-all — empty allowed_ipv6) |"},
 	}
 	for _, c := range cases {
 		md := BuildDetectMarkdown(c.in)
 		needles := []string{
-			"**Coverage this run:**",
-			"IPv4 TCP/UDP ✓ observed",
+			"**Coverage scope**",
+			"| Traffic class | Status |",
+			"| IPv4 TCP | ✓ observed |",
+			"| IPv4 UDP (sendmsg) | ✓ observed |",
 			c.ipv6Cell,
-			"QUIC/HTTP3 ✗ not observed",
-			"Payloads beyond iov[0]: ✓ observed",
+			"| QUIC / HTTP3 | ✗ not observed |",
+			"| io_uring (enhanced profile only) | ✗ not loaded |",
+			"| Unix sockets | ✗ not observed |",
+			"| Payloads beyond iov[0] | ✓ observed |",
 		}
-		needles = append(needles, c.extraCells...)
 		for _, needle := range needles {
 			if !strings.Contains(md, needle) {
 				t.Fatalf("[%s] missing %q in digest:\n%s", c.name, needle, md)
@@ -925,7 +1088,7 @@ func TestBuildDetectMarkdown_CoverageScopeBlock_PartialWhenSendmmsgFirstOnly(t *
 	for _, needle := range []string{
 		"## ⚠️ coldstep — detect",
 		"> ⚠️ Partial coverage — see Coverage block below.",
-		"Payloads beyond iov[0]: ⚠️ partial",
+		"| Payloads beyond iov[0] | ⚠️ partial |",
 	} {
 		if !strings.Contains(md, needle) {
 			t.Fatalf("missing %q in digest:\n%s", needle, md)
@@ -991,6 +1154,8 @@ func TestBuildDetectMarkdown_VisibleLineBudget(t *testing.T) {
 	// A typical detect run should produce a compact visible section (above the
 	// Technical details fold). Count visible lines until the first <details> at
 	// column 0 — that's our budget for what an operator sees by default.
+	// Budget intentionally accommodates the H1 Coverage scope table (≈10 lines)
+	// that makes the observation envelope explicit on every digest.
 	md := BuildDetectMarkdown(DigestInput{
 		BPF:       []telemetry.BPFStatus{{Name: "syscalls", OK: true}},
 		ExecTotal: 12, TCPTotal: 4, UDPTotal: 3, HTTPTotal: 0,
@@ -1005,8 +1170,8 @@ func TestBuildDetectMarkdown_VisibleLineBudget(t *testing.T) {
 	}
 	visible := md[:idx]
 	lines := strings.Count(visible, "\n")
-	if lines > 30 {
-		t.Fatalf("visible portion is %d lines, budget is 30:\n%s", lines, visible)
+	if lines > 40 {
+		t.Fatalf("visible portion is %d lines, budget is 40:\n%s", lines, visible)
 	}
 }
 
@@ -1165,7 +1330,7 @@ func TestBuildDetectMarkdown_SendpageObserved_ClosesPayloadGap(t *testing.T) {
 		SendpageObserved:  3,
 		MaxRowsPerSection: 50,
 	})
-	if !strings.Contains(withSendpage, "Payloads beyond iov[0]: ✓ observed") {
+	if !strings.Contains(withSendpage, "| Payloads beyond iov[0] | ✓ observed |") {
 		t.Fatalf("sendpage_observed > 0 must mark payload coverage as ✓ observed:\n%s", withSendpage)
 	}
 	withoutSendpage := BuildDetectMarkdown(DigestInput{
@@ -1174,7 +1339,7 @@ func TestBuildDetectMarkdown_SendpageObserved_ClosesPayloadGap(t *testing.T) {
 		SendfileObserved:  2,
 		MaxRowsPerSection: 50,
 	})
-	if !strings.Contains(withoutSendpage, "Payloads beyond iov[0]: ⚠️ partial") {
+	if !strings.Contains(withoutSendpage, "| Payloads beyond iov[0] | ⚠️ partial |") {
 		t.Fatalf("missing partial-coverage cell when sendpage_observed = 0 and sendfile fired:\n%s", withoutSendpage)
 	}
 }

--- a/internal/report/digest_types.go
+++ b/internal/report/digest_types.go
@@ -117,6 +117,13 @@ type BPFAuditDigestRow struct {
 type DigestInput struct {
 	DetectProfile string // standard | enhanced (from COLDSTEP_DETECT_PROFILE)
 	BPF           []telemetry.BPFStatus
+	// RunnerHasIPv6 mirrors telemetry.MetaEvent.RunnerHasIPv6 — true when the
+	// runner had at least one non-loopback / non-link-local IPv6 address at
+	// agent startup (H1: digest honesty). Used by verdictEmoji to downgrade
+	// ✅ to ⚠️ on runners with IPv6 connectivity when no IPv6 hooks are
+	// loaded (today: detect mode), surfacing the partial observation in the
+	// headline rather than hiding it behind an apparently clean run.
+	RunnerHasIPv6 bool
 
 	ExecTotal, TCPTotal, UDPTotal, HTTPTotal, TLSTotal int
 	TLSSNIGate                                         bool

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -52,7 +52,14 @@ type MetaEvent struct {
 	// whose wildcard suffix matches a known multi-tenant shared-infrastructure
 	// surface (P1-1 6c). Operators can review and tighten if desired.
 	WildcardRiskDomains []string `json:"wildcard_risk_domains,omitempty"`
-	Sig                 string   `json:"sig,omitempty"`
+	// RunnerHasIPv6 is true when the runner had at least one non-loopback,
+	// non-link-local IPv6 address at agent startup (H1: digest honesty).
+	// Used by the digest to downgrade the ✅ verdict to ⚠️ when the runner
+	// has IPv6 but no IPv6 hooks are loaded — observation is incomplete on
+	// that environment. Population is the action layer's job; the field is
+	// pre-wired here so consumers can rely on it before that lands.
+	RunnerHasIPv6 bool   `json:"runner_has_ipv6,omitempty"`
+	Sig           string `json:"sig,omitempty"`
 }
 
 // MetaGitHub holds non-secret GitHub Actions context.


### PR DESCRIPTION
## Summary

H1 from the v0.2.9 hardening roadmap: make the digest honest about what was and wasn't observed.

- **Headline badge text** spells out what each emoji means so operators do not mistake ✅ for "every byte of egress observed":
  - ✅ **No anomalies detected (IPv4 TCP/UDP in scope)**
  - ⚠️ **Partial observation or coverage gaps — review required**
  - 🚨 **BPF failure or canary pipeline issue**
- **Coverage scope table** replaces the one-line "Coverage this run:" with a 7-row table that names each traffic class and its observation status (IPv4 TCP, IPv4 UDP, IPv6, QUIC/HTTP3, io_uring, Unix sockets, payloads beyond iov[0]). The io_uring row reflects the actual BPF probe status — `⚠ partial` when loaded, `✗ not loaded` when absent/failed — and annotates the enhanced-profile TLS ClientHello peek.
- **`runner_has_ipv6` wiring**: new `MetaEvent.RunnerHasIPv6` + `DigestInput.RunnerHasIPv6` + `config.Config.RunnerHasIPv6` (env: `COLDSTEP_RUNNER_HAS_IPV6`). When the runner advertises IPv6 connectivity and no IPv6 hooks are loaded (today: detect mode), the verdict downgrades ✅ → ⚠️ so the headline reflects the partial envelope. The `/proc/net/if_inet6` detection itself lives in the action layer (separate concern).

The visible-line budget for the above-the-fold portion is bumped 30 → 40 — an intentional H1 trade of compactness for honesty.

## Test plan

- [x] `go test ./...` clean on Linux (WSL)
- [x] `go test -race ./internal/report/... ./internal/agent/... ./internal/telemetry/...`
- [x] `gofmt -l internal/ cmd/` clean
- [x] `go vet ./...` clean
- [x] New tests cover the three verdict labels, the io_uring row state machine, the Unix-sockets always-not-observed invariant, the QUIC candidate flip, and the RunnerHasIPv6 ✅→⚠️ downgrade
- [ ] All 22 CI checks pass
