### PR TITLE
feat(telemetry): H5 — coverage telemetry stub in MetaEvent

### DIFF
--- a/.github/pr-bodies/pr-h5-coverage-telemetry-stub.md
+++ b/.github/pr-bodies/pr-h5-coverage-telemetry-stub.md
@@ -1,0 +1,19 @@
+## Summary
+
+H5 from the v0.2.9 hardening roadmap (item 11a): structured **coverage telemetry stub** in the MetaEvent. This is the machine-readable twin of H1's "Coverage scope" table — downstream consumers (report pipeline, dashboards, audit tooling) can now reason about the per-run observation envelope without re-deriving it from individual BPF status rows.
+
+- **New `telemetry.CoverageReport`** in `internal/telemetry/event.go` (six fields, locked JSON shape so consumers can rely on it across releases):
+  - `ipv4_tcp`, `ipv4_udp_sendmsg` — always `true`; both classes are gated by always-wired cgroup hooks.
+  - `ipv6`, `quic_http3` — always `false` for v0.2.9; the underlying probes are not yet implemented. Shipping the keys now (not `omitempty`) keeps the schema stable as those probes land.
+  - `tls_sni_full` — `"full"` when the `tls_sni` feature gate is on **and** the `raw_tp/sys_enter` TLS sniff hook attached cleanly; `"none"` otherwise. The `"partial"` enum value is reserved for future probe variants.
+  - `io_uring` — `true` when `raw_tp/io_uring_submit_sqe` attached this run.
+- **MetaEvent embeds a `*CoverageReport`** under JSON key `coverage` (`omitempty`). Populated in the same block in `internal/agent/agent_linux.go` that already sets `Capabilities` / `AllowlistIPCount` / `RunnerHasIPv6`. A new `buildCoverageReport` helper in `agent_linux_digest.go` composes the report from the existing BPF status slice + feature gate state + `ioUringRd.R` attach signal.
+- **No digest changes** — H1 (PR #193) already renders the human-facing Coverage scope table; H5 adds the structured form alongside, without duplicating the rendering.
+
+## Test plan
+
+- [x] `go test ./internal/telemetry/... ./internal/report/... ./internal/agent/...` clean on Windows
+- [x] `gofmt -l .` clean
+- [x] `scripts/check-encoding.sh` clean
+- [x] New telemetry tests cover the JSON shape (all six keys present), the `omitempty` behaviour of the MetaEvent pointer, and the `buildCoverageReport` state machine (gate off, gate on + probe ok / degraded / missing, io_uring attached)
+- [ ] All CI checks pass (Linux integration paths exercise the agent population end-to-end)

--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -800,6 +800,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 				meta.WildcardRiskDomains = append([]string(nil), defendCompiled.WildcardRiskDomains...)
 			}
 			meta.RunnerHasIPv6 = cfg.RunnerHasIPv6
+			meta.Coverage = buildCoverageReport(bpfSt, tlsSNIGate, ioUringRd.R != nil)
 			if err := telemetry.AppendJSONL(cfg.EventsLogPath, meta, signer); err != nil {
 				slog.Warn("meta jsonl", "err", err)
 			}

--- a/internal/agent/agent_linux_digest.go
+++ b/internal/agent/agent_linux_digest.go
@@ -86,6 +86,30 @@ func capabilityEnabled(gate bool, bpf []telemetry.BPFStatus, hookName string) bo
 	return gate && !hookDegraded(bpf, hookName)
 }
 
+// buildCoverageReport assembles the H5 v0.2.9 telemetry coverage stub embedded
+// in the meta JSONL record. It is the structured (machine-readable) twin of
+// the digest's "Coverage scope" table (rendered by H1 / writeCoverage). IPv4
+// TCP and IPv4 UDP sendmsg are always wired by the agent's cgroup hooks, so
+// they are reported as `true` independent of probe attach status; the BPF
+// status rows on the same MetaEvent already carry the per-probe outcomes.
+// IPv6 and QUIC/HTTP3 are reported as `false` until the underlying probes
+// land. TLSSNI uses the same gate+hook composition as the `tls_sni`
+// capability flag so a degraded BPF probe demotes coverage to "none".
+func buildCoverageReport(bpf []telemetry.BPFStatus, tlsSNIGate, ioUringAttached bool) *telemetry.CoverageReport {
+	tls := "none"
+	if capabilityEnabled(tlsSNIGate, bpf, "raw_tp/sys_enter (connect, sendto, http sniff, tls)") {
+		tls = "full"
+	}
+	return &telemetry.CoverageReport{
+		IPv4TCP:        true,
+		IPv4UDPSendmsg: true,
+		IPv6:           false,
+		QUICHTTP3:      false,
+		TLSSNI:         tls,
+		IoUring:        ioUringAttached,
+	}
+}
+
 // digestDefendLabel maps internal defend snapshot + config to the digest/JSONL-facing mode name.
 func digestDefendLabel(cfg config.Config, snap defendSnapshot) string {
 	if cfg.Mode != config.ModeDefend {

--- a/internal/agent/coverage_report_linux_test.go
+++ b/internal/agent/coverage_report_linux_test.go
@@ -1,0 +1,97 @@
+//go:build linux
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/coldstep-io/coldstep/internal/telemetry"
+)
+
+// TestBuildCoverageReport covers the H5 v0.2.9 telemetry-stub composition:
+// - IPv4 TCP / UDP sendmsg always true (always-wired cgroup hooks)
+// - IPv6 / QUICHTTP3 always false (probes not yet implemented)
+// - TLSSNI flips on gate + non-degraded probe; "none" otherwise
+// - IoUring tracks ioUringRd.R != nil at MetaEvent build time
+func TestBuildCoverageReport(t *testing.T) {
+	t.Parallel()
+
+	const tlsSniffHook = "raw_tp/sys_enter (connect, sendto, http sniff, tls)"
+
+	cases := []struct {
+		name        string
+		bpf         []telemetry.BPFStatus
+		tlsGate     bool
+		ioUring     bool
+		wantTLSSNI  string
+		wantIoUring bool
+	}{
+		{
+			name:        "default detect — gate off",
+			bpf:         []telemetry.BPFStatus{{Name: tlsSniffHook, OK: true}},
+			tlsGate:     false,
+			ioUring:     false,
+			wantTLSSNI:  "none",
+			wantIoUring: false,
+		},
+		{
+			name:        "gate on + probe ok → full",
+			bpf:         []telemetry.BPFStatus{{Name: tlsSniffHook, OK: true}},
+			tlsGate:     true,
+			ioUring:     false,
+			wantTLSSNI:  "full",
+			wantIoUring: false,
+		},
+		{
+			name:        "gate on + probe degraded → none",
+			bpf:         []telemetry.BPFStatus{{Name: tlsSniffHook, OK: false, Detail: "attach failed"}},
+			tlsGate:     true,
+			ioUring:     false,
+			wantTLSSNI:  "none",
+			wantIoUring: false,
+		},
+		{
+			name:        "gate on + probe missing from bpf list → none",
+			bpf:         []telemetry.BPFStatus{},
+			tlsGate:     true,
+			ioUring:     false,
+			wantTLSSNI:  "none",
+			wantIoUring: false,
+		},
+		{
+			name:        "io_uring attached → true",
+			bpf:         []telemetry.BPFStatus{{Name: tlsSniffHook, OK: true}},
+			tlsGate:     true,
+			ioUring:     true,
+			wantTLSSNI:  "full",
+			wantIoUring: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildCoverageReport(tc.bpf, tc.tlsGate, tc.ioUring)
+			if got == nil {
+				t.Fatal("expected non-nil CoverageReport")
+			}
+			if !got.IPv4TCP {
+				t.Errorf("IPv4TCP = false, want true (always-wired cgroup hook)")
+			}
+			if !got.IPv4UDPSendmsg {
+				t.Errorf("IPv4UDPSendmsg = false, want true (always-wired cgroup hook)")
+			}
+			if got.IPv6 {
+				t.Errorf("IPv6 = true, want false until probe ships")
+			}
+			if got.QUICHTTP3 {
+				t.Errorf("QUICHTTP3 = true, want false until probe ships")
+			}
+			if got.TLSSNI != tc.wantTLSSNI {
+				t.Errorf("TLSSNI = %q, want %q", got.TLSSNI, tc.wantTLSSNI)
+			}
+			if got.IoUring != tc.wantIoUring {
+				t.Errorf("IoUring = %v, want %v", got.IoUring, tc.wantIoUring)
+			}
+		})
+	}
+}

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -66,7 +66,33 @@ type MetaEvent struct {
 	// MetaEvent; the startup MetaEvent leaves this nil (omitted). The map is set
 	// to nil when all counters are zero so omitempty hides it entirely.
 	DroppedEvents map[string]uint64 `json:"dropped_events,omitempty"`
-	Sig           string            `json:"sig,omitempty"`
+	// Coverage is the H5 v0.2.9 telemetry stub — structured per-run summary
+	// of which traffic classes coldstep observed. It is the machine-readable
+	// twin of the digest's "Coverage scope" table; the digest already
+	// renders this information via H1 (PR #193).
+	Coverage *CoverageReport `json:"coverage,omitempty"`
+	Sig      string          `json:"sig,omitempty"`
+}
+
+// CoverageReport summarizes which traffic classes coldstep observed on this
+// run. H5 v0.2.9 telemetry stub: emitted in the MetaEvent so downstream
+// consumers can reason about the observation envelope without re-deriving it
+// from individual probe-attach rows.
+//
+// IPv6 and QUICHTTP3 are wired as `false` for v0.2.9 because the underlying
+// probes are not yet implemented in the agent. They ship as explicit fields
+// (not omitempty) so consumers can rely on the shape being stable as those
+// probes land.
+type CoverageReport struct {
+	IPv4TCP        bool `json:"ipv4_tcp"`
+	IPv4UDPSendmsg bool `json:"ipv4_udp_sendmsg"`
+	IPv6           bool `json:"ipv6"`
+	QUICHTTP3      bool `json:"quic_http3"`
+	// TLSSNI is "full" when the TLS ClientHello sniff probe attached and the
+	// tls_sni feature gate is on, "none" otherwise. "partial" is reserved for
+	// future probe variants that capture some-but-not-all SNI sources.
+	TLSSNI  string `json:"tls_sni_full"`
+	IoUring bool   `json:"io_uring"`
 }
 
 // MetaGitHub holds non-secret GitHub Actions context.

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -266,6 +266,84 @@ func TestTCPStateName(t *testing.T) {
 	}
 }
 
+// TestCoverageReportJSON locks the on-disk shape of the H5 telemetry stub.
+// The field set ships at v0.2.9 even though IPv6 / QUICHTTP3 are wired as
+// false — consumers can rely on the keys being present and stable as those
+// probes land in later releases.
+func TestCoverageReportJSON(t *testing.T) {
+	t.Parallel()
+	cr := CoverageReport{
+		IPv4TCP:        true,
+		IPv4UDPSendmsg: true,
+		IPv6:           false,
+		QUICHTTP3:      false,
+		TLSSNI:         "full",
+		IoUring:        true,
+	}
+	b, err := json.Marshal(cr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, needle := range []string{
+		`"ipv4_tcp":true`,
+		`"ipv4_udp_sendmsg":true`,
+		`"ipv6":false`,
+		`"quic_http3":false`,
+		`"tls_sni_full":"full"`,
+		`"io_uring":true`,
+	} {
+		if !bytes.Contains(b, []byte(needle)) {
+			t.Fatalf("missing %s in %s", needle, string(b))
+		}
+	}
+	var got CoverageReport
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got != cr {
+		t.Fatalf("round-trip mismatch: got %+v want %+v", got, cr)
+	}
+}
+
+// TestMetaEventCoverage_OmitEmpty verifies the MetaEvent.Coverage pointer is
+// dropped from JSON when nil (older releases / write paths that don't yet
+// populate it should not emit an empty object).
+func TestMetaEventCoverage_OmitEmpty(t *testing.T) {
+	t.Parallel()
+	m := MetaEvent{
+		Type:          "meta",
+		SchemaVersion: SchemaVersion,
+		TS:            "2026-05-20T00:00:00Z",
+		AgentVersion:  "test",
+		KernelRelease: "6.0.0",
+		GitHub:        MetaGitHub{},
+		BPF:           []BPFStatus{},
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(b, []byte(`"coverage"`)) {
+		t.Fatalf("nil Coverage should be omitted, got %s", b)
+	}
+
+	m.Coverage = &CoverageReport{
+		IPv4TCP:        true,
+		IPv4UDPSendmsg: true,
+		TLSSNI:         "none",
+	}
+	b, err = json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(b, []byte(`"coverage":{`)) {
+		t.Fatalf("populated Coverage should appear in JSON, got %s", b)
+	}
+	if !bytes.Contains(b, []byte(`"tls_sni_full":"none"`)) {
+		t.Fatalf("missing tls_sni_full in %s", b)
+	}
+}
+
 func TestFSEvent_RoundTrip(t *testing.T) {
 	t.Parallel()
 	ev := FSEvent{


### PR DESCRIPTION
## Summary

H5 from the v0.2.9 hardening roadmap (item 11a): structured **coverage telemetry stub** in the MetaEvent. This is the machine-readable twin of H1's "Coverage scope" table — downstream consumers (report pipeline, dashboards, audit tooling) can now reason about the per-run observation envelope without re-deriving it from individual BPF status rows.

- **New `telemetry.CoverageReport`** in `internal/telemetry/event.go` (six fields, locked JSON shape so consumers can rely on it across releases):
  - `ipv4_tcp`, `ipv4_udp_sendmsg` — always `true`; both classes are gated by always-wired cgroup hooks.
  - `ipv6`, `quic_http3` — always `false` for v0.2.9; the underlying probes are not yet implemented. Shipping the keys now (not `omitempty`) keeps the schema stable as those probes land.
  - `tls_sni_full` — `"full"` when the `tls_sni` feature gate is on **and** the `raw_tp/sys_enter` TLS sniff hook attached cleanly; `"none"` otherwise. The `"partial"` enum value is reserved for future probe variants.
  - `io_uring` — `true` when `raw_tp/io_uring_submit_sqe` attached this run.
- **MetaEvent embeds a `*CoverageReport`** under JSON key `coverage` (`omitempty`). Populated in the same block in `internal/agent/agent_linux.go` that already sets `Capabilities` / `AllowlistIPCount` / `RunnerHasIPv6`. A new `buildCoverageReport` helper in `agent_linux_digest.go` composes the report from the existing BPF status slice + feature gate state + `ioUringRd.R` attach signal.
- **No digest changes** — H1 (PR #193) already renders the human-facing Coverage scope table; H5 adds the structured form alongside, without duplicating the rendering.

## Test plan

- [x] `go test ./internal/telemetry/... ./internal/report/... ./internal/agent/...` clean on Windows
- [x] `gofmt -l .` clean
- [x] `scripts/check-encoding.sh` clean
- [x] New telemetry tests cover the JSON shape (all six keys present), the `omitempty` behaviour of the MetaEvent pointer, and the `buildCoverageReport` state machine (gate off, gate on + probe ok / degraded / missing, io_uring attached)
- [ ] All CI checks pass (Linux integration paths exercise the agent population end-to-end)
