### PR TITLE
feat(H16): DNS TTL re-resolution - background drift detection

### DIFF
--- a/.github/pr-bodies/h16-dns-ttl-reresolution.md
+++ b/.github/pr-bodies/h16-dns-ttl-reresolution.md
@@ -1,0 +1,50 @@
+## Summary
+
+Implements **H16** (DNS allowlist trust hardening — live re-resolution) from the v0.4.0 hardening roadmap, completing the trust surface that **H4** (v0.2.9, startup logging of unresolved domains) and **H9** (v0.3.0, `AllowlistCompileTime` + ⚠️ staleness warning) began. A background goroutine now periodically re-resolves the startup allowlist and emits a `dns_drift` JSONL event when IPv4 addresses change relative to the snapshot programmed into the BPF map.
+
+**Warning-only by design.** The live BPF enforce policy is intentionally **not** updated mid-run. Adding freshly-resolved CDN tenant IPs to the allowlist between the lookup and the egress attempt is a TOCTOU risk (per the H16 risk note in the hardening plan); the snapshot remains the source of truth for enforcement, and the goroutine's job is purely advisory — so operators of long-running jobs see CDN tenant or LB pool rotation as a digest warning instead of a silent gap.
+
+## What changed
+
+- **`internal/policy/allowlist.go`** — new `DriftReport` struct (`AddedIPs`, `RemovedIPs`, `CheckedAt`); pure `Diff(original, updated CompileResult) DriftReport` that returns sorted IPv4 set differences (IPv6 deferred to H14); `ReResolve(ctx, original, resolver, maxAttempts)` re-runs `CompileDomainAllowlist` against the original domain list, sharing the existing concurrency/timeout limits (`coldstepDomainLookupConcurrencyLimit=32`, `coldstepDomainLookupAttemptTimeout=25s`).
+
+- **`internal/telemetry/event.go`** — new `DNSDriftEvent` (json type `"dns_drift"`) and `EventTypeDNSDrift` constant. Fields: `ts`, `added_ips`, `removed_ips`, `domain_count`, `checked_at`. Signed in the same canonical-marshal path as every other event type.
+
+- **`internal/agent/dns_drift.go`** (new, portable) — `runDNSDriftWatch(ctx, original, resolver, maxAttempts, interval, onDrift, onClean)` is the agent's H16 watchdog: ticks every `allowlistReCheckInterval` (5 minutes, mirroring the H9 staleness threshold), calls `policy.ReResolve` + `policy.Diff`, fires `onDrift` on non-empty drift and `onClean` otherwise, and returns promptly on `ctx.Done()`. Dependencies are injected so the loop is unit-testable from Windows without touching BPF or runtime DNS.
+
+- **`internal/agent/agent_linux.go`** — when `defendCompiled.Domains` is non-empty, launch the watch goroutine inside `Run`'s wait group. `onDrift` bumps `runStats.dnsDriftN` and appends a `DNSDriftEvent` JSONL line under the existing `jsonlMu`; `onClean` logs at debug level.
+
+- **`internal/agent/agent_linux_state.go`** — add `runStats.dnsDriftN` plus `addDNSDrift()` / `dnsDriftTotal()` accessors (lock-protected like every other run counter).
+
+- **`internal/agent/agent_linux_digest.go`** — surface `stats.dnsDriftTotal()` into `DigestInput.DNSDriftCount`.
+
+- **`internal/report/digest_types.go`** — add `DNSDriftCount int` to `DigestInput`.
+
+- **`internal/report/digest.go`** — `writeAllowlistTrust` now emits a fourth box when `DNSDriftCount > 0`: `> ⚠️ **DNS drift detected** — allowlist IPs changed N time(s) during this run. Enforcement was not updated mid-job.` The advisory composes with the existing unresolved / wildcard / staleness / entry-count rows.
+
+- **`SECURITY.md`** — extend the "Coverage Boundaries" → "Operational implications" bullets to call out the new advisory-only re-resolution behavior: the snapshot is fixed at startup, drift surfaces as JSONL + digest, and long-running jobs that need fresh CDN coverage must restart the agent (or pin literal IPs / CIDRs).
+
+- **`internal/policy/dns_drift_test.go`** (new) — `Diff` cases (no-change, added-only, removed-only, both, deterministic sort), and a `ReResolve` smoke test that flips the resolver between calls.
+
+- **`internal/agent/dns_drift_test.go`** (new) — exercises `runDNSDriftWatch` end-to-end: drift emission with added IPs, drift with removed IPs, table-driven add/remove/clean ticks, immediate-return on cancelled context, immediate-return on empty domain list, and clean-callback firing when DNS is stable.
+
+## Constraints honored
+
+- **No mid-job allowlist expansion.** Per the H16 risk note in the hardening plan, drift never feeds back into the BPF `allowed_ipv4` LPM trie — only JSONL + digest. Comments on `policy.DriftReport`, `runDNSDriftWatch`, and `DNSDriftEvent` repeat this so future readers don't try to "fix" the absence of a map update.
+- **No new BPF programs or maps** — pure Go + digest + telemetry surface.
+- **Concurrency budget** is the original compile's (`coldstepDomainLookupConcurrencyLimit=32`, `coldstepDomainLookupAttemptTimeout=25s`); the periodic check uses `maxAttempts=1` so transient resolver flakes recover on the next tick rather than producing retry storms against the runner's stub resolver.
+- **Cross-platform stub stays intact** — `dns_drift.go` is portable and only depends on `context`, `time`, `log/slog`, and `internal/policy`; the test file is portable too so non-Linux contributors can iterate without docker.
+- **No `enforce` references introduced** anywhere in the new surface (the rejection in `internal/config` for legacy `CI_GUARD_MODE=enforce` is unchanged).
+
+## Validation
+
+- `go vet ./internal/policy/... ./internal/report/... ./internal/telemetry/...` — pass.
+- `go test ./internal/policy/... ./internal/agent/... -count=1` (Windows, non-BPF packages) — pass.
+- `go test ./internal/report/... ./internal/telemetry/... -count=1` — pass.
+- BPF compile + verifier load + Linux unit/integration are validated by CI's `coldstep-ci-runner.yml` (`unit`, `unit-arm64`, `integration`, `detect-mode`, `defend-mode`).
+
+## Follow-ups (out of scope)
+
+- **H14 (IPv6 allowlist drift)** — `Diff` currently compares IPv4 sets only; extending to `AllowedIPv6` is a one-line follow-up once the IPv6 enforcement path graduates from observe-only.
+- **Drift-aware suggest-allow output** — the `coldstep-report` post-run pipeline could surface drift in `suggested-allow` so operators see "CDN flipped during run X, here's the union" without re-running. Tracking separately.
+- **Operator-tunable interval** — `allowlistReCheckInterval` is a 5-minute const today. If real runs show heavy CDN churn making the digest noisy, expose it via env (e.g. `COLDSTEP_DNS_RECHECK_SECONDS`) in a later PR rather than wiring a new action input now.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,6 +40,7 @@ coldstep observes and enforces a **deliberately scoped** subset of egress. Trust
 - **Detect-mode allowlist promotion** (`suggested-allow` output) reflects IPv4 destinations only. A workload that exfiltrates over IPv6, QUIC inner payload, or AF_UNIX → host-proxy will appear clean in detect and will not contribute to the suggested allowlist.
 - **Defend-mode enforcement** does not bar IPv6 destinations even when an IPv4 entry of the "same" host exists; if the runner resolves AAAA and prefers IPv6, the connection is unenforced.
 - **Service containers and DinD** run in separate network namespaces from the job's primary cgroup. Egress originating inside those namespaces is outside coldstep's hook scope; route them through the job container or rely on organizational network controls.
+- **DNS allowlist is compiled once at startup.** A background goroutine re-resolves every 5 minutes and emits `dns_drift` JSONL events (with added/removed IPv4 addresses) when CDN tenants or load-balancer pools shift mid-run, but **does not update the live enforce policy mid-run** to avoid TOCTOU races. The shutdown digest surfaces the drift count under "Allowlist trust model"; long-running jobs that need fresh CDN coverage must restart the agent (or pin literal IPs / CIDRs).
 
 ## GitHub Actions: threat model and mitigations
 

--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -1042,6 +1042,44 @@ func Run(ctx context.Context, cfg config.Config) error {
 		}()
 	}
 
+	// H16: DNS allowlist trust hardening — background re-resolution goroutine.
+	// Periodically re-resolves the startup allowlist and emits a `dns_drift`
+	// JSONL event when the IPv4 set changes. WARNING-ONLY: the live BPF enforce
+	// policy is intentionally not updated mid-run (mid-job allowlist expansion
+	// is a TOCTOU risk — a freshly-resolved CDN tenant IP could be added between
+	// the lookup and the egress attempt). Only spins up when an allowlist was
+	// compiled (defend mode with at least one resolvable domain).
+	if len(defendCompiled.Domains) > 0 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			onDrift := func(dr policy.DriftReport) {
+				stats.addDNSDrift()
+				if cfg.EventsLogPath == "" {
+					return
+				}
+				ev := telemetry.DNSDriftEvent{
+					Type:        telemetry.EventTypeDNSDrift,
+					TS:          time.Now().UTC().Format(time.RFC3339Nano),
+					AddedIPs:    dr.AddedIPs,
+					RemovedIPs:  dr.RemovedIPs,
+					DomainCount: len(defendCompiled.Domains),
+					CheckedAt:   dr.CheckedAt,
+				}
+				jsonlMu.Lock()
+				err := telemetry.AppendJSONL(cfg.EventsLogPath, ev, signer)
+				jsonlMu.Unlock()
+				if err != nil {
+					slog.Warn("dns_drift jsonl append failed", "err", err)
+				}
+			}
+			onClean := func() {
+				slog.Debug("allowlist DNS re-resolution: no drift", "domains", len(defendCompiled.Domains))
+			}
+			runDNSDriftWatch(runCtx, defendCompiled, nil, allowlistReCheckMaxAttempts, allowlistReCheckInterval, onDrift, onClean)
+		}()
+	}
+
 	// Capability 7A: BPF self-protection heartbeat monitor.
 	// Periodically polls the main sys_enter BPF program to ensure it's still attached and valid.
 	if syscallObjs != nil {

--- a/internal/agent/agent_linux_digest.go
+++ b/internal/agent/agent_linux_digest.go
@@ -264,6 +264,7 @@ func buildDigestInput(
 	in.WildcardRiskDomains = wildcardRisk
 	in.AllowlistCompileTime = compileTime
 	in.AllowlistEntryCount = defendState.allowlistSize
+	in.DNSDriftCount = stats.dnsDriftTotal()
 	in.DomainContactCounts = stats.snapshotDomainCounts()
 
 	return in

--- a/internal/agent/agent_linux_state.go
+++ b/internal/agent/agent_linux_state.go
@@ -96,6 +96,14 @@ type runStats struct {
 	allowlistUnresolvedDomains   []string
 	allowlistWildcardRiskDomains []string
 
+	// dnsDriftN counts the number of times the H16 background re-resolution
+	// goroutine observed IPv4 drift (added or removed) between the startup
+	// snapshot and a periodic re-resolution. Each non-empty DriftReport
+	// bumps this counter by 1. Live BPF policy is NOT updated on drift —
+	// the counter is purely advisory and surfaces in the shutdown digest as
+	// a "DNS drift detected" warning.
+	dnsDriftN int
+
 	// dstDomainCounts maps observed FQDN → connection-event count across TCP +
 	// UDP egress (P1-1 6e). Empty FQDNs are ignored.
 	dstDomainCounts map[string]int
@@ -826,6 +834,22 @@ func (s *runStats) allowlistSnapshot() (compileTime time.Time, ipCount int, doma
 		slices.Clone(s.allowlistDomains),
 		slices.Clone(s.allowlistUnresolvedDomains),
 		slices.Clone(s.allowlistWildcardRiskDomains)
+}
+
+// addDNSDrift bumps the H16 drift-observation counter. Called by the
+// background re-resolution goroutine's onDrift closure.
+func (s *runStats) addDNSDrift() {
+	s.mu.Lock()
+	s.dnsDriftN++
+	s.mu.Unlock()
+}
+
+// dnsDriftTotal returns the count of distinct drift observations during the
+// run. Zero when DNS was stable or re-resolution never fired.
+func (s *runStats) dnsDriftTotal() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.dnsDriftN
 }
 
 // incDomainCount bumps the per-FQDN observation counter (P1-1 6e). No-op for

--- a/internal/agent/dns_drift.go
+++ b/internal/agent/dns_drift.go
@@ -1,0 +1,85 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/coldstep-io/coldstep/internal/policy"
+)
+
+// allowlistReCheckInterval is how often the background goroutine re-runs
+// CompileDomainAllowlist against the startup allowlist to compare against
+// the IPv4 set programmed into the BPF map (H16 DNS allowlist trust
+// hardening). Five minutes mirrors the digest's TTL-staleness threshold
+// (report.allowlistStaleThreshold) so drift is observed before the digest
+// would flag the snapshot as stale.
+const allowlistReCheckInterval = 5 * time.Minute
+
+// allowlistReCheckMaxAttempts caps per-domain DNS retries inside one tick.
+// A single attempt keeps the periodic check cheap; transient resolver flakes
+// recover naturally on the next tick rather than producing a long-running
+// retry storm against the runner's stub resolver.
+const allowlistReCheckMaxAttempts = 1
+
+// runDNSDriftWatch periodically re-resolves original.Domains and reports
+// IPv4 drift via onDrift. It is the agent's H16 watchdog: warning-only —
+// it never updates the live BPF enforce policy, since mid-job expansion is a
+// TOCTOU risk (a freshly-resolved CDN tenant IP could be added between the
+// lookup and the egress attempt).
+//
+// The loop terminates when ctx is cancelled and ignores ticks that fire while
+// the previous re-resolution is still running (a stuck stub resolver on the
+// runner cannot pile up overlapping work).
+//
+// Dependencies are injected for testability:
+//   - resolver: nil → net.DefaultResolver.LookupIP (production path)
+//   - onDrift: called once per non-empty DriftReport; agent-side closure
+//     emits a JSONL DNSDriftEvent and bumps the runStats counter.
+//   - onClean: called once per tick when AddedIPs and RemovedIPs are both
+//     empty; agent-side closure logs at debug level.
+func runDNSDriftWatch(
+	ctx context.Context,
+	original policy.CompileResult,
+	resolver policy.LookupIPFunc,
+	maxAttempts int,
+	interval time.Duration,
+	onDrift func(policy.DriftReport),
+	onClean func(),
+) {
+	if len(original.Domains) == 0 {
+		return
+	}
+	if interval <= 0 {
+		interval = allowlistReCheckInterval
+	}
+	if maxAttempts < 1 {
+		maxAttempts = allowlistReCheckMaxAttempts
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		updated := policy.ReResolve(ctx, original, resolver, maxAttempts)
+		dr := policy.Diff(original, updated)
+		if len(dr.AddedIPs) == 0 && len(dr.RemovedIPs) == 0 {
+			if onClean != nil {
+				onClean()
+			}
+			continue
+		}
+		slog.Warn("allowlist DNS drift detected",
+			"added", len(dr.AddedIPs),
+			"removed", len(dr.RemovedIPs))
+		if onDrift != nil {
+			onDrift(dr)
+		}
+	}
+}

--- a/internal/agent/dns_drift_test.go
+++ b/internal/agent/dns_drift_test.go
@@ -1,0 +1,280 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"net"
+	"reflect"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/coldstep-io/coldstep/internal/policy"
+)
+
+// buildOriginal compiles a CompileResult with a fixed IPv4 set, without going
+// through CompileDomainAllowlist (so we don't have to mock the per-call resolver
+// state machine for the initial compile).
+func buildOriginal(domains []string, ipv4s ...string) policy.CompileResult {
+	cr := policy.CompileResult{
+		Domains:          append([]string(nil), domains...),
+		AllowedIPv4:      policy.IPv4Set{},
+		AllowedIPv6:      policy.IPv6Set{},
+		CompileTimestamp: time.Now(),
+	}
+	for _, s := range ipv4s {
+		cr.AllowedIPv4.Add(net.ParseIP(s))
+	}
+	return cr
+}
+
+func TestRunDNSDriftWatch_EmitsDriftWhenIPsChange(t *testing.T) {
+	original := buildOriginal([]string{"cdn.example.com"}, "1.1.1.1")
+
+	// Re-resolve will return 1.1.1.1 + 5.5.5.5 — addition of 5.5.5.5.
+	resolver := func(_ context.Context, network, host string) ([]net.IP, error) {
+		if network != "ip4" {
+			return nil, nil
+		}
+		if host != "cdn.example.com" {
+			t.Fatalf("unexpected host %q", host)
+		}
+		return []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("5.5.5.5")}, nil
+	}
+
+	driftCh := make(chan policy.DriftReport, 4)
+	onDrift := func(dr policy.DriftReport) { driftCh <- dr }
+	cleanCh := make(chan struct{}, 4)
+	onClean := func() { cleanCh <- struct{}{} }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go runDNSDriftWatch(ctx, original, resolver, 1, 5*time.Millisecond, onDrift, onClean)
+
+	select {
+	case dr := <-driftCh:
+		if !reflect.DeepEqual(dr.AddedIPs, []string{"5.5.5.5"}) {
+			t.Fatalf("AddedIPs: got %v want [5.5.5.5]", dr.AddedIPs)
+		}
+		if len(dr.RemovedIPs) != 0 {
+			t.Fatalf("RemovedIPs: got %v want empty", dr.RemovedIPs)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for onDrift")
+	}
+}
+
+func TestRunDNSDriftWatch_NoDriftFiresOnClean(t *testing.T) {
+	original := buildOriginal([]string{"stable.example.com"}, "1.1.1.1", "2.2.2.2")
+
+	resolver := func(_ context.Context, network, host string) ([]net.IP, error) {
+		if network != "ip4" {
+			return nil, nil
+		}
+		return []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2")}, nil
+	}
+
+	var driftCount, cleanCount atomic.Int32
+	onDrift := func(_ policy.DriftReport) { driftCount.Add(1) }
+	onClean := func() { cleanCount.Add(1) }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	doneCh := make(chan struct{})
+	go func() {
+		runDNSDriftWatch(ctx, original, resolver, 1, 5*time.Millisecond, onDrift, onClean)
+		close(doneCh)
+	}()
+
+	// Let a couple of ticks run.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	select {
+	case <-doneCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runDNSDriftWatch did not return after cancel")
+	}
+
+	if driftCount.Load() != 0 {
+		t.Fatalf("expected no drift; got %d drift callbacks", driftCount.Load())
+	}
+	if cleanCount.Load() == 0 {
+		t.Fatal("expected at least one onClean callback")
+	}
+}
+
+func TestRunDNSDriftWatch_RespectsContextCancellation(t *testing.T) {
+	original := buildOriginal([]string{"x.example.com"}, "1.1.1.1")
+	resolver := func(_ context.Context, _ string, _ string) ([]net.IP, error) {
+		return nil, errors.New("should not be called when ctx already cancelled")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	doneCh := make(chan struct{})
+	go func() {
+		runDNSDriftWatch(ctx, original, resolver, 1, time.Hour, nil, nil)
+		close(doneCh)
+	}()
+
+	select {
+	case <-doneCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runDNSDriftWatch did not return on pre-cancelled ctx")
+	}
+}
+
+func TestRunDNSDriftWatch_NoDomainsIsNoop(t *testing.T) {
+	original := buildOriginal(nil)
+	called := false
+	resolver := func(_ context.Context, _ string, _ string) ([]net.IP, error) {
+		called = true
+		return nil, nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	doneCh := make(chan struct{})
+	go func() {
+		runDNSDriftWatch(ctx, original, resolver, 1, 5*time.Millisecond, nil, nil)
+		close(doneCh)
+	}()
+	select {
+	case <-doneCh:
+	case <-time.After(time.Second):
+		t.Fatal("expected immediate return with empty domain list")
+	}
+	if called {
+		t.Fatal("resolver should not be called when domain list is empty")
+	}
+}
+
+func TestRunDNSDriftWatch_DriftWithRemovedIPs(t *testing.T) {
+	original := buildOriginal([]string{"shrink.example.com"}, "1.1.1.1", "2.2.2.2", "3.3.3.3")
+
+	// Re-resolve only returns 1.1.1.1 — 2.2.2.2 and 3.3.3.3 dropped.
+	resolver := func(_ context.Context, network, _ string) ([]net.IP, error) {
+		if network != "ip4" {
+			return nil, nil
+		}
+		return []net.IP{net.ParseIP("1.1.1.1")}, nil
+	}
+
+	driftCh := make(chan policy.DriftReport, 4)
+	onDrift := func(dr policy.DriftReport) { driftCh <- dr }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go runDNSDriftWatch(ctx, original, resolver, 1, 5*time.Millisecond, onDrift, nil)
+
+	select {
+	case dr := <-driftCh:
+		wantRemoved := []string{"2.2.2.2", "3.3.3.3"}
+		if !reflect.DeepEqual(dr.RemovedIPs, wantRemoved) {
+			t.Fatalf("RemovedIPs: got %v want %v", dr.RemovedIPs, wantRemoved)
+		}
+		if len(dr.AddedIPs) != 0 {
+			t.Fatalf("AddedIPs: got %v want empty", dr.AddedIPs)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for onDrift")
+	}
+}
+
+// TestRunDNSDriftWatch_TableDriven cycles through scenarios to validate the
+// loop handles add-only, remove-only, and clean ticks with the expected
+// callback counts.
+func TestRunDNSDriftWatch_TableDriven(t *testing.T) {
+	cases := []struct {
+		name        string
+		startIPs    []string
+		resolveIPs  []net.IP
+		wantDrift   bool
+		wantAdded   []string
+		wantRemoved []string
+	}{
+		{
+			name:       "stable - no drift",
+			startIPs:   []string{"1.1.1.1"},
+			resolveIPs: []net.IP{net.ParseIP("1.1.1.1")},
+			wantDrift:  false,
+		},
+		{
+			name:        "single addition",
+			startIPs:    []string{"1.1.1.1"},
+			resolveIPs:  []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("4.4.4.4")},
+			wantDrift:   true,
+			wantAdded:   []string{"4.4.4.4"},
+			wantRemoved: nil,
+		},
+		{
+			name:        "complete CDN flip",
+			startIPs:    []string{"1.1.1.1", "2.2.2.2"},
+			resolveIPs:  []net.IP{net.ParseIP("9.9.9.9"), net.ParseIP("10.10.10.10")},
+			wantDrift:   true,
+			wantAdded:   []string{"10.10.10.10", "9.9.9.9"},
+			wantRemoved: []string{"1.1.1.1", "2.2.2.2"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			original := buildOriginal([]string{"host"}, tc.startIPs...)
+			resolveIPs := append([]net.IP(nil), tc.resolveIPs...)
+			resolver := func(_ context.Context, network, _ string) ([]net.IP, error) {
+				if network != "ip4" {
+					return nil, nil
+				}
+				return resolveIPs, nil
+			}
+
+			driftCh := make(chan policy.DriftReport, 1)
+			cleanCh := make(chan struct{}, 1)
+			onDrift := func(dr policy.DriftReport) {
+				select {
+				case driftCh <- dr:
+				default:
+				}
+			}
+			onClean := func() {
+				select {
+				case cleanCh <- struct{}{}:
+				default:
+				}
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			go runDNSDriftWatch(ctx, original, resolver, 1, 5*time.Millisecond, onDrift, onClean)
+
+			if tc.wantDrift {
+				select {
+				case dr := <-driftCh:
+					if !reflect.DeepEqual(dr.AddedIPs, tc.wantAdded) {
+						t.Fatalf("AddedIPs: got %v want %v", dr.AddedIPs, tc.wantAdded)
+					}
+					if len(tc.wantRemoved) == 0 {
+						if len(dr.RemovedIPs) != 0 {
+							t.Fatalf("RemovedIPs: got %v want empty", dr.RemovedIPs)
+						}
+					} else if !reflect.DeepEqual(dr.RemovedIPs, tc.wantRemoved) {
+						t.Fatalf("RemovedIPs: got %v want %v", dr.RemovedIPs, tc.wantRemoved)
+					}
+				case <-time.After(2 * time.Second):
+					t.Fatal("expected onDrift; timed out")
+				}
+				return
+			}
+			select {
+			case <-cleanCh:
+			case <-driftCh:
+				t.Fatal("expected onClean; got onDrift")
+			case <-time.After(2 * time.Second):
+				t.Fatal("expected onClean; timed out")
+			}
+		})
+	}
+}

--- a/internal/policy/allowlist.go
+++ b/internal/policy/allowlist.go
@@ -377,3 +377,54 @@ func normalizeAllowlistDomains(domains []string) []string {
 func NormalizeDomainsFromRaw(raw string) []string {
 	return normalizeAllowlistDomains(splitFields(raw))
 }
+
+// DriftReport summarizes the difference between two CompileResult snapshots
+// of the same domain allowlist. AddedIPs / RemovedIPs are deterministic
+// (sorted ascending) so the caller can emit them in a stable JSONL payload.
+//
+// H16 DNS allowlist trust hardening: emitted as warning-only telemetry by the
+// background re-resolution goroutine in internal/agent. Drift does NOT trigger
+// a live BPF policy update — mid-job expansion is intentionally out of scope
+// to avoid TOCTOU races where a freshly-resolved CDN tenant IP is added to
+// the enforce set between the lookup and the egress attempt.
+type DriftReport struct {
+	AddedIPs   []string  // dotted-quad IPv4 addresses present in updated but not original
+	RemovedIPs []string  // dotted-quad IPv4 addresses present in original but not updated
+	CheckedAt  time.Time // wall-clock time the re-resolution finished
+}
+
+// ReResolve re-runs CompileDomainAllowlist with the same domain list as
+// the original compile and returns the new snapshot for comparison via Diff.
+// Concurrency and per-lookup timeout limits match the original compile path
+// (set by CompileDomainAllowlist itself via the package-level constants).
+// resolver may be nil (defaults to net.DefaultResolver.LookupIP); maxAttempts
+// is clamped to ≥1 by CompileDomainAllowlist.
+func ReResolve(ctx context.Context, original CompileResult, resolver LookupIPFunc, maxAttempts int) CompileResult {
+	return CompileDomainAllowlist(ctx, original.Domains, resolver, maxAttempts)
+}
+
+// Diff returns the set difference between original and updated allowlist
+// IPv4 resolutions. IPv6 diffing is deferred until H14 lands. Output slices
+// are sorted ascending so the resulting DriftReport is byte-stable for
+// deterministic JSONL emission. CheckedAt is set to time.Now().
+func Diff(original, updated CompileResult) DriftReport {
+	added := make([]string, 0)
+	removed := make([]string, 0)
+	updated.AllowedIPv4.ForEach(func(k [4]byte) {
+		if !original.AllowedIPv4.Contains(net.IP(k[:])) {
+			added = append(added, net.IP(k[:]).String())
+		}
+	})
+	original.AllowedIPv4.ForEach(func(k [4]byte) {
+		if !updated.AllowedIPv4.Contains(net.IP(k[:])) {
+			removed = append(removed, net.IP(k[:]).String())
+		}
+	})
+	slices.Sort(added)
+	slices.Sort(removed)
+	return DriftReport{
+		AddedIPs:   added,
+		RemovedIPs: removed,
+		CheckedAt:  time.Now(),
+	}
+}

--- a/internal/policy/dns_drift_test.go
+++ b/internal/policy/dns_drift_test.go
@@ -1,0 +1,136 @@
+package policy
+
+import (
+	"context"
+	"net"
+	"reflect"
+	"sync/atomic"
+	"testing"
+)
+
+// makeCompileResult constructs a CompileResult whose AllowedIPv4 set contains
+// the given dotted-quad addresses. Used by Diff tests to drive both sides of
+// the comparison without going through CompileDomainAllowlist.
+func makeCompileResult(domains []string, ipv4s ...string) CompileResult {
+	cr := CompileResult{
+		Domains:     append([]string(nil), domains...),
+		AllowedIPv4: IPv4Set{},
+		AllowedIPv6: IPv6Set{},
+	}
+	for _, s := range ipv4s {
+		cr.AllowedIPv4.Add(net.ParseIP(s))
+	}
+	return cr
+}
+
+func TestDiff_NoChange(t *testing.T) {
+	original := makeCompileResult([]string{"example.com"}, "1.1.1.1", "2.2.2.2")
+	updated := makeCompileResult([]string{"example.com"}, "1.1.1.1", "2.2.2.2")
+
+	dr := Diff(original, updated)
+	if len(dr.AddedIPs) != 0 {
+		t.Fatalf("AddedIPs: got %v want empty", dr.AddedIPs)
+	}
+	if len(dr.RemovedIPs) != 0 {
+		t.Fatalf("RemovedIPs: got %v want empty", dr.RemovedIPs)
+	}
+	if dr.CheckedAt.IsZero() {
+		t.Fatal("CheckedAt should be set to time.Now()")
+	}
+}
+
+func TestDiff_AddedOnly(t *testing.T) {
+	original := makeCompileResult([]string{"example.com"}, "1.1.1.1")
+	updated := makeCompileResult([]string{"example.com"}, "1.1.1.1", "2.2.2.2", "3.3.3.3")
+
+	dr := Diff(original, updated)
+	wantAdded := []string{"2.2.2.2", "3.3.3.3"}
+	if !reflect.DeepEqual(dr.AddedIPs, wantAdded) {
+		t.Fatalf("AddedIPs: got %v want %v", dr.AddedIPs, wantAdded)
+	}
+	if len(dr.RemovedIPs) != 0 {
+		t.Fatalf("RemovedIPs: got %v want empty", dr.RemovedIPs)
+	}
+}
+
+func TestDiff_RemovedOnly(t *testing.T) {
+	original := makeCompileResult([]string{"example.com"}, "1.1.1.1", "2.2.2.2", "3.3.3.3")
+	updated := makeCompileResult([]string{"example.com"}, "1.1.1.1")
+
+	dr := Diff(original, updated)
+	wantRemoved := []string{"2.2.2.2", "3.3.3.3"}
+	if !reflect.DeepEqual(dr.RemovedIPs, wantRemoved) {
+		t.Fatalf("RemovedIPs: got %v want %v", dr.RemovedIPs, wantRemoved)
+	}
+	if len(dr.AddedIPs) != 0 {
+		t.Fatalf("AddedIPs: got %v want empty", dr.AddedIPs)
+	}
+}
+
+func TestDiff_AddedAndRemoved(t *testing.T) {
+	// CDN tenant flipped: 1.1.1.1 dropped, 9.9.9.9 + 10.10.10.10 added.
+	original := makeCompileResult([]string{"cdn.example.com"}, "1.1.1.1", "2.2.2.2")
+	updated := makeCompileResult([]string{"cdn.example.com"}, "2.2.2.2", "9.9.9.9", "10.10.10.10")
+
+	dr := Diff(original, updated)
+	wantAdded := []string{"10.10.10.10", "9.9.9.9"} // sorted lexicographically
+	wantRemoved := []string{"1.1.1.1"}
+	if !reflect.DeepEqual(dr.AddedIPs, wantAdded) {
+		t.Fatalf("AddedIPs: got %v want %v", dr.AddedIPs, wantAdded)
+	}
+	if !reflect.DeepEqual(dr.RemovedIPs, wantRemoved) {
+		t.Fatalf("RemovedIPs: got %v want %v", dr.RemovedIPs, wantRemoved)
+	}
+}
+
+func TestDiff_OutputIsSorted(t *testing.T) {
+	original := makeCompileResult([]string{"a"}, "1.1.1.1")
+	// IPv4Set ForEach iteration order over a map is random — Diff must sort.
+	updated := makeCompileResult([]string{"a"},
+		"1.1.1.1", "8.8.8.8", "2.2.2.2", "5.5.5.5", "3.3.3.3")
+
+	dr := Diff(original, updated)
+	wantAdded := []string{"2.2.2.2", "3.3.3.3", "5.5.5.5", "8.8.8.8"}
+	if !reflect.DeepEqual(dr.AddedIPs, wantAdded) {
+		t.Fatalf("AddedIPs (sorted): got %v want %v", dr.AddedIPs, wantAdded)
+	}
+}
+
+func TestReResolve_RunsCompileWithOriginalDomainsAndDetectsDrift(t *testing.T) {
+	ctx := context.Background()
+
+	// Stage 1: original compile sees "1.1.1.1" for example.com.
+	// Stage 2: re-resolve sees "1.1.1.1" + "5.5.5.5" (CDN expansion).
+	var call atomic.Int32
+	resolver := func(_ context.Context, network, host string) ([]net.IP, error) {
+		if host != "example.com" {
+			t.Fatalf("unexpected host %q", host)
+		}
+		if network != "ip4" {
+			return nil, nil
+		}
+		n := call.Add(1)
+		if n == 1 {
+			return []net.IP{net.ParseIP("1.1.1.1")}, nil
+		}
+		return []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("5.5.5.5")}, nil
+	}
+
+	original := CompileDomainAllowlist(ctx, []string{"example.com"}, resolver, 1)
+	if !original.AllowedIPv4.Contains(net.ParseIP("1.1.1.1")) {
+		t.Fatal("original missing 1.1.1.1")
+	}
+
+	updated := ReResolve(ctx, original, resolver, 1)
+	if !updated.AllowedIPv4.Contains(net.ParseIP("5.5.5.5")) {
+		t.Fatalf("re-resolve missing 5.5.5.5; got Len=%d", updated.AllowedIPv4.Len())
+	}
+
+	dr := Diff(original, updated)
+	if !reflect.DeepEqual(dr.AddedIPs, []string{"5.5.5.5"}) {
+		t.Fatalf("drift AddedIPs: got %v", dr.AddedIPs)
+	}
+	if len(dr.RemovedIPs) != 0 {
+		t.Fatalf("drift RemovedIPs: got %v want empty", dr.RemovedIPs)
+	}
+}

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -1191,7 +1191,8 @@ func writeAllowlistTrust(b *strings.Builder, in DigestInput) {
 	hasStale := staleAge > 0
 	hasEntryCount := in.AllowlistEntryCount > 0 && isBlockingDigestMode(in.DefendMode)
 	hasContactSummary := isBlockingDigestMode(in.DefendMode) && len(in.AllowlistDomains) > 0
-	if !hasUnresolved && !hasWildcard && !hasStale && !hasEntryCount && !hasContactSummary {
+	hasDrift := in.DNSDriftCount > 0
+	if !hasUnresolved && !hasWildcard && !hasStale && !hasEntryCount && !hasContactSummary && !hasDrift {
 		return
 	}
 
@@ -1219,6 +1220,12 @@ func writeAllowlistTrust(b *strings.Builder, in DigestInput) {
 		b.WriteString(fmt.Sprintf(
 			"> ⚠️ **DNS allowlist may be stale** — compiled %.0f minutes ago. DNS TTLs may have expired.\n\n",
 			staleAge.Minutes()))
+	}
+
+	if hasDrift {
+		b.WriteString(fmt.Sprintf(
+			"> ⚠️ **DNS drift detected** — allowlist IPs changed %d time(s) during this run. Enforcement was not updated mid-job.\n\n",
+			in.DNSDriftCount))
 	}
 
 	if hasEntryCount {

--- a/internal/report/digest_types.go
+++ b/internal/report/digest_types.go
@@ -370,6 +370,14 @@ type DigestInput struct {
 	// since the snapshot was programmed into the BPF map. Zero value means no
 	// allowlist was compiled and the warning is suppressed.
 	AllowlistCompileTime time.Time
+	// DNSDriftCount is the number of times the H16 background re-resolution
+	// goroutine observed IPv4 drift relative to the startup snapshot during
+	// the run. Each non-empty policy.DriftReport bumps the counter by 1.
+	// Non-zero values surface a "DNS drift detected" advisory in the
+	// allowlist trust section — enforcement was intentionally not updated
+	// mid-job, so operators see TOCTOU-safe staleness as a warning rather
+	// than a silent gap.
+	DNSDriftCount int
 	// AllowlistEntryCount is the total number of /32 + CIDR entries programmed
 	// into the BPF allowed_ipv4 LPM trie at startup (H12). Mirrors
 	// MetaEvent.AllowlistEntryCount; rendered as a fixed-point reminder in the

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -3,6 +3,7 @@ package telemetry
 import (
 	"encoding/json"
 	"sync"
+	"time"
 )
 
 // SchemaVersion is bumped when JSONL field shapes change incompatibly.
@@ -587,6 +588,31 @@ type BPFTamperEvent struct {
 	Expected string `json:"expected,omitempty"`
 	Actual   string `json:"actual,omitempty"`
 	Sig      string `json:"sig,omitempty"`
+}
+
+// EventTypeDNSDrift is the JSONL discriminator for DNSDriftEvent.
+const EventTypeDNSDrift = "dns_drift"
+
+// DNSDriftEvent is one JSONL record emitted when the periodic allowlist
+// re-resolution observes IPv4 addresses changing relative to the startup
+// compile. Drift is warning-only — the live BPF enforce policy is intentionally
+// NOT updated mid-run (H16 DNS allowlist trust hardening). The event lets
+// operators see that DNS TTLs flipped CDN tenants mid-job without exposing the
+// enforcement path to TOCTOU expansion races.
+//
+// AddedIPs and RemovedIPs are dotted-quad strings, sorted ascending by
+// policy.Diff. DomainCount snapshots the size of the allowlist domain list
+// at the time of the re-resolution (the same input to CompileDomainAllowlist).
+// CheckedAt records when the re-resolution finished; Timestamp/TS is the
+// JSONL emission time as with other event types.
+type DNSDriftEvent struct {
+	Type        string    `json:"type"` // "dns_drift"
+	TS          string    `json:"ts"`
+	AddedIPs    []string  `json:"added_ips,omitempty"`
+	RemovedIPs  []string  `json:"removed_ips,omitempty"`
+	DomainCount int       `json:"domain_count"`
+	CheckedAt   time.Time `json:"checked_at"`
+	Sig         string    `json:"sig,omitempty"`
 }
 
 // SeqGen assigns monotonic per-run sequence numbers in userspace.


### PR DESCRIPTION
## Summary

Implements **H16** (DNS allowlist trust hardening — live re-resolution) from the v0.4.0 hardening roadmap, completing the trust surface that **H4** (v0.2.9, startup logging of unresolved domains) and **H9** (v0.3.0, `AllowlistCompileTime` + ⚠️ staleness warning) began. A background goroutine now periodically re-resolves the startup allowlist and emits a `dns_drift` JSONL event when IPv4 addresses change relative to the snapshot programmed into the BPF map.

**Warning-only by design.** The live BPF enforce policy is intentionally **not** updated mid-run. Adding freshly-resolved CDN tenant IPs to the allowlist between the lookup and the egress attempt is a TOCTOU risk (per the H16 risk note in the hardening plan); the snapshot remains the source of truth for enforcement, and the goroutine's job is purely advisory — so operators of long-running jobs see CDN tenant or LB pool rotation as a digest warning instead of a silent gap.

## What changed

- **`internal/policy/allowlist.go`** — new `DriftReport` struct (`AddedIPs`, `RemovedIPs`, `CheckedAt`); pure `Diff(original, updated CompileResult) DriftReport` that returns sorted IPv4 set differences (IPv6 deferred to H14); `ReResolve(ctx, original, resolver, maxAttempts)` re-runs `CompileDomainAllowlist` against the original domain list, sharing the existing concurrency/timeout limits (`coldstepDomainLookupConcurrencyLimit=32`, `coldstepDomainLookupAttemptTimeout=25s`).

- **`internal/telemetry/event.go`** — new `DNSDriftEvent` (json type `"dns_drift"`) and `EventTypeDNSDrift` constant. Fields: `ts`, `added_ips`, `removed_ips`, `domain_count`, `checked_at`. Signed in the same canonical-marshal path as every other event type.

- **`internal/agent/dns_drift.go`** (new, portable) — `runDNSDriftWatch(ctx, original, resolver, maxAttempts, interval, onDrift, onClean)` is the agent's H16 watchdog: ticks every `allowlistReCheckInterval` (5 minutes, mirroring the H9 staleness threshold), calls `policy.ReResolve` + `policy.Diff`, fires `onDrift` on non-empty drift and `onClean` otherwise, and returns promptly on `ctx.Done()`. Dependencies are injected so the loop is unit-testable from Windows without touching BPF or runtime DNS.

- **`internal/agent/agent_linux.go`** — when `defendCompiled.Domains` is non-empty, launch the watch goroutine inside `Run`'s wait group. `onDrift` bumps `runStats.dnsDriftN` and appends a `DNSDriftEvent` JSONL line under the existing `jsonlMu`; `onClean` logs at debug level.

- **`internal/agent/agent_linux_state.go`** — add `runStats.dnsDriftN` plus `addDNSDrift()` / `dnsDriftTotal()` accessors (lock-protected like every other run counter).

- **`internal/agent/agent_linux_digest.go`** — surface `stats.dnsDriftTotal()` into `DigestInput.DNSDriftCount`.

- **`internal/report/digest_types.go`** — add `DNSDriftCount int` to `DigestInput`.

- **`internal/report/digest.go`** — `writeAllowlistTrust` now emits a fourth box when `DNSDriftCount > 0`: `> ⚠️ **DNS drift detected** — allowlist IPs changed N time(s) during this run. Enforcement was not updated mid-job.` The advisory composes with the existing unresolved / wildcard / staleness / entry-count rows.

- **`SECURITY.md`** — extend the "Coverage Boundaries" → "Operational implications" bullets to call out the new advisory-only re-resolution behavior: the snapshot is fixed at startup, drift surfaces as JSONL + digest, and long-running jobs that need fresh CDN coverage must restart the agent (or pin literal IPs / CIDRs).

- **`internal/policy/dns_drift_test.go`** (new) — `Diff` cases (no-change, added-only, removed-only, both, deterministic sort), and a `ReResolve` smoke test that flips the resolver between calls.

- **`internal/agent/dns_drift_test.go`** (new) — exercises `runDNSDriftWatch` end-to-end: drift emission with added IPs, drift with removed IPs, table-driven add/remove/clean ticks, immediate-return on cancelled context, immediate-return on empty domain list, and clean-callback firing when DNS is stable.

## Constraints honored

- **No mid-job allowlist expansion.** Per the H16 risk note in the hardening plan, drift never feeds back into the BPF `allowed_ipv4` LPM trie — only JSONL + digest. Comments on `policy.DriftReport`, `runDNSDriftWatch`, and `DNSDriftEvent` repeat this so future readers don't try to "fix" the absence of a map update.
- **No new BPF programs or maps** — pure Go + digest + telemetry surface.
- **Concurrency budget** is the original compile's (`coldstepDomainLookupConcurrencyLimit=32`, `coldstepDomainLookupAttemptTimeout=25s`); the periodic check uses `maxAttempts=1` so transient resolver flakes recover on the next tick rather than producing retry storms against the runner's stub resolver.
- **Cross-platform stub stays intact** — `dns_drift.go` is portable and only depends on `context`, `time`, `log/slog`, and `internal/policy`; the test file is portable too so non-Linux contributors can iterate without docker.
- **No `enforce` references introduced** anywhere in the new surface (the rejection in `internal/config` for legacy `CI_GUARD_MODE=enforce` is unchanged).

## Validation

- `go vet ./internal/policy/... ./internal/report/... ./internal/telemetry/...` — pass.
- `go test ./internal/policy/... ./internal/agent/... -count=1` (Windows, non-BPF packages) — pass.
- `go test ./internal/report/... ./internal/telemetry/... -count=1` — pass.
- BPF compile + verifier load + Linux unit/integration are validated by CI's `coldstep-ci-runner.yml` (`unit`, `unit-arm64`, `integration`, `detect-mode`, `defend-mode`).

## Follow-ups (out of scope)

- **H14 (IPv6 allowlist drift)** — `Diff` currently compares IPv4 sets only; extending to `AllowedIPv6` is a one-line follow-up once the IPv6 enforcement path graduates from observe-only.
- **Drift-aware suggest-allow output** — the `coldstep-report` post-run pipeline could surface drift in `suggested-allow` so operators see "CDN flipped during run X, here's the union" without re-running. Tracking separately.
- **Operator-tunable interval** — `allowlistReCheckInterval` is a 5-minute const today. If real runs show heavy CDN churn making the digest noisy, expose it via env (e.g. `COLDSTEP_DNS_RECHECK_SECONDS`) in a later PR rather than wiring a new action input now.
