### PR TITLE
feat(agent): H2 — surface ringbuf drops in JSONL shutdown meta + digest KPI

### DIFF
--- a/.github/pr-bodies/pr-h2-ringbuf-drop-counters.md
+++ b/.github/pr-bodies/pr-h2-ringbuf-drop-counters.md
@@ -1,0 +1,38 @@
+## Summary
+
+Implements **H2** from the v0.2.9 hardening roadmap: make ringbuffer event drops visible in the JSONL output and digest so silent event loss never occurs without a user-visible signal.
+
+The end-to-end path from BPF per-CPU `*_ringbuf_reserve_failures` arrays → `runStats.set*RingbufReserveFailures` → `DigestInput` → digest renderer was already wired (verified during the H2 audit), and `digest.go:98` already includes `totalDetectRingbufReserveFailures(in) > 0` in the `review := …` ⚠️ trigger. This PR adds the missing JSONL surface (a shutdown `MetaEvent` carrying per-channel drop counts) and tightens the digest KPI row label so operators do not have to translate "Ringbuf drops (detect-path total)" → "we lost events".
+
+## What changed
+
+- **`internal/telemetry/event.go`** — new `MetaEvent.DroppedEvents map[string]uint64` (json `dropped_events,omitempty`). Keys are BPF counter names minus the `_ringbuf_reserve_failures` suffix (`connect`, `udp`, `dns`, `http`, `tls`, `exec`, `fork`, `fs`, `ktls`, `bpf_audit`, `tcp_state`, `io_uring`, `deny`). Only emitted on the shutdown `MetaEvent`; the startup `MetaEvent` leaves it nil.
+
+- **`internal/agent/agent_linux_digest.go`** — new `buildDroppedEventsMap(stats, defendState)` helper. Returns `nil` when every counter is zero (so `omitempty` hides the field entirely); otherwise contains only the non-zero entries. Zero keys are dropped at construction time, not at marshal time, so the JSON is genuinely free of `"foo": 0` clutter.
+
+- **`internal/agent/agent_linux.go`** — the existing shutdown defer (the first defer registered in `Run`, therefore LIFO-last) already runs after every BPF per-CPU reader defer has snapshotted into `runStats`. Right after the digest is written, the defer now emits a second `MetaEvent` line into the JSONL with `DroppedEvents` populated, so the *.coldstep-events.jsonl* file always tells the operator what was lost — even if the markdown digest path is suppressed.
+
+- **`internal/report/digest.go`** — rename the Full KPI row from `**⚠️ Ringbuf drops (detect-path total)** | N events dropped` to `**⚠️ Dropped events (ringbuf overflow)** | N`. Matches the H2 spec label and reads cleanly alongside the other KPI rows. Still hidden when `totalDetectRingbufReserveFailures(in) == 0`.
+
+- **`internal/report/digest_test.go`** — updated `TestBuildDetectMarkdown_RingbufDropKPIRow` to match the new label, and added `TestBuildDetectMarkdown_RingbufDropBadge_PerChannel` which walks every detect-path channel (`connect / udp / dns / http / tls / exec / fork / fs / bpf_audit`) and asserts a single non-zero reserve failure flips the headline badge to ⚠️ and renders the KPI row. This is the H2 "silent loss must be visible" guarantee.
+
+- **`internal/agent/agent_linux_test.go`** — `TestBuildDroppedEventsMap_OmitsZerosAndNilWhenClean` (verifies nil when clean, omits zero-valued keys when partial) and `TestBuildDroppedEventsMap_NilDefendState` (detect-only runs that construct no defendState).
+
+## Constraints honored
+
+- No new BPF programs or maps. The shutdown-counter propagation (H2 steps 1–3 + 5–6) was the must-have; the optional real-time `meta_overflow` rate-limit hint (H2 step 4) is intentionally deferred — it requires a new ringbuf map + Go reader and is more invasive than the rest of H2 combined. Filed for a follow-up.
+- The shutdown `MetaEvent` is emitted from the existing first-registered (LIFO-last) defer in `Run`, so it lands *after* every per-CPU reserve-failure counter has been snapshotted into `runStats` — no read race on the agent shutdown path.
+- `dropped_events,omitempty` + nil-when-empty construction means clean runs see no schema churn in their JSONL.
+- No `enforce` references introduced; agent only emits `mode: detect|defend`.
+
+## Validation
+
+- `bash scripts/check-gofmt.sh` — pass.
+- `bash scripts/check-encoding.sh` — pass.
+- `go test ./... -count=1` (WSL, with BPF stubs generated via `scripts/build-agent-linux.sh`) — pass across all packages.
+- BPF compile + verifier load are validated by CI's `coldstep-ci-runner.yml` (`unit`, `unit-arm64`, `integration`, `detect-mode`, `defend-mode`).
+
+## Follow-ups (out of scope)
+
+- **H2 step 4 (BPF real-time overflow hint)** — add a dedicated `overflow_hint_ringbuf` so the Go reader can emit `meta_overflow` JSONL events mid-run when a percpu threshold (e.g. 1000 reserve failures) is crossed. Stretch goal explicitly carved out in the H2 task description because it requires a new BPF ringbuf map + dedicated Go reader.
+- Re-label of the `Ringbuf drops` row reference in `website/index.html` lands in the post-tag website-bump PR per `RELEASE_PROCESS.md`; the marketing copy still accurately describes the surface.

--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -128,6 +128,21 @@ func Run(ctx context.Context, cfg config.Config) error {
 				slog.Warn("detect digest", "err", err)
 			}
 		}
+		// H2: emit a shutdown MetaEvent line carrying per-channel ringbuf
+		// reserve-failure counts under `dropped_events`. The startup meta is
+		// already in JSONL; this second meta lands at the very end of the run
+		// so consumers can see silent event loss without parsing the digest.
+		// Map is nil (and omitted) when every counter is zero.
+		if cfg.EventsLogPath != "" {
+			if shutdownMeta, err := telemetry.BuildMeta(agentVersionString(), bpfSt, cfg.DetectProfile); err != nil {
+				slog.Warn("build shutdown meta", "err", err)
+			} else {
+				shutdownMeta.DroppedEvents = buildDroppedEventsMap(stats, defendState)
+				if err := telemetry.AppendJSONL(cfg.EventsLogPath, shutdownMeta, signer); err != nil {
+					slog.Warn("shutdown meta jsonl", "err", err)
+				}
+			}
+		}
 	}()
 
 	compileCtx, compileCancel := context.WithTimeout(ctx, 120*time.Second)

--- a/internal/agent/agent_linux_digest.go
+++ b/internal/agent/agent_linux_digest.go
@@ -14,6 +14,40 @@ import (
 	"github.com/coldstep-io/coldstep/internal/telemetry"
 )
 
+// buildDroppedEventsMap returns a map of ringbuf reserve failures keyed by
+// event-type slug (BPF counter name minus the `_ringbuf_reserve_failures`
+// suffix). Returns nil when every counter is zero so MetaEvent.DroppedEvents
+// omitempty hides the field entirely. The map is the H2 "silent event loss
+// must be visible" surface — operators reading the JSONL shutdown meta can see
+// at a glance which channels lost events without parsing the digest.
+func buildDroppedEventsMap(stats *runStats, defendState *defendState) map[string]uint64 {
+	m := make(map[string]uint64, 13)
+	add := func(k string, v int) {
+		if v > 0 {
+			m[k] = uint64(v)
+		}
+	}
+	add("connect", stats.connectRingbufReserveFailures())
+	add("udp", stats.udpRingbufReserveFailures())
+	add("dns", stats.dnsRingbufReserveFailures())
+	add("http", stats.httpRingbufReserveFailures())
+	add("tls", stats.tlsRingbufReserveFailures())
+	add("exec", stats.execRingbufReserveFailures())
+	add("fork", stats.forkRingbufReserveFailures())
+	add("fs", stats.fsRingbufReserveFailures())
+	add("ktls", stats.ktlsRingbufReserveFailures())
+	add("bpf_audit", stats.bpfAuditRingbufReserveFailures())
+	add("tcp_state", stats.tcpStateRingbufReserveFailures())
+	add("io_uring", stats.ioUringRingbufReserveFailures())
+	if defendState != nil {
+		add("deny", defendState.snapshot().denyReserveFailures)
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	return m
+}
+
 func preferRunError(current error, candidate error) error {
 	if candidate == nil || errors.Is(candidate, context.Canceled) {
 		return current

--- a/internal/agent/agent_linux_test.go
+++ b/internal/agent/agent_linux_test.go
@@ -1307,3 +1307,58 @@ func TestReadUint32PerCPUArraySum_NilMapReturnsZero(t *testing.T) {
 		t.Fatalf("expected no log output on nil map, got: %q", buf.String())
 	}
 }
+
+// TestBuildDroppedEventsMap_OmitsZerosAndNilWhenClean asserts the H2 shutdown
+// meta surface: when no ringbuf reserve failed, the map is nil so MetaEvent's
+// omitempty hides the field. When some channels failed, the map contains only
+// the non-zero entries keyed by BPF-counter-name-minus-suffix.
+func TestBuildDroppedEventsMap_OmitsZerosAndNilWhenClean(t *testing.T) {
+	stats := newRunStats()
+	defst := newDefendState()
+	if got := buildDroppedEventsMap(stats, defst); got != nil {
+		t.Fatalf("expected nil map when all counters zero, got %#v", got)
+	}
+
+	stats.setConnectRingbufReserveFailures(3)
+	stats.setUDPRingbufReserveFailures(0)
+	stats.setHTTPRingbufReserveFailures(1)
+	stats.setTLSRingbufReserveFailures(0)
+	stats.setIoUringRingbufReserveFailures(2)
+	defst.setDenyReserveFailures(5)
+
+	got := buildDroppedEventsMap(stats, defst)
+	want := map[string]uint64{
+		"connect":  3,
+		"http":     1,
+		"io_uring": 2,
+		"deny":     5,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Fatalf("key %q: got %d, want %d (full map: %v)", k, got[k], v, got)
+		}
+	}
+	if _, ok := got["udp"]; ok {
+		t.Fatalf("zero-valued udp key should be omitted, got %v", got)
+	}
+	if _, ok := got["tls"]; ok {
+		t.Fatalf("zero-valued tls key should be omitted, got %v", got)
+	}
+}
+
+// TestBuildDroppedEventsMap_NilDefendState guards the defend-disabled path
+// (detect-only runs construct no defendState — historically a nil pointer).
+func TestBuildDroppedEventsMap_NilDefendState(t *testing.T) {
+	stats := newRunStats()
+	stats.setUDPRingbufReserveFailures(7)
+	got := buildDroppedEventsMap(stats, nil)
+	if got["udp"] != 7 {
+		t.Fatalf("expected udp=7, got %v", got)
+	}
+	if _, ok := got["deny"]; ok {
+		t.Fatalf("deny key should be absent when defendState is nil, got %v", got)
+	}
+}

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -598,7 +598,7 @@ func writeFullKPITable(b *strings.Builder, in DigestInput) {
 		fmt.Fprintf(b, "| **dropped events (decode/jsonl)** | %d |\n", dt)
 	}
 	if rb := totalDetectRingbufReserveFailures(in); rb > 0 {
-		fmt.Fprintf(b, "| **⚠️ Ringbuf drops (detect-path total)** | %d events dropped |\n", rb)
+		fmt.Fprintf(b, "| **⚠️ Dropped events (ringbuf overflow)** | %d |\n", rb)
 	}
 
 	// --- health (last) ---

--- a/internal/report/digest_test.go
+++ b/internal/report/digest_test.go
@@ -1115,6 +1115,44 @@ func TestBuildDetectMarkdown_AllowlistTrust_DefendUnresolved(t *testing.T) {
 	}
 }
 
+// TestBuildDetectMarkdown_RingbufDropBadge_PerChannel asserts that every
+// detect-path ringbuf reserve failure counter individually flips the headline
+// badge to ⚠️. This is the H2 "silent loss must be visible" guarantee: any
+// channel losing events on its own is enough to override the otherwise-✅
+// verdict, with no other counters required.
+func TestBuildDetectMarkdown_RingbufDropBadge_PerChannel(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   DigestInput
+	}{
+		{"connect", DigestInput{ConnectRingbufReserveFailures: 1}},
+		{"udp", DigestInput{UDPRingbufReserveFailures: 1}},
+		{"dns", DigestInput{DNSRingbufReserveFailures: 1}},
+		{"http", DigestInput{HTTPRingbufReserveFailures: 1}},
+		{"tls", DigestInput{TLSRingbufReserveFailures: 1}},
+		{"exec", DigestInput{ExecRingbufReserveFailures: 1}},
+		{"fork", DigestInput{ForkRingbufReserveFailures: 1}},
+		{"fs", DigestInput{FSRingbufReserveFailures: 1}},
+		{"bpf_audit", DigestInput{BPFAuditRingbufReserveFailures: 1}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			in := tc.in
+			in.BPF = []telemetry.BPFStatus{{Name: "syscalls", OK: true}}
+			md := BuildDetectMarkdown(in)
+			if !strings.Contains(md, "## ⚠️ coldstep — detect") {
+				t.Fatalf("expected ⚠️ header for %s channel; got:\n%s", tc.name, md)
+			}
+			if !strings.Contains(md, "**⚠️ Dropped events (ringbuf overflow)**") {
+				t.Fatalf("expected dropped-events KPI row for %s channel; got:\n%s", tc.name, md)
+			}
+		})
+	}
+}
+
 func TestBuildDetectMarkdown_RingbufDropKPIRow(t *testing.T) {
 	t.Parallel()
 	md := BuildDetectMarkdown(DigestInput{
@@ -1125,7 +1163,7 @@ func TestBuildDetectMarkdown_RingbufDropKPIRow(t *testing.T) {
 	for _, needle := range []string{
 		"## ⚠️ coldstep — detect",
 		"> ⚠️ Partial coverage — see Coverage block below.",
-		"| **⚠️ Ringbuf drops (detect-path total)** | 5 events dropped |",
+		"| **⚠️ Dropped events (ringbuf overflow)** | 5 |",
 	} {
 		if !strings.Contains(md, needle) {
 			t.Fatalf("missing %q in digest:\n%s", needle, md)
@@ -1135,7 +1173,7 @@ func TestBuildDetectMarkdown_RingbufDropKPIRow(t *testing.T) {
 		BPF:       []telemetry.BPFStatus{{Name: "syscalls", OK: true}},
 		ExecTotal: 1,
 	})
-	if strings.Contains(cleanMD, "Ringbuf drops (detect-path total)") {
+	if strings.Contains(cleanMD, "Dropped events (ringbuf overflow)") {
 		t.Fatalf("ringbuf drop row should be hidden when no drops; got:\n%s", cleanMD)
 	}
 }

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -58,8 +58,15 @@ type MetaEvent struct {
 	// has IPv6 but no IPv6 hooks are loaded — observation is incomplete on
 	// that environment. Population is the action layer's job; the field is
 	// pre-wired here so consumers can rely on it before that lands.
-	RunnerHasIPv6 bool   `json:"runner_has_ipv6,omitempty"`
-	Sig           string `json:"sig,omitempty"`
+	RunnerHasIPv6 bool `json:"runner_has_ipv6,omitempty"`
+	// DroppedEvents counts ringbuffer reserve failures per event type at shutdown.
+	// Non-zero values indicate silent event loss during the run. Keys are the BPF
+	// counter names minus the `_ringbuf_reserve_failures` suffix (e.g. "connect",
+	// "udp", "http", "tls", "deny", "io_uring"). Only emitted on the shutdown
+	// MetaEvent; the startup MetaEvent leaves this nil (omitted). The map is set
+	// to nil when all counters are zero so omitempty hides it entirely.
+	DroppedEvents map[string]uint64 `json:"dropped_events,omitempty"`
+	Sig           string            `json:"sig,omitempty"`
 }
 
 // MetaGitHub holds non-secret GitHub Actions context.


### PR DESCRIPTION
## Summary

Implements **H2** from the v0.2.9 hardening roadmap: make ringbuffer event drops visible in the JSONL output and digest so silent event loss never occurs without a user-visible signal.

The end-to-end path from BPF per-CPU `*_ringbuf_reserve_failures` arrays → `runStats.set*RingbufReserveFailures` → `DigestInput` → digest renderer was already wired (verified during the H2 audit), and `digest.go:98` already includes `totalDetectRingbufReserveFailures(in) > 0` in the `review := …` ⚠️ trigger. This PR adds the missing JSONL surface (a shutdown `MetaEvent` carrying per-channel drop counts) and tightens the digest KPI row label so operators do not have to translate "Ringbuf drops (detect-path total)" → "we lost events".

## What changed

- **`internal/telemetry/event.go`** — new `MetaEvent.DroppedEvents map[string]uint64` (json `dropped_events,omitempty`). Keys are BPF counter names minus the `_ringbuf_reserve_failures` suffix (`connect`, `udp`, `dns`, `http`, `tls`, `exec`, `fork`, `fs`, `ktls`, `bpf_audit`, `tcp_state`, `io_uring`, `deny`). Only emitted on the shutdown `MetaEvent`; the startup `MetaEvent` leaves it nil.

- **`internal/agent/agent_linux_digest.go`** — new `buildDroppedEventsMap(stats, defendState)` helper. Returns `nil` when every counter is zero (so `omitempty` hides the field entirely); otherwise contains only the non-zero entries. Zero keys are dropped at construction time, not at marshal time, so the JSON is genuinely free of `"foo": 0` clutter.

- **`internal/agent/agent_linux.go`** — the existing shutdown defer (the first defer registered in `Run`, therefore LIFO-last) already runs after every BPF per-CPU reader defer has snapshotted into `runStats`. Right after the digest is written, the defer now emits a second `MetaEvent` line into the JSONL with `DroppedEvents` populated, so the *.coldstep-events.jsonl* file always tells the operator what was lost — even if the markdown digest path is suppressed.

- **`internal/report/digest.go`** — rename the Full KPI row from `**⚠️ Ringbuf drops (detect-path total)** | N events dropped` to `**⚠️ Dropped events (ringbuf overflow)** | N`. Matches the H2 spec label and reads cleanly alongside the other KPI rows. Still hidden when `totalDetectRingbufReserveFailures(in) == 0`.

- **`internal/report/digest_test.go`** — updated `TestBuildDetectMarkdown_RingbufDropKPIRow` to match the new label, and added `TestBuildDetectMarkdown_RingbufDropBadge_PerChannel` which walks every detect-path channel (`connect / udp / dns / http / tls / exec / fork / fs / bpf_audit`) and asserts a single non-zero reserve failure flips the headline badge to ⚠️ and renders the KPI row. This is the H2 "silent loss must be visible" guarantee.

- **`internal/agent/agent_linux_test.go`** — `TestBuildDroppedEventsMap_OmitsZerosAndNilWhenClean` (verifies nil when clean, omits zero-valued keys when partial) and `TestBuildDroppedEventsMap_NilDefendState` (detect-only runs that construct no defendState).

## Constraints honored

- No new BPF programs or maps. The shutdown-counter propagation (H2 steps 1–3 + 5–6) was the must-have; the optional real-time `meta_overflow` rate-limit hint (H2 step 4) is intentionally deferred — it requires a new ringbuf map + Go reader and is more invasive than the rest of H2 combined. Filed for a follow-up.
- The shutdown `MetaEvent` is emitted from the existing first-registered (LIFO-last) defer in `Run`, so it lands *after* every per-CPU reserve-failure counter has been snapshotted into `runStats` — no read race on the agent shutdown path.
- `dropped_events,omitempty` + nil-when-empty construction means clean runs see no schema churn in their JSONL.
- No `enforce` references introduced; agent only emits `mode: detect|defend`.

## Validation

- `bash scripts/check-gofmt.sh` — pass.
- `bash scripts/check-encoding.sh` — pass.
- `go test ./... -count=1` (WSL, with BPF stubs generated via `scripts/build-agent-linux.sh`) — pass across all packages.
- BPF compile + verifier load are validated by CI's `coldstep-ci-runner.yml` (`unit`, `unit-arm64`, `integration`, `detect-mode`, `defend-mode`).

## Follow-ups (out of scope)

- **H2 step 4 (BPF real-time overflow hint)** — add a dedicated `overflow_hint_ringbuf` so the Go reader can emit `meta_overflow` JSONL events mid-run when a percpu threshold (e.g. 1000 reserve failures) is crossed. Stretch goal explicitly carved out in the H2 task description because it requires a new BPF ringbuf map + dedicated Go reader.
- Re-label of the `Ringbuf drops` row reference in `website/index.html` lands in the post-tag website-bump PR per `RELEASE_PROCESS.md`; the marketing copy still accurately describes the surface.
