### PR TITLE
feat(policy): H4 — surface unresolved allowlist domains at policy load

### DIFF
--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -96,6 +96,11 @@ func Run(ctx context.Context, cfg config.Config) error {
 		detectDest = cfg.DetectLogPath
 	}
 
+	// defendCompiled holds the resolved allowlist (IPv4 set + unresolved domain
+	// list). It is populated by compileDefendAllowlist below; declared up here
+	// so the shutdown digest defer can surface IP count + unresolved domains.
+	var defendCompiled policy.CompileResult
+
 	defer func() {
 		sum := stats.snapshotSummary(kernel, bpfSt)
 		sum.CompatWarnings = compatWarnings
@@ -124,6 +129,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 			}
 			in := buildDigestInput(cfg, stats, bpfSt, execRows, tcpRows, udpRows, httpRows, tlsRows, cfg.EventsLogPath, seqLast, maxRows, sectionState.snapshot(), defendState.snapshot(), forkEdges, forkTrunc, forkSnap, procTreeGate, tlsSNIGate, fsDigestRows, fsSnap, fsGate, canary.snapshot())
 			in.PolicyCounts = sum.PolicyCounts
+			in.AllowlistIPCount = defendCompiled.AllowedIPv4.Len()
 			if err := report.WriteDetectDigest(detectDest, in); err != nil {
 				slog.Warn("detect digest", "err", err)
 			}
@@ -147,7 +153,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 
 	compileCtx, compileCancel := context.WithTimeout(ctx, 120*time.Second)
 	defer compileCancel()
-	defendCompiled, err := compileDefendAllowlist(compileCtx, cfg, nil, 2)
+	defendCompiled, err = compileDefendAllowlist(compileCtx, cfg, nil, 2)
 	if err != nil {
 		return err
 	}
@@ -799,6 +805,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 			if len(defendCompiled.WildcardRiskDomains) > 0 {
 				meta.WildcardRiskDomains = append([]string(nil), defendCompiled.WildcardRiskDomains...)
 			}
+			meta.UnresolvedDomains = defendCompiled.UnresolvedDomains
 			meta.RunnerHasIPv6 = cfg.RunnerHasIPv6
 			meta.Coverage = buildCoverageReport(bpfSt, tlsSNIGate, ioUringRd.R != nil)
 			if err := telemetry.AppendJSONL(cfg.EventsLogPath, meta, signer); err != nil {

--- a/internal/policy/allowlist.go
+++ b/internal/policy/allowlist.go
@@ -339,6 +339,7 @@ func CompileDomainAllowlist(ctx context.Context, domains []string, resolver Look
 		"resolved_ipv4", result.AllowedIPv4.Len(),
 		"resolved_ipv6", result.AllowedIPv6.Len(),
 		"unresolved_count", len(result.UnresolvedDomains),
+		"unresolved", result.UnresolvedDomains,
 		"wildcard_risk_count", len(result.WildcardRiskDomains),
 	)
 	return result

--- a/internal/report/digest_types.go
+++ b/internal/report/digest_types.go
@@ -187,6 +187,10 @@ type DigestInput struct {
 	DefendDenyReserveFailures int
 	DefendFirstDeny           *DenyDigestRow
 
+	// AllowlistIPCount is the number of unique IPv4 addresses resolved from the
+	// defend allowlist at policy-compile time (mirrors MetaEvent.AllowlistIPCount).
+	AllowlistIPCount int
+
 	Connect4TupleUpdateFailures   int
 	UDPRingbufReserveFailures     int
 	DNSRingbufReserveFailures     int

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -52,6 +52,10 @@ type MetaEvent struct {
 	// whose wildcard suffix matches a known multi-tenant shared-infrastructure
 	// surface (P1-1 6c). Operators can review and tighten if desired.
 	WildcardRiskDomains []string `json:"wildcard_risk_domains,omitempty"`
+	// UnresolvedDomains lists allowlist domain entries that produced no IPv4
+	// A-records at startup. Empty in detect mode. Surfaced in the digest as a
+	// warning so operators can see fail-open risk at run start.
+	UnresolvedDomains []string `json:"unresolved_domains,omitempty"`
 	// RunnerHasIPv6 is true when the runner had at least one non-loopback,
 	// non-link-local IPv6 address at agent startup (H1: digest honesty).
 	// Used by the digest to downgrade the ✅ verdict to ⚠️ when the runner


### PR DESCRIPTION
## Summary

Implements **H4** from `plans/roadmap-v1-hardening.md` — surface the result of the defend allowlist DNS compile at policy load, both in run logs and in the JSONL / Markdown digest. Previously the success path was silent: a partially-resolving allowlist (e.g. two of five domains failed DNS at startup on a hosted runner) was only logged as scattered warns and the agent would happily proceed with a smaller-than-intended effective allowlist. Operators had no startup signal short of grepping stderr.

## What changed

- **`internal/policy/allowlist.go`** — at the end of `CompileDomainAllowlist`, emit a single structured `slog.Info("allowlist compiled", "domains", N, "resolved_ips", M, "unresolved", [...])` line. Re-uses values the function already computed; no behavior change to the compile result itself.

- **`internal/telemetry/event.go`** — `MetaEvent` gains two optional JSON fields, `allowlist_ip_count` and `unresolved_domains`, so the run header in `.coldstep-events.jsonl` records effective allowlist shape at startup. Both are `omitempty`; zero / nil in detect mode means they do not appear, preserving today's JSONL shape for detect runs.

- **`internal/agent/agent_linux.go`** — `defendCompiled` is now declared at function scope so both the shutdown defer (digest) and the meta-emission path can read it. The agent populates the two new MetaEvent fields right before `AppendJSONL`, and threads them into the shutdown `DigestInput` alongside the existing `PolicyCounts` wiring.

- **`internal/report/digest_types.go`** — `DigestInput` mirrors the two new fields (`AllowlistIPCount`, `UnresolvedDomains`).

- **`internal/report/digest.go`** — adds `writeUnresolvedDomainsWarning`. When the defend section renders and `UnresolvedDomains` is non-empty, it prints a one-line GFM blockquote `> ⚠️ **Allowlist: N domain(s) unresolved at startup** — domain1, domain2` above the existing Defend field table. Singular/plural noun handled. Domains go through `sanitizeCell` so Markdown injection from a hostile allowlist entry is contained to the table cell escape rules already used everywhere else in the digest.

- **`internal/report/digest_test.go`** — new `TestBuildDetectMarkdown_UnresolvedDomainsWarning` asserts plural form, singular form, and clean-compile absence.

## Why this matters

The empty-effective-allowlist case already errored loudly (the agent refuses to start defend mode with zero IPv4 entries). The case this addresses is the **partial resolve** — the agent starts cleanly with `M` IPs and `K` unresolved domains, the silently-shrunk allowlist now denies traffic the operator believed they had allowed, and the only signal was the cgroup `deny` event after the fact. Surfacing this at policy load lets operators see the gap in the same digest where they review the run.

## Constraints honored

- Detect / defend only — no `enforce` references introduced.
- `omitempty` on both new MetaEvent fields keeps the existing detect-mode JSONL header unchanged when the agent is not in defend mode.
- No signature changes to `buildDigestInput` — new fields are set on the returned struct, matching the existing `in.PolicyCounts = …` pattern.
- The warning blockquote sits at the top of the existing Defend section, not the headline badge — keeping the badge's existing alert / review / clean-run semantics undisturbed.

## Validation

- `gofmt -l` on touched files — clean.
- `go test ./internal/report/... ./internal/telemetry/... ./internal/agent/...` — pass on Windows (where `agent_linux.go` is excluded by build tag, but the test file's `buildDigestInput` callers are unchanged).
- Linux build + integration + defend-mode runs are validated by `coldstep-ci-runner.yml` (`unit`, `unit-arm64`, `integration`, `detect-mode`, `defend-mode`).

## Test plan

- [ ] CI: `coldstep-ci.yml` green (gofmt, encoding, unit, unit-arm64, integration, action_bundle, detect-mode, defend-mode).
- [ ] CodeQL + supply-chain checks green.
- [ ] Manually inspect a defend-mode run's `.coldstep-detect.md` with a deliberately-unresolvable allowlist entry (e.g. `nonexistent.example.invalid`) and confirm the ⚠️ blockquote appears at the top of the Defend section.
