### PR TITLE
feat(H9+H12): DNS TTL staleness warning + wildcard CDN risk scoring + entry count telemetry

### DIFF
--- a/.github/pr-bodies/h9-dns-ttl-wildcard.md
+++ b/.github/pr-bodies/h9-dns-ttl-wildcard.md
@@ -1,0 +1,46 @@
+## Summary
+
+Implements **H9** (DNS TTL staleness warning + wildcard CDN risk scoring) and bundles **H12** (allowlist startup entry count telemetry) from the v0.3.0 hardening roadmap. The digest now tells operators when the in-memory DNS-resolved allowlist is older than the typical DNS TTL window, when a high-risk multi-tenant CDN wildcard is in the allowlist, and how many `/32 + CIDR` entries are actually programmed into the BPF `allowed_ipv4` LPM trie at startup (which is fixed until the agent restarts).
+
+The wildcard-risk scoring and the underlying digest "Allowlist trust model" section already landed in earlier P1-1 work — this PR completes the H9 surface (TTL-staleness warning, spec-prescribed wording, per-domain `slog.Warn`) and adds the missing H12 telemetry field and digest note.
+
+## What changed
+
+- **`internal/policy/allowlist.go`** — add `CompileResult.CompileTimestamp time.Time`, stamped with `time.Now()` at the end of `CompileDomainAllowlist`. Emit `slog.Warn("allowlist: wildcard CDN domain may match unintended hosts", "domain", d)` for every entry the H9 CDN risk list matched (`*.githubusercontent.com`, `*.s3.amazonaws.com`, `*.blob.core.windows.net`, `*.azureedge.net`, `*.cloudfront.net` — plus the pre-existing `*.r2.dev` / `*.pages.dev`). The per-domain warn moved out of `internal/agent/agent_linux.go` and into the policy layer so non-Linux replay paths surface the same signal.
+
+- **`internal/telemetry/event.go`** — new `MetaEvent.AllowlistEntryCount int` (json `allowlist_entry_count,omitempty`). Distinct from `AllowlistIPCount`, which counts domain-resolved IPv4s only — `AllowlistEntryCount` mirrors the post-merge total written into the BPF LPM trie at startup, so the JSONL meta records `len(domain-resolved IPv4) + len(literal --allowed-ips /32 + CIDR entries)`.
+
+- **`internal/agent/agent_linux.go`** — pass `defendCompiled.CompileTimestamp` into `stats.setAllowlistCompileSnapshot` instead of a separate `time.Now()` capture; populate `meta.AllowlistEntryCount` from `defendState.snapshot().allowlistSize` (the actual programmed entry count, captured after `loadDefendMaps` returns).
+
+- **`internal/agent/agent_linux_digest.go`** — wire `AllowlistCompileTime` (instead of the derived `AllowlistAgeMinutes`) and `AllowlistEntryCount` into `DigestInput`. The digest renderer is now the single source of truth for "is the compile stale?", so test/replay paths can compare to a fixed clock.
+
+- **`internal/report/digest_types.go`** — replace `AllowlistAgeMinutes float64` with `AllowlistCompileTime time.Time` (per H9 spec) and add `AllowlistEntryCount int` (per H12 spec). The digest renderer computes `time.Since(...) > 5*time.Minute` itself.
+
+- **`internal/report/digest.go`** — update `writeAllowlistTrust`:
+  - New ⚠️ "DNS allowlist may be stale — compiled N minutes ago. DNS TTLs may have expired." box when `time.Since(AllowlistCompileTime) > 5m` (was a softer ℹ️ note tied to `AllowlistAgeMinutes`).
+  - Wildcard warning rewritten to the spec-prescribed batched form: `> ⚠️ **High-risk wildcard domains in allowlist** — \`*.s3.amazonaws.com\`, \`*.cloudfront.net\` — may match unintended hosts.`
+  - New ℹ️ "Allowlist: N IPv4 entries loaded at startup (fixed until restart)." note in defend mode when `AllowlistEntryCount > 0` (H12).
+
+- **`internal/policy/allowlist_test.go`** — `TestCompileDomainAllowlist_FlagsAllH9CDNWildcards` walks the five CDN suffixes named in the H9 spec and asserts each is flagged; `TestCompileDomainAllowlist_RecordsCompileTimestamp` asserts the new field lands inside the call window.
+
+- **`internal/report/digest_test.go`** — `TestBuildDetectMarkdown_AllowlistTrust_StaleWarning` covers the 6-minutes-ago / 2-minutes-ago / zero-time cases; `TestBuildDetectMarkdown_AllowlistTrust_EntryCountNote` covers the H12 defend-mode rendering and detect-mode suppression. The existing wildcard test was updated to the new "may match unintended hosts" wording.
+
+## Constraints honored
+
+- No new BPF programs or maps — pure Go + digest.
+- No `enforce` references introduced; the staleness/wildcard surfaces follow the same `isBlockingDigestMode(...)` gate as the rest of the allowlist trust block.
+- `AllowlistEntryCount` is a parallel field to the existing `AllowlistIPCount`, not a rename — the older field stays as-is so any downstream JSONL consumers keep working.
+- The wildcard suffix list (`internal/policy/allowlist.go:highRiskWildcardSuffixes`) is unchanged; it already contained the H9-named CDNs.
+
+## Validation
+
+- `bash scripts/check-gofmt.sh` — pass.
+- `bash scripts/check-encoding.sh` — pass.
+- `go test ./internal/policy/... ./internal/report/... ./internal/telemetry/... ./internal/agent/... -count=1` (Windows, non-BPF packages) — pass.
+- `GOOS=linux go test -c -o /tmp/policy.test ./internal/policy/` / `... ./internal/report/` cross-compile — pass.
+- BPF compile + verifier load + Linux unit/integration are validated by CI's `coldstep-ci-runner.yml` (`unit`, `unit-arm64`, `integration`, `detect-mode`, `defend-mode`).
+
+## Follow-ups (out of scope)
+
+- **H16 (DNS allowlist trust hardening — live re-resolution)** — the H9 warning surfaces drift; a future PR can wire a background refresh goroutine if the warning fires often in real runs. The "warning-only" leg of H16 is now covered.
+- **Documentation drift** — `website/` allowlist copy will be touched in the post-tag website-bump PR per `RELEASE_PROCESS.md`; this PR keeps the repo-side surface consistent.

--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -157,7 +157,10 @@ func Run(ctx context.Context, cfg config.Config) error {
 	if err != nil {
 		return err
 	}
-	allowlistCompileTime := time.Now()
+	allowlistCompileTime := defendCompiled.CompileTimestamp
+	if allowlistCompileTime.IsZero() {
+		allowlistCompileTime = time.Now()
+	}
 	stats.setAllowlistCompileSnapshot(
 		allowlistCompileTime,
 		defendCompiled.AllowedIPv4.Len(),
@@ -170,9 +173,6 @@ func Run(ctx context.Context, cfg config.Config) error {
 	if cfg.Mode == config.ModeDefend && len(defendCompiled.UnresolvedDomains) > 0 {
 		slog.Warn("allowlist domains unresolved — legitimate traffic to these domains may be blocked",
 			"count", len(defendCompiled.UnresolvedDomains))
-	}
-	for _, d := range defendCompiled.WildcardRiskDomains {
-		slog.Warn("high-risk wildcard in allowlist", "domain", d)
 	}
 
 	dnsCache := NewDNSCache()
@@ -802,6 +802,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 				meta.Capabilities["fs_events"] = true
 			}
 			meta.AllowlistIPCount = defendCompiled.AllowedIPv4.Len()
+			meta.AllowlistEntryCount = defendState.snapshot().allowlistSize
 			if len(defendCompiled.WildcardRiskDomains) > 0 {
 				meta.WildcardRiskDomains = append([]string(nil), defendCompiled.WildcardRiskDomains...)
 			}

--- a/internal/agent/agent_linux_digest.go
+++ b/internal/agent/agent_linux_digest.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"strings"
-	"time"
 
 	"github.com/coldstep-io/coldstep/internal/config"
 	"github.com/coldstep-io/coldstep/internal/proctree"
@@ -259,9 +258,8 @@ func buildDigestInput(
 	compileTime, _, unresolved, wildcardRisk := stats.allowlistSnapshot()
 	in.UnresolvedAllowlistDomains = unresolved
 	in.WildcardRiskDomains = wildcardRisk
-	if !compileTime.IsZero() {
-		in.AllowlistAgeMinutes = time.Since(compileTime).Minutes()
-	}
+	in.AllowlistCompileTime = compileTime
+	in.AllowlistEntryCount = defendState.allowlistSize
 	in.DomainContactCounts = stats.snapshotDomainCounts()
 
 	return in

--- a/internal/policy/allowlist.go
+++ b/internal/policy/allowlist.go
@@ -144,12 +144,17 @@ func (s IPv6Set) ForEach(fn func(k [16]byte)) {
 // into the BPF allowed_ipv6 LPM trie in defend mode. IPv6 loopback (::1)
 // and link-local (fe80::/10) are NOT included here — those bypass
 // enforcement directly inside the BPF program.
+//
+// CompileTimestamp records when CompileDomainAllowlist finished resolving the
+// allowlist (H9 DNS-6b). Downstream consumers (digest renderer) compare it to
+// time.Now() to surface a TTL-staleness warning on long-running CI jobs.
 type CompileResult struct {
 	Domains             []string
 	AllowedIPv4         IPv4Set
 	AllowedIPv6         IPv6Set
 	UnresolvedDomains   []string
 	WildcardRiskDomains []string
+	CompileTimestamp    time.Time
 }
 
 // highRiskWildcardSuffixes lists shared-infrastructure DNS suffixes where a
@@ -333,6 +338,10 @@ func CompileDomainAllowlist(ctx context.Context, domains []string, resolver Look
 
 	slices.Sort(result.UnresolvedDomains)
 	result.WildcardRiskDomains = scoreWildcardRisk(normalized)
+	for _, d := range result.WildcardRiskDomains {
+		slog.Warn("allowlist: wildcard CDN domain may match unintended hosts", "domain", d)
+	}
+	result.CompileTimestamp = time.Now()
 
 	slog.Info("allowlist compiled",
 		"domains", len(normalized),

--- a/internal/policy/allowlist_test.go
+++ b/internal/policy/allowlist_test.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func bumpCallCount(cm *sync.Map, key string) {
@@ -227,6 +228,49 @@ func TestCompileDomainAllowlist_PopulatesWildcardRiskDomains(t *testing.T) {
 	want := []string{"*.s3.amazonaws.com"}
 	if !slices.Equal(got.WildcardRiskDomains, want) {
 		t.Fatalf("WildcardRiskDomains: got %v want %v", got.WildcardRiskDomains, want)
+	}
+}
+
+func TestCompileDomainAllowlist_FlagsAllH9CDNWildcards(t *testing.T) {
+	ctx := context.Background()
+	resolver := func(_ context.Context, _, _ string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("9.9.9.9")}, nil
+	}
+	in := []string{
+		"*.githubusercontent.com",
+		"*.s3.amazonaws.com",
+		"*.blob.core.windows.net",
+		"*.azureedge.net",
+		"*.cloudfront.net",
+		"github.com",
+		"*.example.org",
+	}
+	got := CompileDomainAllowlist(ctx, in, resolver, 1)
+	want := []string{
+		"*.githubusercontent.com",
+		"*.s3.amazonaws.com",
+		"*.blob.core.windows.net",
+		"*.azureedge.net",
+		"*.cloudfront.net",
+	}
+	if !slices.Equal(got.WildcardRiskDomains, want) {
+		t.Fatalf("WildcardRiskDomains: got %v want %v", got.WildcardRiskDomains, want)
+	}
+}
+
+func TestCompileDomainAllowlist_RecordsCompileTimestamp(t *testing.T) {
+	ctx := context.Background()
+	resolver := func(_ context.Context, _, _ string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("9.9.9.9")}, nil
+	}
+	before := time.Now()
+	got := CompileDomainAllowlist(ctx, []string{"api.example.com"}, resolver, 1)
+	after := time.Now()
+	if got.CompileTimestamp.IsZero() {
+		t.Fatalf("CompileTimestamp is zero; want a recent time")
+	}
+	if got.CompileTimestamp.Before(before) || got.CompileTimestamp.After(after) {
+		t.Fatalf("CompileTimestamp %v outside [%v, %v]", got.CompileTimestamp, before, after)
 	}
 }
 

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -22,10 +22,16 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/coldstep-io/coldstep/internal/atomicwrite"
 	"github.com/coldstep-io/coldstep/internal/telemetry"
 )
+
+// allowlistStaleThreshold is the digest's TTL-staleness boundary (H9 DNS-6b).
+// Above this age the digest emits a ⚠️ box reminding operators that DNS TTLs
+// may have expired since the BPF map snapshot was programmed.
+const allowlistStaleThreshold = 5 * time.Minute
 
 // partialEgressTotal sums the BG-01 per-syscall partial-observe counters so the
 // headline-verdict "Review" threshold flips on any non-zero partial-observe.
@@ -1097,15 +1103,23 @@ func writeFooter(b *strings.Builder, in DigestInput) {
 	fmt.Fprintf(b, "> Full event log: `%s`\n", sanitizeCell(path))
 }
 
-// writeAllowlistTrust emits P1-1 (DNS Allowlist Trust Model hardening)
+// writeAllowlistTrust emits P1-1 / H9 (DNS Allowlist Trust Model hardening)
 // surface: unresolved allowlist domains (defend-mode warning), high-risk
-// wildcard entries, and a TTL-age info note when the compile is >5 minutes
-// old. The section is skipped when there is nothing to show.
+// wildcard CDN entries, a TTL-staleness warning when the compile is more than
+// allowlistStaleThreshold old, and a fixed-at-startup entry-count note (H12).
+// The section is skipped when there is nothing to show.
 func writeAllowlistTrust(b *strings.Builder, in DigestInput) {
 	hasUnresolved := isBlockingDigestMode(in.DefendMode) && len(in.UnresolvedAllowlistDomains) > 0
 	hasWildcard := len(in.WildcardRiskDomains) > 0
-	hasAgeNote := in.AllowlistAgeMinutes > 5
-	if !hasUnresolved && !hasWildcard && !hasAgeNote {
+	staleAge := time.Duration(0)
+	if !in.AllowlistCompileTime.IsZero() {
+		if age := time.Since(in.AllowlistCompileTime); age > allowlistStaleThreshold {
+			staleAge = age
+		}
+	}
+	hasStale := staleAge > 0
+	hasEntryCount := in.AllowlistEntryCount > 0 && isBlockingDigestMode(in.DefendMode)
+	if !hasUnresolved && !hasWildcard && !hasStale && !hasEntryCount {
 		return
 	}
 
@@ -1120,16 +1134,25 @@ func writeAllowlistTrust(b *strings.Builder, in DigestInput) {
 	}
 
 	if hasWildcard {
-		b.WriteString("> ⚠️ **High-risk wildcards** — these entries grant reach across a shared multi-tenant surface. Prefer tighter literal hostnames where possible.\n>\n")
+		quoted := make([]string, 0, len(in.WildcardRiskDomains))
 		for _, d := range in.WildcardRiskDomains {
-			b.WriteString(fmt.Sprintf("> - `%s`\n", sanitizeCell(d)))
+			quoted = append(quoted, fmt.Sprintf("`%s`", sanitizeCell(d)))
 		}
-		b.WriteString("\n")
+		b.WriteString(fmt.Sprintf(
+			"> ⚠️ **High-risk wildcard domains in allowlist** — %s — may match unintended hosts.\n\n",
+			strings.Join(quoted, ", ")))
 	}
 
-	if hasAgeNote {
-		b.WriteString(fmt.Sprintf("> ℹ️ Allowlist was compiled %.0f minutes ago — DNS TTLs may have expired. Consider shorter jobs or re-running for long CI pipelines.\n\n",
-			in.AllowlistAgeMinutes))
+	if hasStale {
+		b.WriteString(fmt.Sprintf(
+			"> ⚠️ **DNS allowlist may be stale** — compiled %.0f minutes ago. DNS TTLs may have expired.\n\n",
+			staleAge.Minutes()))
+	}
+
+	if hasEntryCount {
+		b.WriteString(fmt.Sprintf(
+			"> ℹ️ Allowlist: %d IPv4 entries loaded at startup (fixed until restart).\n\n",
+			in.AllowlistEntryCount))
 	}
 }
 

--- a/internal/report/digest_test.go
+++ b/internal/report/digest_test.go
@@ -3,6 +3,7 @@ package report
 import (
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/coldstep-io/coldstep/internal/telemetry"
@@ -1415,9 +1416,10 @@ func TestBuildDetectMarkdown_AllowlistTrust_WildcardRisk(t *testing.T) {
 	})
 	for _, needle := range []string{
 		"### Allowlist trust model",
-		"High-risk wildcards",
+		"High-risk wildcard domains in allowlist",
 		"`*.s3.amazonaws.com`",
 		"`*.cloudfront.net`",
+		"may match unintended hosts",
 	} {
 		if !strings.Contains(md, needle) {
 			t.Fatalf("missing %q in:\n%s", needle, md)
@@ -1425,21 +1427,60 @@ func TestBuildDetectMarkdown_AllowlistTrust_WildcardRisk(t *testing.T) {
 	}
 }
 
-func TestBuildDetectMarkdown_AllowlistTrust_AgeInfo(t *testing.T) {
+func TestBuildDetectMarkdown_AllowlistTrust_StaleWarning(t *testing.T) {
 	md := BuildDetectMarkdown(DigestInput{
-		AllowlistAgeMinutes: 17.4,
-		MaxRowsPerSection:   50,
+		AllowlistCompileTime: time.Now().Add(-6 * time.Minute),
+		MaxRowsPerSection:    50,
 	})
-	if !strings.Contains(md, "ℹ️") || !strings.Contains(md, "17 minutes ago") {
-		t.Fatalf("expected age info note; got:\n%s", md)
+	for _, needle := range []string{
+		"⚠️",
+		"DNS allowlist may be stale",
+		"compiled 6 minutes ago",
+		"DNS TTLs may have expired",
+	} {
+		if !strings.Contains(md, needle) {
+			t.Fatalf("missing %q in stale warning; got:\n%s", needle, md)
+		}
 	}
 
 	mdFresh := BuildDetectMarkdown(DigestInput{
-		AllowlistAgeMinutes: 2.0,
+		AllowlistCompileTime: time.Now().Add(-2 * time.Minute),
+		MaxRowsPerSection:    50,
+	})
+	if strings.Contains(mdFresh, "may be stale") {
+		t.Fatalf("should not surface TTL hint when allowlist is fresh; got:\n%s", mdFresh)
+	}
+
+	mdZero := BuildDetectMarkdown(DigestInput{
+		MaxRowsPerSection: 50,
+	})
+	if strings.Contains(mdZero, "may be stale") {
+		t.Fatalf("should not surface TTL hint when AllowlistCompileTime is zero; got:\n%s", mdZero)
+	}
+}
+
+func TestBuildDetectMarkdown_AllowlistTrust_EntryCountNote(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{
+		DefendMode:          "defend",
+		AllowlistEntryCount: 42,
 		MaxRowsPerSection:   50,
 	})
-	if strings.Contains(mdFresh, "minutes ago") {
-		t.Fatalf("should not surface TTL hint when allowlist is fresh; got:\n%s", mdFresh)
+	for _, needle := range []string{
+		"### Allowlist trust model",
+		"Allowlist: 42 IPv4 entries loaded at startup",
+		"fixed until restart",
+	} {
+		if !strings.Contains(md, needle) {
+			t.Fatalf("missing %q in entry-count note; got:\n%s", needle, md)
+		}
+	}
+
+	mdDetect := BuildDetectMarkdown(DigestInput{
+		AllowlistEntryCount: 42,
+		MaxRowsPerSection:   50,
+	})
+	if strings.Contains(mdDetect, "IPv4 entries loaded at startup") {
+		t.Fatalf("entry-count note must be suppressed in detect mode; got:\n%s", mdDetect)
 	}
 }
 

--- a/internal/report/digest_types.go
+++ b/internal/report/digest_types.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"time"
 	"unicode/utf8"
 
 	"github.com/coldstep-io/coldstep/internal/telemetry"
@@ -341,10 +342,18 @@ type DigestInput struct {
 	// shared-infrastructure wildcard surface (e.g. `*.s3.amazonaws.com`). Empty
 	// when no such entries are present.
 	WildcardRiskDomains []string
-	// AllowlistAgeMinutes is minutes between allowlist compile time and digest
-	// build time. Surfaces a TTL re-validation hint for long jobs; zero when no
-	// allowlist was compiled.
-	AllowlistAgeMinutes float64
+	// AllowlistCompileTime is the wall-clock time CompileDomainAllowlist
+	// finished resolving the defend allowlist (H9 DNS-6b). The digest renders a
+	// staleness warning when time.Since(AllowlistCompileTime) exceeds 5 minutes
+	// so operators of long-running jobs see that DNS TTLs may have expired
+	// since the snapshot was programmed into the BPF map. Zero value means no
+	// allowlist was compiled and the warning is suppressed.
+	AllowlistCompileTime time.Time
+	// AllowlistEntryCount is the total number of /32 + CIDR entries programmed
+	// into the BPF allowed_ipv4 LPM trie at startup (H12). Mirrors
+	// MetaEvent.AllowlistEntryCount; rendered as a fixed-point reminder in the
+	// digest's allowlist trust section.
+	AllowlistEntryCount int
 	// DomainContactCounts maps observed FQDN → observation count across TCP +
 	// UDP egress. Sorted descending by count in the digest section.
 	DomainContactCounts map[string]int

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -48,6 +48,14 @@ type MetaEvent struct {
 	// AllowlistIPCount snapshots the number of unique IPv4 addresses produced by
 	// compiling the domain allowlist (P1-1 6a). Zero when not in defend mode.
 	AllowlistIPCount int `json:"allowlist_ip_count,omitempty"`
+	// AllowlistEntryCount snapshots the total number of /32 + CIDR entries
+	// programmed into the BPF allowed_ipv4 LPM trie at startup (H12). Distinct
+	// from AllowlistIPCount, which counts domain-resolved IPv4 addresses only;
+	// AllowlistEntryCount also includes literal `allowed-ips` entries (single
+	// IPs and CIDR ranges) merged into the trie. Surfaced in the digest as a
+	// reminder that the allowlist is fixed at startup until the next agent
+	// restart.
+	AllowlistEntryCount int `json:"allowlist_entry_count,omitempty"`
 	// WildcardRiskDomains lists allowlist entries (e.g. `*.s3.amazonaws.com`)
 	// whose wildcard suffix matches a known multi-tenant shared-infrastructure
 	// surface (P1-1 6c). Operators can review and tighten if desired.


### PR DESCRIPTION
## Summary

Implements **H9** (DNS TTL staleness warning + wildcard CDN risk scoring) and bundles **H12** (allowlist startup entry count telemetry) from the v0.3.0 hardening roadmap. The digest now tells operators when the in-memory DNS-resolved allowlist is older than the typical DNS TTL window, when a high-risk multi-tenant CDN wildcard is in the allowlist, and how many `/32 + CIDR` entries are actually programmed into the BPF `allowed_ipv4` LPM trie at startup (which is fixed until the agent restarts).

The wildcard-risk scoring and the underlying digest "Allowlist trust model" section already landed in earlier P1-1 work — this PR completes the H9 surface (TTL-staleness warning, spec-prescribed wording, per-domain `slog.Warn`) and adds the missing H12 telemetry field and digest note.

## What changed

- **`internal/policy/allowlist.go`** — add `CompileResult.CompileTimestamp time.Time`, stamped with `time.Now()` at the end of `CompileDomainAllowlist`. Emit `slog.Warn("allowlist: wildcard CDN domain may match unintended hosts", "domain", d)` for every entry the H9 CDN risk list matched (`*.githubusercontent.com`, `*.s3.amazonaws.com`, `*.blob.core.windows.net`, `*.azureedge.net`, `*.cloudfront.net` — plus the pre-existing `*.r2.dev` / `*.pages.dev`). The per-domain warn moved out of `internal/agent/agent_linux.go` and into the policy layer so non-Linux replay paths surface the same signal.

- **`internal/telemetry/event.go`** — new `MetaEvent.AllowlistEntryCount int` (json `allowlist_entry_count,omitempty`). Distinct from `AllowlistIPCount`, which counts domain-resolved IPv4s only — `AllowlistEntryCount` mirrors the post-merge total written into the BPF LPM trie at startup, so the JSONL meta records `len(domain-resolved IPv4) + len(literal --allowed-ips /32 + CIDR entries)`.

- **`internal/agent/agent_linux.go`** — pass `defendCompiled.CompileTimestamp` into `stats.setAllowlistCompileSnapshot` instead of a separate `time.Now()` capture; populate `meta.AllowlistEntryCount` from `defendState.snapshot().allowlistSize` (the actual programmed entry count, captured after `loadDefendMaps` returns).

- **`internal/agent/agent_linux_digest.go`** — wire `AllowlistCompileTime` (instead of the derived `AllowlistAgeMinutes`) and `AllowlistEntryCount` into `DigestInput`. The digest renderer is now the single source of truth for "is the compile stale?", so test/replay paths can compare to a fixed clock.

- **`internal/report/digest_types.go`** — replace `AllowlistAgeMinutes float64` with `AllowlistCompileTime time.Time` (per H9 spec) and add `AllowlistEntryCount int` (per H12 spec). The digest renderer computes `time.Since(...) > 5*time.Minute` itself.

- **`internal/report/digest.go`** — update `writeAllowlistTrust`:
  - New ⚠️ "DNS allowlist may be stale — compiled N minutes ago. DNS TTLs may have expired." box when `time.Since(AllowlistCompileTime) > 5m` (was a softer ℹ️ note tied to `AllowlistAgeMinutes`).
  - Wildcard warning rewritten to the spec-prescribed batched form: `> ⚠️ **High-risk wildcard domains in allowlist** — \`*.s3.amazonaws.com\`, \`*.cloudfront.net\` — may match unintended hosts.`
  - New ℹ️ "Allowlist: N IPv4 entries loaded at startup (fixed until restart)." note in defend mode when `AllowlistEntryCount > 0` (H12).

- **`internal/policy/allowlist_test.go`** — `TestCompileDomainAllowlist_FlagsAllH9CDNWildcards` walks the five CDN suffixes named in the H9 spec and asserts each is flagged; `TestCompileDomainAllowlist_RecordsCompileTimestamp` asserts the new field lands inside the call window.

- **`internal/report/digest_test.go`** — `TestBuildDetectMarkdown_AllowlistTrust_StaleWarning` covers the 6-minutes-ago / 2-minutes-ago / zero-time cases; `TestBuildDetectMarkdown_AllowlistTrust_EntryCountNote` covers the H12 defend-mode rendering and detect-mode suppression. The existing wildcard test was updated to the new "may match unintended hosts" wording.

## Constraints honored

- No new BPF programs or maps — pure Go + digest.
- No `enforce` references introduced; the staleness/wildcard surfaces follow the same `isBlockingDigestMode(...)` gate as the rest of the allowlist trust block.
- `AllowlistEntryCount` is a parallel field to the existing `AllowlistIPCount`, not a rename — the older field stays as-is so any downstream JSONL consumers keep working.
- The wildcard suffix list (`internal/policy/allowlist.go:highRiskWildcardSuffixes`) is unchanged; it already contained the H9-named CDNs.

## Validation

- `bash scripts/check-gofmt.sh` — pass.
- `bash scripts/check-encoding.sh` — pass.
- `go test ./internal/policy/... ./internal/report/... ./internal/telemetry/... ./internal/agent/... -count=1` (Windows, non-BPF packages) — pass.
- `GOOS=linux go test -c -o /tmp/policy.test ./internal/policy/` / `... ./internal/report/` cross-compile — pass.
- BPF compile + verifier load + Linux unit/integration are validated by CI's `coldstep-ci-runner.yml` (`unit`, `unit-arm64`, `integration`, `detect-mode`, `defend-mode`).

## Follow-ups (out of scope)

- **H16 (DNS allowlist trust hardening — live re-resolution)** — the H9 warning surfaces drift; a future PR can wire a background refresh goroutine if the warning fires often in real runs. The "warning-only" leg of H16 is now covered.
- **Documentation drift** — `website/` allowlist copy will be touched in the post-tag website-bump PR per `RELEASE_PROCESS.md`; this PR keeps the repo-side surface consistent.
