### PR TITLE
feat(H10/H11): per-domain observation counts + JSONL/digest file integrity

### DIFF
--- a/.github/pr-bodies/h10-h11-domain-counts-integrity.md
+++ b/.github/pr-bodies/h10-h11-domain-counts-integrity.md
@@ -1,0 +1,43 @@
+## Summary
+
+Implements **H10** (per-domain observation counts, DNS-6e) and **H11** (summary file integrity) from the v0.3.0 hardening roadmap.
+
+- **H10** turns the existing observed-FQDN map into an operator-actionable allowlist cross-reference: every entry compiled into the defend allowlist is rendered with its run-time contact count, and entries with zero contacts are flagged as trim candidates so allowlists shrink between runs.
+- **H11** adds two tamper-evidence surfaces — a SHA-256 of `.coldstep-events.jsonl` embedded in the shutdown `MetaEvent`, and a `<!-- coldstep-digest-sha256: <hex> -->` marker appended to `.coldstep-detect.md` after the action writes it. JSONL signing remains the cryptographically strong guarantee; the new hashes are documented as hints in `SECURITY.md`.
+
+## H10 — per-domain observation counts
+
+- **`internal/agent/agent_linux_state.go`** — `runStats.setAllowlistCompileSnapshot` now also captures the full compiled domain list; `allowlistSnapshot` returns it alongside the existing IP count / unresolved / wildcard-risk fields. The per-FQDN counter map (`dstDomainCounts`) was already in place from P1-1 6e — this PR adds the cross-reference rather than re-deriving the data.
+- **`internal/agent/agent_linux.go`** — pass `defendCompiled.Domains` into the snapshot.
+- **`internal/agent/agent_linux_digest.go`** — unpack the new `domains` value from `allowlistSnapshot` into `DigestInput.AllowlistDomains`.
+- **`internal/agent/agent_linux_ring_read.go`** — wire `stats.incDomainCount` on TLS SNI and HTTP Host as well as the existing TCP/UDP FQDN paths so cleartext HTTP and TLS handshakes count toward per-domain totals.
+- **`internal/report/digest_types.go`** — add `DigestInput.AllowlistDomains []string`.
+- **`internal/report/digest.go`** — `writeAllowlistTrust` gains a fourth render condition (`hasContactSummary`), and a new `writeAllowlistDomainContactSummary` produces a collapsible table that lists each allowlist domain with its observation count and a trim-candidate note for entries at zero. The section is gated on defend mode so it cannot surface in detect (where there is no allowlist to act on).
+
+## H11 — summary file integrity
+
+- **`internal/telemetry/event.go`** — add `MetaEvent.EventsFileSHA256 string \`json:"events_file_sha256,omitempty"\``. Empty on the startup meta; populated on shutdown.
+- **`internal/agent/agent_linux.go`** — at shutdown, after the final flush and before appending the shutdown `MetaEvent`, compute SHA-256 of the events file via a new `sha256File` helper and embed the hex digest. Best-effort: a hash failure logs and proceeds with an empty field rather than blocking the shutdown record.
+- **`cmd/coldstep-action/main.go`** — extract `digestIntegrityMarker(body)` (pure, testable) and call it from `runStop` after reading `.coldstep-detect.md`. The marker is appended both to the on-disk file and to the in-memory `body` so the same hash travels into `GITHUB_STEP_SUMMARY` and the PR comment.
+- **`SECURITY.md`** — new **File integrity** section. Documents JSONL signing (`signing-key`) as the strong guarantee and the two new hashes as tamper-evidence hints, with their limits stated plainly (a step that can rewrite the JSONL can also rewrite the embedded hash — a signing key is the only cryptographic stop).
+
+## Tests
+
+- `TestBuildDetectMarkdown_AllowlistDomainContactSummary` covers a mixed run (two domains with contacts, one without) and pins the "1 unused entry (trim candidates)" headline plus the no-contacts row note.
+- `TestBuildDetectMarkdown_AllowlistDomainContactSummary_HiddenInDetect` defends against the renderer surfacing the table outside defend mode.
+- `TestDigestIntegrityMarker_RoundTrip` pins the canonical marker format and confirms the SHA matches `sha256.Sum256(body)`.
+- `TestDigestIntegrityMarker_EmptyBodyYieldsNothing` defends the no-write path so missing / whitespace digests do not produce a stray comment line.
+
+## Validation
+
+- `bash scripts/check-gofmt.sh` — pass.
+- `bash scripts/check-encoding.sh` — pass.
+- `go test ./internal/report/... ./internal/telemetry/... ./cmd/coldstep-action/... -count=1` — pass.
+- `internal/agent/...` Linux tests + the BPF matrix run on CI (the agent package uses build tags that require generated BPF stubs, so the Windows local environment uses the stub build only).
+
+## Constraints honored
+
+- No new BPF programs, maps, or wire-format changes.
+- No schema bump — `telemetry.SchemaVersion` is unchanged. `EventsFileSHA256` is `omitempty`.
+- No `enforce` references introduced.
+- No new action inputs.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -78,6 +78,18 @@ Coldstep’s contract has three layers:
 
 Both are **IPv4 only**. The agent reports BPF load/attach status in **`.coldstep-telemetry.json`** and in logs. If a program fails to attach, treat **defend** as **degraded** and inspect those rows and stderr—do not assume silent fallback implies the same defense story on every kernel.
 
+### File integrity
+
+Coldstep ships two distinct integrity surfaces for its on-disk artifacts. Pick the right tool for the trust level your pipeline needs:
+
+| Surface | Artifact | Guarantee | Notes |
+| ------- | -------- | --------- | ----- |
+| **JSONL signing** (`signing-key`) | `.coldstep-events.jsonl` | **Strong.** Each JSONL line is HMAC-signed with the supplied key; downstream replay rejects lines whose `sig` field does not verify. | Recommended for any workflow that gates merges, promotions, or releases on coldstep output. The key never appears in the runner image — supply it via secrets. |
+| **Events file SHA-256** (`MetaEvent.events_file_sha256`) | `.coldstep-events.jsonl` | **Tamper-evidence hint.** The agent's shutdown `MetaEvent` line carries the SHA-256 of every preceding line, hex-encoded. A consumer can recompute the digest over the bytes ahead of that line and compare. | Detects post-run modification by anything that does not also rewrite the shutdown meta. Not a substitute for signing — a malicious step that can rewrite the JSONL can also rewrite the meta line. |
+| **Digest hash marker** | `.coldstep-detect.md` | **Tamper-evidence hint.** The `coldstep-action stop` step appends `<!-- coldstep-digest-sha256: <hex> -->` as the final line of the digest after computing SHA-256 over the agent-written content. | Lets consumers downstream of the Job Summary / PR comment verify the digest body has not been edited in transit. Same caveat as above: not cryptographic, hint-only. |
+
+Hash markers are intentionally placed **inside the artifact** so they survive copy-paste into PR comments, issue bodies, and email — wherever the digest travels, the hash travels with it.
+
 ### Residual risk (honest scope)
 
 No userland agent can promise **complete** observation of every kernel path on every kernel revision. Consumers needing **audit-grade non-repudiation** must combine Coldstep with **organizational controls** (locked-down workflows, secrets policies, optional additional LSM / host controls outside this project).

--- a/cmd/coldstep-action/main.go
+++ b/cmd/coldstep-action/main.go
@@ -24,6 +24,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -138,6 +140,20 @@ func parseStopFlags(args []string) (stopConfig, error) {
 		return cfg, err
 	}
 	return cfg, nil
+}
+
+// digestIntegrityMarker is the H11 tamper-evidence HTML comment appended to
+// `.coldstep-detect.md`. It returns the empty string for an empty / whitespace
+// body so the marker is only emitted when there is a real digest to protect.
+// The leading newline guarantees the comment lands on its own line even when
+// the agent's digest does not end in `\n`; the trailing newline keeps the
+// file POSIX-clean.
+func digestIntegrityMarker(body string) string {
+	if strings.TrimSpace(body) == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(body))
+	return fmt.Sprintf("\n<!-- coldstep-digest-sha256: %s -->\n", hex.EncodeToString(sum[:]))
 }
 
 // parseReportFlags maps the unified `report` input to per-surface booleans
@@ -358,6 +374,28 @@ func runStop(cfg stopConfig) error {
 	body := ""
 	if raw, err := os.ReadFile(detectLog); err == nil {
 		body = string(raw)
+	}
+
+	// H11: tamper-evidence hash of the digest file. The SHA-256 covers the
+	// agent-written digest content (everything currently in `body`); we then
+	// append the marker comment to the on-disk file and to `body` so
+	// downstream surfaces (Job Summary, PR comment) carry the same value.
+	// Best-effort: a failure here logs to stderr and continues — the digest
+	// remains readable without the integrity comment. JSONL signing remains
+	// the cryptographically strong guarantee; this is a lightweight surface
+	// for unsigned runs.
+	if marker := digestIntegrityMarker(body); marker != "" {
+		if f, ferr := os.OpenFile(detectLog, os.O_APPEND|os.O_WRONLY, 0o644); ferr != nil {
+			fmt.Fprintf(os.Stderr, "coldstep: open detect log for hash marker: %v\n", ferr)
+		} else {
+			if _, werr := f.WriteString(marker); werr != nil {
+				fmt.Fprintf(os.Stderr, "coldstep: write hash marker: %v\n", werr)
+			}
+			if cerr := f.Close(); cerr != nil {
+				fmt.Fprintf(os.Stderr, "coldstep: close detect log: %v\n", cerr)
+			}
+		}
+		body += marker
 	}
 
 	reportJobSummary, reportPRSummary := parseReportFlags(cfg.Report)

--- a/cmd/coldstep-action/main_test.go
+++ b/cmd/coldstep-action/main_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -178,6 +181,34 @@ func TestParseStartFlags_Explicit(t *testing.T) {
 	}
 	if cfg.ReadyTimeoutSeconds != 120 {
 		t.Errorf("expected 120, got %d", cfg.ReadyTimeoutSeconds)
+	}
+}
+
+// H11: digestIntegrityMarker must produce the canonical hash marker for any
+// non-empty body, and yield the empty string for empty / whitespace input so
+// runStop does not write a marker against a missing digest file.
+func TestDigestIntegrityMarker_RoundTrip(t *testing.T) {
+	body := "## Coldstep digest\n\n- exec rows: 4\n"
+	got := digestIntegrityMarker(body)
+	sum := sha256.Sum256([]byte(body))
+	want := fmt.Sprintf("\n<!-- coldstep-digest-sha256: %s -->\n", hex.EncodeToString(sum[:]))
+	if got != want {
+		t.Fatalf("marker mismatch:\n got %q\nwant %q", got, want)
+	}
+	if !strings.HasPrefix(got, "\n<!-- coldstep-digest-sha256: ") {
+		t.Errorf("marker missing canonical prefix: %q", got)
+	}
+	if !strings.HasSuffix(got, " -->\n") {
+		t.Errorf("marker missing canonical suffix: %q", got)
+	}
+}
+
+func TestDigestIntegrityMarker_EmptyBodyYieldsNothing(t *testing.T) {
+	if got := digestIntegrityMarker(""); got != "" {
+		t.Fatalf("expected empty marker for empty body, got %q", got)
+	}
+	if got := digestIntegrityMarker("   \n\t  "); got != "" {
+		t.Fatalf("expected empty marker for whitespace body, got %q", got)
 	}
 }
 

--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -9,9 +9,13 @@ package agent
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"os"
 	"os/signal"
 	"strings"
 	"sync"
@@ -144,6 +148,17 @@ func Run(ctx context.Context, cfg config.Config) error {
 				slog.Warn("build shutdown meta", "err", err)
 			} else {
 				shutdownMeta.DroppedEvents = buildDroppedEventsMap(stats, defendState)
+				// H11: SHA-256 of the JSONL file before this MetaEvent gets
+				// appended so the hash covers every preceding event line.
+				// Tamper-evidence only — JSONL signing remains the strong
+				// guarantee. Best-effort: log a warning on hash failure and
+				// continue writing the meta (the field stays empty rather
+				// than blocking the shutdown record).
+				if sum, herr := sha256File(cfg.EventsLogPath); herr != nil {
+					slog.Warn("events file sha256", "err", herr)
+				} else {
+					shutdownMeta.EventsFileSHA256 = sum
+				}
 				if err := telemetry.AppendJSONL(cfg.EventsLogPath, shutdownMeta, signer); err != nil {
 					slog.Warn("shutdown meta jsonl", "err", err)
 				}
@@ -164,6 +179,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 	stats.setAllowlistCompileSnapshot(
 		allowlistCompileTime,
 		defendCompiled.AllowedIPv4.Len(),
+		defendCompiled.Domains,
 		defendCompiled.UnresolvedDomains,
 		defendCompiled.WildcardRiskDomains,
 	)
@@ -1159,4 +1175,19 @@ func loadAllowedDomainsMap(m *ebpf.Map, pol *policy.Policy) error {
 		}
 	}
 	return nil
+}
+
+// sha256File returns the lowercase-hex SHA-256 digest of path's contents.
+// H11 helper used to populate MetaEvent.EventsFileSHA256 on shutdown.
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path) // #nosec G304 — path is the agent's own events log under $GITHUB_WORKSPACE
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/internal/agent/agent_linux_digest.go
+++ b/internal/agent/agent_linux_digest.go
@@ -255,7 +255,8 @@ func buildDigestInput(
 		in.SeqFirst = 0
 	}
 
-	compileTime, _, unresolved, wildcardRisk := stats.allowlistSnapshot()
+	compileTime, _, domains, unresolved, wildcardRisk := stats.allowlistSnapshot()
+	in.AllowlistDomains = domains
 	in.UnresolvedAllowlistDomains = unresolved
 	in.WildcardRiskDomains = wildcardRisk
 	in.AllowlistCompileTime = compileTime

--- a/internal/agent/agent_linux_ring_read.go
+++ b/internal/agent/agent_linux_ring_read.go
@@ -530,6 +530,7 @@ func readTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, pol
 			confReason = "ktls"
 		}
 		stats.addTLS(cl, conf, confReason == "ktls")
+		stats.incDomainCount(sni)
 
 		ts := time.Now().UTC().Format(time.RFC3339Nano)
 		rows.addTLS(report.TLSDigestRow{
@@ -713,6 +714,7 @@ func readHTTPRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, po
 		path = telemetry.SanitizeField(path, 4096)
 		cl := pol.Classify(host, ip)
 		stats.addHTTP(cl)
+		stats.incDomainCount(host)
 
 		ts := time.Now().UTC().Format(time.RFC3339Nano)
 		sumPath := telemetry.RedactPathForSummary(path)

--- a/internal/agent/agent_linux_state.go
+++ b/internal/agent/agent_linux_state.go
@@ -90,6 +90,7 @@ type runStats struct {
 	// CompileDomainAllowlist; read at shutdown by buildDigestInput.
 	allowlistCompileTime         time.Time
 	allowlistIPCount             int
+	allowlistDomains             []string
 	allowlistUnresolvedDomains   []string
 	allowlistWildcardRiskDomains []string
 
@@ -749,21 +750,25 @@ func (s *runStats) counts() (execN, tcpN, udpN, httpN, tlsN, fsN int) {
 // setAllowlistCompileSnapshot records a one-shot snapshot of the resolved
 // allowlist at agent startup. Inputs are copied so the caller can free the
 // originals. Used by the shutdown digest to surface unresolved domains, the
-// IPv4-count snapshot, the wildcard-risk list, and the age-since-compile note.
-func (s *runStats) setAllowlistCompileSnapshot(t time.Time, ipCount int, unresolved, wildcardRisk []string) {
+// IPv4-count snapshot, the wildcard-risk list, the age-since-compile note,
+// and (P1-1 6e) the full allowlist domain list for the per-domain contact
+// cross-reference.
+func (s *runStats) setAllowlistCompileSnapshot(t time.Time, ipCount int, domains, unresolved, wildcardRisk []string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.allowlistCompileTime = t
 	s.allowlistIPCount = ipCount
+	s.allowlistDomains = slices.Clone(domains)
 	s.allowlistUnresolvedDomains = slices.Clone(unresolved)
 	s.allowlistWildcardRiskDomains = slices.Clone(wildcardRisk)
 }
 
 // allowlistSnapshot returns a copy of the recorded compile-time snapshot.
-func (s *runStats) allowlistSnapshot() (compileTime time.Time, ipCount int, unresolved []string, wildcardRisk []string) {
+func (s *runStats) allowlistSnapshot() (compileTime time.Time, ipCount int, domains, unresolved, wildcardRisk []string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.allowlistCompileTime, s.allowlistIPCount,
+		slices.Clone(s.allowlistDomains),
 		slices.Clone(s.allowlistUnresolvedDomains),
 		slices.Clone(s.allowlistWildcardRiskDomains)
 }

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -1127,7 +1127,8 @@ func writeAllowlistTrust(b *strings.Builder, in DigestInput) {
 	}
 	hasStale := staleAge > 0
 	hasEntryCount := in.AllowlistEntryCount > 0 && isBlockingDigestMode(in.DefendMode)
-	if !hasUnresolved && !hasWildcard && !hasStale && !hasEntryCount {
+	hasContactSummary := isBlockingDigestMode(in.DefendMode) && len(in.AllowlistDomains) > 0
+	if !hasUnresolved && !hasWildcard && !hasStale && !hasEntryCount && !hasContactSummary {
 		return
 	}
 
@@ -1162,6 +1163,61 @@ func writeAllowlistTrust(b *strings.Builder, in DigestInput) {
 			"> ℹ️ Allowlist: %d IPv4 entries loaded at startup (fixed until restart).\n\n",
 			in.AllowlistEntryCount))
 	}
+
+	if hasContactSummary {
+		writeAllowlistDomainContactSummary(b, in)
+	}
+}
+
+// writeAllowlistDomainContactSummary cross-references each defend-allowlist
+// domain against the per-FQDN observation counters (H10 / DNS-6e). Domains
+// observed at least once are listed with their count; entries with zero
+// contacts are flagged as trimming candidates so operators can prune
+// allowlists between runs.
+func writeAllowlistDomainContactSummary(b *strings.Builder, in DigestInput) {
+	type row struct {
+		domain string
+		count  int
+	}
+	rows := make([]row, 0, len(in.AllowlistDomains))
+	zero := 0
+	for _, d := range in.AllowlistDomains {
+		c := in.DomainContactCounts[d]
+		if c == 0 {
+			zero++
+		}
+		rows = append(rows, row{domain: d, count: c})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].count != rows[j].count {
+			return rows[i].count > rows[j].count
+		}
+		return rows[i].domain < rows[j].domain
+	})
+
+	b.WriteString("<details>\n<summary><strong>Allowlist domain contact summary</strong>")
+	if zero > 0 {
+		fmt.Fprintf(b, " — %d unused entr%s (trim candidates)", zero, plural(zero, "y", "ies"))
+	}
+	b.WriteString("</summary>\n\n")
+	b.WriteString("Per-domain observation counts for entries compiled into the defend allowlist this run.\n\n")
+	b.WriteString("| Domain | Count | Note |\n|:--|--:|:--|\n")
+	for _, r := range rows {
+		note := "—"
+		if r.count == 0 {
+			note = "no contacts observed — consider removing from allowlist"
+		}
+		fmt.Fprintf(b, "| `%s` | %d | %s |\n", sanitizeCell(r.domain), r.count, note)
+	}
+	b.WriteString("\n</details>\n\n")
+}
+
+// plural picks singular vs plural form by count. Tiny helper for digest copy.
+func plural(n int, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
 }
 
 // writeDomainContactCounts emits a collapsible section listing observed FQDNs

--- a/internal/report/digest_test.go
+++ b/internal/report/digest_test.go
@@ -1593,6 +1593,50 @@ func TestBuildDetectMarkdown_DomainContactCounts_HiddenWhenEmpty(t *testing.T) {
 	}
 }
 
+// H10 / DNS-6e: every allowlist domain must appear in the cross-reference
+// table under defend mode; entries observed at least once carry their count,
+// entries with zero observations carry the trim-candidate note so operators
+// can shrink the allowlist between runs.
+func TestBuildDetectMarkdown_AllowlistDomainContactSummary(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{
+		DefendMode:       "defend",
+		AllowlistDomains: []string{"api.github.com", "registry.npmjs.org", "unused.example.com"},
+		DomainContactCounts: map[string]int{
+			"api.github.com":     7,
+			"registry.npmjs.org": 3,
+			// unused.example.com has no contacts; treated as a trim candidate.
+		},
+		MaxRowsPerSection: 50,
+	})
+	for _, needle := range []string{
+		"### Allowlist trust model",
+		"Allowlist domain contact summary",
+		"`api.github.com`",
+		"`registry.npmjs.org`",
+		"`unused.example.com`",
+		"no contacts observed — consider removing from allowlist",
+		"1 unused entry (trim candidates)",
+	} {
+		if !strings.Contains(md, needle) {
+			t.Fatalf("missing %q in:\n%s", needle, md)
+		}
+	}
+}
+
+// H10: in detect mode there is no allowlist to enforce against, so the
+// cross-reference table must remain hidden even when AllowlistDomains is
+// non-empty (defensive — buildDigestInput won't normally populate this list
+// outside defend mode, but the renderer is the last line of defence).
+func TestBuildDetectMarkdown_AllowlistDomainContactSummary_HiddenInDetect(t *testing.T) {
+	md := BuildDetectMarkdown(DigestInput{
+		AllowlistDomains:  []string{"api.github.com"},
+		MaxRowsPerSection: 50,
+	})
+	if strings.Contains(md, "Allowlist domain contact summary") {
+		t.Fatalf("cross-ref table must be suppressed outside defend mode; got:\n%s", md)
+	}
+}
+
 // TestBuildDetectMarkdown_KTLSBucket exercises the P4 wiring: a TLSDigestRow
 // whose Confidence was forced to unknown by the readTLSRing KTLS override
 // (ConfidenceReason="ktls") must surface in three places in the digest:

--- a/internal/report/digest_types.go
+++ b/internal/report/digest_types.go
@@ -357,6 +357,12 @@ type DigestInput struct {
 	// DomainContactCounts maps observed FQDN → observation count across TCP +
 	// UDP egress. Sorted descending by count in the digest section.
 	DomainContactCounts map[string]int
+	// AllowlistDomains lists the FQDN entries compiled into the defend
+	// allowlist at agent startup (P1-1 6e cross-reference). Used by the
+	// digest to produce a per-allowlist-domain contact summary so operators
+	// can spot allowlist entries that observed zero egress this run —
+	// candidates for trimming. Empty in detect mode.
+	AllowlistDomains []string
 }
 
 // TruncateUTF8ToMaxBytes cuts s so len(result) <= maxBytes without splitting a UTF-8 code point.

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -83,7 +83,16 @@ type MetaEvent struct {
 	// twin of the digest's "Coverage scope" table; the digest already
 	// renders this information via H1 (PR #193).
 	Coverage *CoverageReport `json:"coverage,omitempty"`
-	Sig      string          `json:"sig,omitempty"`
+	// EventsFileSHA256 is the lowercase hex SHA-256 of the JSONL events file
+	// computed at agent shutdown, embedded in the final MetaEvent record
+	// (H11). It is a tamper-evidence hint — a downstream consumer can re-hash
+	// the bytes that preceded this MetaEvent line and compare against the
+	// value; a mismatch indicates the file was modified after the agent
+	// finished writing. The startup MetaEvent leaves this empty. JSONL
+	// signing (`signing-key`) remains the cryptographically strong guarantee;
+	// this field is the lightweight integrity surface for unsigned runs.
+	EventsFileSHA256 string `json:"events_file_sha256,omitempty"`
+	Sig              string `json:"sig,omitempty"`
 }
 
 // CoverageReport summarizes which traffic classes coldstep observed on this


### PR DESCRIPTION
## Summary

Implements **H10** (per-domain observation counts, DNS-6e) and **H11** (summary file integrity) from the v0.3.0 hardening roadmap.

- **H10** turns the existing observed-FQDN map into an operator-actionable allowlist cross-reference: every entry compiled into the defend allowlist is rendered with its run-time contact count, and entries with zero contacts are flagged as trim candidates so allowlists shrink between runs.
- **H11** adds two tamper-evidence surfaces — a SHA-256 of `.coldstep-events.jsonl` embedded in the shutdown `MetaEvent`, and a `<!-- coldstep-digest-sha256: <hex> -->` marker appended to `.coldstep-detect.md` after the action writes it. JSONL signing remains the cryptographically strong guarantee; the new hashes are documented as hints in `SECURITY.md`.

## H10 — per-domain observation counts

- **`internal/agent/agent_linux_state.go`** — `runStats.setAllowlistCompileSnapshot` now also captures the full compiled domain list; `allowlistSnapshot` returns it alongside the existing IP count / unresolved / wildcard-risk fields. The per-FQDN counter map (`dstDomainCounts`) was already in place from P1-1 6e — this PR adds the cross-reference rather than re-deriving the data.
- **`internal/agent/agent_linux.go`** — pass `defendCompiled.Domains` into the snapshot.
- **`internal/agent/agent_linux_digest.go`** — unpack the new `domains` value from `allowlistSnapshot` into `DigestInput.AllowlistDomains`.
- **`internal/agent/agent_linux_ring_read.go`** — wire `stats.incDomainCount` on TLS SNI and HTTP Host as well as the existing TCP/UDP FQDN paths so cleartext HTTP and TLS handshakes count toward per-domain totals.
- **`internal/report/digest_types.go`** — add `DigestInput.AllowlistDomains []string`.
- **`internal/report/digest.go`** — `writeAllowlistTrust` gains a fourth render condition (`hasContactSummary`), and a new `writeAllowlistDomainContactSummary` produces a collapsible table that lists each allowlist domain with its observation count and a trim-candidate note for entries at zero. The section is gated on defend mode so it cannot surface in detect (where there is no allowlist to act on).

## H11 — summary file integrity

- **`internal/telemetry/event.go`** — add `MetaEvent.EventsFileSHA256 string \`json:"events_file_sha256,omitempty"\``. Empty on the startup meta; populated on shutdown.
- **`internal/agent/agent_linux.go`** — at shutdown, after the final flush and before appending the shutdown `MetaEvent`, compute SHA-256 of the events file via a new `sha256File` helper and embed the hex digest. Best-effort: a hash failure logs and proceeds with an empty field rather than blocking the shutdown record.
- **`cmd/coldstep-action/main.go`** — extract `digestIntegrityMarker(body)` (pure, testable) and call it from `runStop` after reading `.coldstep-detect.md`. The marker is appended both to the on-disk file and to the in-memory `body` so the same hash travels into `GITHUB_STEP_SUMMARY` and the PR comment.
- **`SECURITY.md`** — new **File integrity** section. Documents JSONL signing (`signing-key`) as the strong guarantee and the two new hashes as tamper-evidence hints, with their limits stated plainly (a step that can rewrite the JSONL can also rewrite the embedded hash — a signing key is the only cryptographic stop).

## Tests

- `TestBuildDetectMarkdown_AllowlistDomainContactSummary` covers a mixed run (two domains with contacts, one without) and pins the "1 unused entry (trim candidates)" headline plus the no-contacts row note.
- `TestBuildDetectMarkdown_AllowlistDomainContactSummary_HiddenInDetect` defends against the renderer surfacing the table outside defend mode.
- `TestDigestIntegrityMarker_RoundTrip` pins the canonical marker format and confirms the SHA matches `sha256.Sum256(body)`.
- `TestDigestIntegrityMarker_EmptyBodyYieldsNothing` defends the no-write path so missing / whitespace digests do not produce a stray comment line.

## Validation

- `bash scripts/check-gofmt.sh` — pass.
- `bash scripts/check-encoding.sh` — pass.
- `go test ./internal/report/... ./internal/telemetry/... ./cmd/coldstep-action/... -count=1` — pass.
- `internal/agent/...` Linux tests + the BPF matrix run on CI (the agent package uses build tags that require generated BPF stubs, so the Windows local environment uses the stub build only).

## Constraints honored

- No new BPF programs, maps, or wire-format changes.
- No schema bump — `telemetry.SchemaVersion` is unchanged. `EventsFileSHA256` is `omitempty`.
- No `enforce` references introduced.
- No new action inputs.
