### PR TITLE
feat(H14): IPv6 block phase 2 — AAAA resolution + LPM trie enforcement

### DIFF
--- a/.github/pr-bodies/h14-ipv6-block-phase2.md
+++ b/.github/pr-bodies/h14-ipv6-block-phase2.md
@@ -1,0 +1,52 @@
+## Summary
+
+Implements **H14 — IPv6 block Phase 2** from the v0.4.0 hardening roadmap. The defend-mode BPF / userspace plumbing for blocking non-allowlisted IPv6 egress already landed in P2-1 (PR #164): `bpf/trace_defend_cgroup.inc` carries `cgroup/connect6` + `cgroup/sendmsg6` hooks that consult an AAAA-populated `allowed_ipv6` LPM trie and return EPERM on miss, `bpf/defend_lpm_v6_key.h` declares the trie key, `internal/policy/allowlist.go` resolves AAAA records in parallel, and `internal/agent/agent_linux_policy_maps.go` populates the trie. This PR closes the three remaining H14 gaps relative to that baseline:
+
+- the public coverage telemetry now carries a meaningful **`ipv6` enforcement label** ("enforce" / "off") instead of the v0.2.9 stub `bool: false`,
+- a Go-side unit test pins the **loopback / link-local bypass classification** that the BPF program relies on,
+- **README** and **SECURITY.md** drop the "IPv6 is unsupported in defend" wording that was true at v0.2.9 and now reflect the H14 enforcement story.
+
+## What changed
+
+- **`internal/telemetry/event.go`** — `CoverageReport.IPv6` changes type from `bool` to `string` with three named values (`telemetry.CoverageIPv6Off`, `…ObserveOnly`, `…Enforce`). The "observe-only" tier is reserved for the standalone detect-mode IPv6 observer (H7, separately tracked in PR #199) and is not emitted by the current agent. The field stays in the same JSON position (`"ipv6": …`) with no `omitempty` so consumers can rely on the key always being present.
+
+- **`internal/agent/agent_linux_digest.go`** — `buildCoverageReport` grows an `ipv6Enforced bool` parameter. When true it sets `CoverageReport.IPv6 = "enforce"`; otherwise `"off"`. No change to the other coverage cells (IPv4 TCP/UDP, TLS SNI, io_uring) — the agent's "Coverage scope" digest table already reads its IPv6 row from the digest-side renderer (`ipv6CoverageCell` in `internal/report/digest.go`), which is unchanged.
+
+- **`internal/agent/agent_linux.go`** — the single `buildCoverageReport` caller computes `ipv6Enforced := cfg.Mode == config.ModeDefend && hasDefend`. An empty `allowed_ipv6` trie is still reported as `"enforce"` because the cgroup6 hook denies every non-loopback IPv6 destination in that posture (the existing digest renderer already labels it `✓ gated (defend block-all — empty allowed_ipv6)`). When the hooks are not loaded (detect mode, or kernel rejected the program), `hasDefend` is false and the label degrades to `"off"`.
+
+- **`internal/agent/coverage_report_linux_test.go`** — `TestBuildCoverageReport` grows a sixth row pinning the defend-mode `"enforce"` outcome, plus an `ipv6Enforced` column on every existing row so detect-mode and probe-degraded paths regress against the `"off"` value. The IPv4 / TLS / io_uring assertions are unchanged.
+
+- **`internal/telemetry/event_test.go`** — `TestCoverageReportJSON` now exercises `"ipv6":"enforce"` and a sibling `TestCoverageReportIPv6OffSerialization` locks the default `"off"` shape.
+
+- **`internal/policy/ipv6_bypass.go` (new)** — `IPv6BypassesDefend(net.IP) bool` is the userspace mirror of the BPF helpers `cg_ipv6_is_loopback` and `cg_ipv6_is_link_local` in `bpf/trace_defend_cgroup.inc`. The function is documentation + a regression anchor: production code does not consult it (the BPF program is authoritative), but a Go test asserts the exact classification (`::1` and `fe80::/10` bypass; everything else — including `fec0::1`, `fe00::1`, `2001:db8::1`, `fc00::1`, `ff02::1`, `::` — does not). Drift here is a defend-bypass risk in either direction.
+
+- **`internal/policy/ipv6_bypass_test.go` (new)** — table-test for `IPv6BypassesDefend` covering loopback, the fe80::/10 lower and upper bounds, the adjacent fec0::/10 and fe00::/10 ranges that must NOT bypass, unique-local fc00::/7, multicast ff00::/8, global 2000::/3, the unspecified `::`, and IPv4 inputs (which the IPv6 hook never sees but the helper defensively rejects).
+
+- **`README.md`** — "At a glance" defend row now reads "Block IPv4 and IPv6 egress not on the allowlist (cgroup `connect4`/`sendmsg4` + `connect6`/`sendmsg6`; QUIC payloads remain uninspected)". The Requirements row for IP versions describes the H14 enforcement scope, the `::1` / `fe80::/10` always-bypass rule, and the explicit detect-mode IPv6 gap.
+
+- **`SECURITY.md`** — the Coverage Boundaries table splits the old `IPv6 (all)` row into `IPv6 TCP (connect6)` and `IPv6 UDP (sendmsg6)`, both `✗` in detect / `✓` in defend with the H14 attribution. The "Why IPv4-only" paragraph is replaced by a "Defend-mode IPv6 enforcement (H14, v0.4.0)" paragraph spelling out the LPM-trie path, the always-bypass classes, and the still-open detect-mode gap. The "Operational implications", "What a job adversary can do", "Guarantees vs best-effort", and "Defend hooks" sections are updated in lockstep so no stale "IPv6 is unsupported" claim survives.
+
+## Why no BPF or policy-compile changes
+
+The BPF cgroup6 hooks (`defend_cgroup_connect6`, `defend_cgroup_sendmsg6`) already do the LPM lookup against `allowed_ipv6` and emit deny events on miss (P2-1, merged at `f243dcf`). `IPv6Set` already lives on `CompileResult` and is populated from parallel AAAA lookups bounded by `coldstepDomainLookupConcurrencyLimit = 32`; `populateAllowedIPv6Map` in `agent_linux_policy_maps.go` programs the trie. Reworking any of those would be churn, not progress — the H14 spec items that named those changes were satisfied by P2-1 ahead of v0.4.0.
+
+What was left was the public-surface alignment: telemetry shape, docs, and a pinned regression for the loopback/link-local classifier. That is the scope of this PR.
+
+## Constraints honored
+
+- No new BPF programs, maps, or wire-format changes — `lpm_v6_key`, `allowed_ipv6`, and the cgroup6 hooks are unchanged.
+- No schema bump — `telemetry.SchemaVersion` is unchanged. The `CoverageReport.IPv6` type change is a JSON value-shape adjustment (`bool` → `string`) within the same key; downstream consumers that parsed the v0.2.9 stub as `bool false` need to update to a string-typed reader, but the field has never carried a meaningful value before v0.4.0.
+- No new `enforce` mode references — defend/detect remain the only public mode names.
+
+## Validation
+
+- `bash scripts/check-gofmt.sh` — clean on the modified files.
+- `bash scripts/check-encoding.sh` — pass.
+- `go vet ./...` on the non-BPF subset (BPF-stub packages require `go generate` on Linux) — pass.
+- `go test ./internal/policy/... ./internal/telemetry/... -count=1` — pass.
+- BPF compile + verifier load, defend integration, and the cross-architecture matrix are validated by `coldstep-ci-runner.yml` (`unit`, `unit-arm64`, `integration`, `detect-mode`, `defend-mode`).
+
+## Follow-ups (out of scope)
+
+- **H7 detect-mode IPv6 observation** (PR #199, branch `feat/h7-ipv6-detect-warn`) ships a standalone `internal/bpf/traceipv6` package that attaches cgroup/connect6+sendmsg6 in detect mode as observe-only. When that lands, `buildCoverageReport` should grow a second signal so the label can flip to `telemetry.CoverageIPv6ObserveOnly` in detect-mode runs where the observer attached. The constant is already defined.
+- **Cgroup6 attach BPFStatus rows.** The current code logs at `slog.Info` when `cgroup/connect6` / `sendmsg6` fail to attach but does not append `BPFStatus` rows, so a degraded IPv6 path is not visible in the digest's BPF section. Tracking separately.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Using Coldstep in **your** workflow does **not** require **Python** or **`pip in
 | Mode | What it does | Allowlist |
 | :--- | :------------- | :-------- |
 | **`detect`** (default) | Observe and log IPv4-focused TCP/UDP egress activity (IPv6 and QUIC not observed); no blocking. | Optional (policy labels only). |
-| **`defend`** | Block IPv4 egress not on the allowlist (IPv4 TCP/UDP only — IPv6 and QUIC not blocked; cgroup programs). | **Required** — non-empty effective allowlist. |
+| **`defend`** | Block IPv4 and IPv6 egress not on the allowlist (cgroup `connect4`/`sendmsg4` + `connect6`/`sendmsg6`; QUIC payloads remain uninspected). | **Required** — non-empty effective allowlist (A and/or AAAA resolutions). |
 
 **Upgrading from old workflows**
 
@@ -59,7 +59,7 @@ The single `uses:` block is enough — node24 pre/post hooks start the agent bef
 
 | Topic | Detail |
 | :---- | :----- |
-| **IP versions** | Coldstep observes and enforces **IPv4 TCP/UDP only**. **IPv6 is not supported** — IPv6 egress is silently bypassed in both detect and defend modes. QUIC/HTTP3 traffic is observed as UDP/443 events but the inner framing is not inspected. See **[Coverage Boundaries](SECURITY.md#coverage-boundaries)** for the full matrix (Unix sockets, io_uring, service containers, Docker-in-Docker). |
+| **IP versions** | Coldstep observes IPv4 TCP/UDP egress (detect + defend). In **defend mode** coldstep also enforces IPv6 TCP/UDP egress via cgroup `connect6` + `sendmsg6` hooks against an AAAA-resolved `allowed_ipv6` LPM trie (H14, v0.4.0); `::1` (loopback) and `fe80::/10` (link-local) bypass enforcement by design. Detect-mode IPv6 egress is still silently bypassed (no observation). QUIC/HTTP3 traffic is observed as UDP/443 events but the inner framing is not inspected. See **[Coverage Boundaries](SECURITY.md#coverage-boundaries)** for the full matrix (Unix sockets, io_uring, service containers, Docker-in-Docker). |
 | **Runner OS** | **Linux only** for the agent. **v1 supports `ubuntu-latest` only** (GitHub-hosted Ubuntu x64). Not supported on macOS, Windows, self-hosted, or other `runs-on` labels until explicitly documented in a later release. |
 | **Build on runner** | The action runs [`scripts/build-agent-linux.sh`](scripts/build-agent-linux.sh) (clang, libbpf, **bpftool** against `/sys/kernel/btf/vmlinux` → `bpf/vmlinux.h`, `go generate` / bpf2go, then **`go build`** → **`bin/coldstep`**). |
 | **Privileges** | The agent runs under **`sudo`** to load BPF. |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,19 +26,20 @@ coldstep observes and enforces a **deliberately scoped** subset of egress. Trust
 | IPv4 TCP | ✓ | ✓ | Via `connect4` tracepoint + cgroup hook |
 | IPv4 UDP (`sendmsg`) | ✓ | ✓ | Via `sendmsg4` tracepoint + cgroup hook |
 | IPv4 UDP (`write` on connected socket) | partial | ✓ | `write(2)` on a connected UDP socket may not emit a per-message event; cgroup `sendmsg4` still enforces |
-| IPv6 (all) | ✗ | ✗ | No IPv6 hooks; silent bypass in all modes |
+| IPv6 TCP (`connect6`) | ✗ | ✓ | Defend mode attaches `cgroup/connect6` + AAAA-resolved `allowed_ipv6` LPM trie (H14, v0.4.0). `::1` (loopback) and `fe80::/10` (link-local) always bypass. Detect mode does not observe IPv6. |
+| IPv6 UDP (`sendmsg6`) | ✗ | ✓ | Defend mode attaches `cgroup/sendmsg6` against the same `allowed_ipv6` trie. Detect mode does not observe IPv6. |
 | QUIC / HTTP3 (UDP/443) | UDP event only | ✓ (port/IP) | Inner QUIC framing not inspected; SNI not extracted |
 | TLS via io_uring | partial (enhanced) | ✗ | io_uring detection gated behind `detect-profile: enhanced` (raw_tp/io_uring_submit_sqe); the sysctl `io-uring-disable` remains the primary defense |
 | Unix domain sockets | ✗ | ✗ | AF_UNIX not tracked |
 | Docker-in-Docker inner containers | ✗ | ✗ | Separate cgroup/network namespace |
 | GitHub Actions service containers | ✗ | ✗ | Docker networking, separate namespace |
 
-**Why IPv4-only.** Defend hooks attach to the kernel-side BPF program types `cgroup/connect4` and `cgroup/sendmsg4`. These hook types are address-family-specific by ABI — the analogous `connect6` / `sendmsg6` slots would have to be implemented, attached, and verified separately, and require parallel IPv6 LPM map machinery on the userspace side. Until those land, IPv6 egress is not observed by coldstep tracepoints and is not gated by coldstep cgroup hooks. Treat any IPv6-capable destination as an uncovered path.
+**Defend-mode IPv6 enforcement (H14, v0.4.0).** Defend mode attaches `cgroup/connect6` and `cgroup/sendmsg6` programs against an `allowed_ipv6` LPM trie populated from AAAA resolutions of the configured allowlist (alongside the existing IPv4 cgroup hooks). Non-loopback / non-link-local IPv6 destinations that miss the trie return EPERM, mirroring the IPv4 path. `::1` (loopback) and `fe80::/10` (link-local) always bypass enforcement so test runners' localhost traffic and IPv6 neighbour-discovery / SLAAC are not disrupted. **Detect mode does not currently observe IPv6 egress** — IPv6 visibility outside defend is a known coverage gap (tracked separately).
 
 **Operational implications.**
 
-- **Detect-mode allowlist promotion** (`suggested-allow` output) reflects IPv4 destinations only. A workload that exfiltrates over IPv6, QUIC inner payload, or AF_UNIX → host-proxy will appear clean in detect and will not contribute to the suggested allowlist.
-- **Defend-mode enforcement** does not bar IPv6 destinations even when an IPv4 entry of the "same" host exists; if the runner resolves AAAA and prefers IPv6, the connection is unenforced.
+- **Detect-mode allowlist promotion** (`suggested-allow` output) reflects IPv4 destinations only. A workload that exfiltrates over IPv6, QUIC inner payload, or AF_UNIX → host-proxy will appear clean in detect and will not contribute to the suggested allowlist. IPv6 visibility in detect mode is on the roadmap.
+- **Defend-mode enforcement** gates IPv4 and IPv6 destinations against their respective allowlists. AAAA-resolved hosts are programmed as `/128` entries in `allowed_ipv6`; if the runner resolves AAAA and prefers IPv6, the connection is now subject to the allowlist (no longer silently allowed). An IPv4-only allowlist with no AAAA resolutions still defends IPv6 — every non-loopback IPv6 destination is denied because the trie is empty.
 - **Service containers and DinD** run in separate network namespaces from the job's primary cgroup. Egress originating inside those namespaces is outside coldstep's hook scope; route them through the job container or rely on organizational network controls.
 - **DNS allowlist is compiled once at startup.** A background goroutine re-resolves every 5 minutes and emits `dns_drift` JSONL events (with added/removed IPv4 addresses) when CDN tenants or load-balancer pools shift mid-run, but **does not update the live enforce policy mid-run** to avoid TOCTOU races. The shutdown digest surfaces the drift count under "Allowlist trust model"; long-running jobs that need fresh CDN coverage must restart the agent (or pin literal IPs / CIDRs).
 
@@ -48,7 +49,7 @@ Coldstep is commonly used in **GitHub-hosted Ubuntu** jobs. This section summari
 
 ### What a job adversary can do
 
-Workflow steps run with the **same privileges** as the job (modulo `sudo` elevation for the agent per action design). A malicious or compromised step can attempt **egress**, **binary execution**, or **tampering** patterns similar to those discussed in public literature on **eBPF monitoring limits** (instrumentation gaps, overload/drops, cgroup scope). Coldstep’s **defend** (blocking) path is **IPv4-only** for cgroup **connect** / **sendmsg** hooks. **IPv6 is not supported** — see **README** → Requirements.
+Workflow steps run with the **same privileges** as the job (modulo `sudo` elevation for the agent per action design). A malicious or compromised step can attempt **egress**, **binary execution**, or **tampering** patterns similar to those discussed in public literature on **eBPF monitoring limits** (instrumentation gaps, overload/drops, cgroup scope). Coldstep's **defend** (blocking) path gates **IPv4 and IPv6** via cgroup `connect4`/`sendmsg4` and `connect6`/`sendmsg6` hooks (H14, v0.4.0); **detect** mode currently observes IPv4 only. See **README** → Requirements.
 
 ### Mitigations consumers should apply
 
@@ -64,9 +65,9 @@ Workflow steps run with the **same privileges** as the job (modulo `sudo` elevat
 
 Coldstep’s contract has three layers:
 
-1. **Defend (when programs are loaded and mode is blocking):** **IPv4** egress that hits the attached **cgroup** and/or **BPF LSM** hooks is **denied** unless it matches the **effective allowlist** (IPv4 literals / CIDRs in the LPM map, plus optional **DNS cache–backed** domain rules). This is **hook-scoped** and **IPv4-only**; it is not a promise that every kernel egress mechanism was evaluated.
-2. **Detect:** Syscall and tracepoint visibility is **best-effort**. Counters may show **partial** visibility (e.g. unobserved syscall families, multi-iovec captures, ringbuf reserve failures). **Absence of JSONL lines does not prove absence of traffic.**
-3. **Explicit non-coverage:** **IPv6** is unsupported. **io_uring** and similar paths can **bypass typical syscall tracepoints**; Coldstep may surface `io_uring_setup` as a **signal**, not as payload visibility. **Defend mode (Linux 5.19+ with `CONFIG_BPF_LSM` + `bpf` in the kernel's `lsm=` boot chain):** `lsm/io_uring_cmd` (H15) denies IPv4 egress via `IORING_OP_URING_CMD` to non-allowlisted destinations, closing the URING_CMD branch that does not flow through `security_socket_sendmsg()`. `IORING_OP_SEND` / `IORING_OP_SENDMSG` are already covered by the existing `lsm/socket_sendmsg` hook because they go through `sock_sendmsg()`. On older kernels (pre-5.19) or kernels without `CONFIG_BPF_LSM`, the `lsm/io_uring_cmd` hook is silently skipped at load time and no status row is emitted — the cgroup IPv4 hooks remain the primary defense path. Organizational controls remain necessary for audit-grade posture (see **Residual risk** below).
+1. **Defend (when programs are loaded and mode is blocking):** **IPv4 and IPv6** egress that hits the attached **cgroup** (`connect4`/`sendmsg4`/`connect6`/`sendmsg6`) and/or **BPF LSM** hooks is **denied** unless it matches the **effective allowlist** (IPv4 literals / CIDRs and AAAA-resolved `/128` IPv6 entries in the respective LPM maps, plus optional **DNS cache–backed** domain rules). This is **hook-scoped**; it is not a promise that every kernel egress mechanism was evaluated. IPv6 loopback (`::1`) and link-local (`fe80::/10`) always bypass enforcement by design.
+2. **Detect:** Syscall and tracepoint visibility is **best-effort** and currently **IPv4 only**. Counters may show **partial** visibility (e.g. unobserved syscall families, multi-iovec captures, ringbuf reserve failures). **Absence of JSONL lines does not prove absence of traffic.**
+3. **Explicit non-coverage:** **Detect-mode IPv6** is not observed (defend mode does enforce IPv6). **io_uring** and similar paths can **bypass typical syscall tracepoints**; Coldstep may surface `io_uring_setup` as a **signal**, not as payload visibility. **Defend mode (Linux 5.19+ with `CONFIG_BPF_LSM` + `bpf` in the kernel's `lsm=` boot chain):** `lsm/io_uring_cmd` (H15) denies IPv4 egress via `IORING_OP_URING_CMD` to non-allowlisted destinations, closing the URING_CMD branch that does not flow through `security_socket_sendmsg()`. `IORING_OP_SEND` / `IORING_OP_SENDMSG` are already covered by the existing `lsm/socket_sendmsg` hook because they go through `sock_sendmsg()`. On older kernels (pre-5.19) or kernels without `CONFIG_BPF_LSM`, the `lsm/io_uring_cmd` hook is silently skipped at load time and no status row is emitted — the cgroup hooks remain the primary defense path. Organizational controls remain necessary for audit-grade posture (see **Residual risk** below).
 
 **DNS domain allowlists (defend):** Resolution and BPF `dns_cache` updates are **best-effort**. High cardinality answers, shared IPs, and cache timing can make **allow-by-domain** subtle. Prefer **IPv4 literals or CIDRs** when you need crisp policy; treat domain rules as convenient but higher-ambiguity. The agent may **log a warning** when a single allowed domain resolves to more than **10** distinct IPv4 addresses (warn-only — does not change the effective allowlist). Future digest surfacing may add operator-visible notes without changing allow/deny unless explicitly documented.
 
@@ -74,11 +75,11 @@ Coldstep’s contract has three layers:
 
 | Layer | BPF object (repo) | Role |
 | ----- | ----------------- | ---- |
-| **cgroup** | `bpf/trace_defend_all.bpf.c` (`bpf/trace_defend_cgroup.inc`) | **`cgroup/connect4`**, **`cgroup/sendmsg4`** — primary IPv4 egress defend for TCP and UDP on the job cgroup. |
-| **LSM** | `bpf/trace_defend_all.bpf.c` (`bpf/trace_lsm_defend_lsm.inc`) | **`lsm/socket_connect`**, **`lsm/socket_sendmsg`** (`SEC(...)` names; supplemental BPF LSM defend where available). |
-| **LSM (io_uring)** | `bpf/trace_defend_all.bpf.c` (`bpf/trace_lsm_defend_iouring.inc`) | **`lsm/io_uring_cmd`** — H15 defense-in-depth on `IORING_OP_URING_CMD` paths that bypass `security_socket_sendmsg()`. Requires Linux **5.19+** (`security_uring_cmd` BTF) plus `CONFIG_BPF_LSM`; silently skipped on older kernels. |
+| **cgroup** | `bpf/trace_defend_all.bpf.c` (`bpf/trace_defend_cgroup.inc`) | **`cgroup/connect4`**, **`cgroup/sendmsg4`**, **`cgroup/connect6`**, **`cgroup/sendmsg6`** — primary IPv4 and IPv6 egress defend for TCP and UDP on the job cgroup. IPv6 (H14) consults the AAAA-populated `allowed_ipv6` LPM trie; `::1` and `fe80::/10` always bypass. |
+| **LSM** | `bpf/trace_defend_all.bpf.c` (`bpf/trace_lsm_defend_lsm.inc`) | **`lsm/socket_connect`**, **`lsm/socket_sendmsg`** (`SEC(...)` names; supplemental BPF LSM defend where available; IPv4 path only). |
+| **LSM (io_uring)** | `bpf/trace_defend_all.bpf.c` (`bpf/trace_lsm_defend_iouring.inc`) | **`lsm/io_uring_cmd`** — H15 defense-in-depth on `IORING_OP_URING_CMD` paths that bypass `security_socket_sendmsg()`. Requires Linux **5.19+** (`security_uring_cmd` BTF) plus `CONFIG_BPF_LSM`; silently skipped on older kernels. IPv4 path only. |
 
-All three are **IPv4 only**. The agent reports BPF load/attach status in **`.coldstep-telemetry.json`** and in logs. If a program fails to attach, treat **defend** as **degraded** and inspect those rows and stderr—do not assume silent fallback implies the same defense story on every kernel.
+The LSM supplemental paths remain **IPv4 only**; the cgroup path gates **IPv4 and IPv6**. The agent reports BPF load/attach status in **`.coldstep-telemetry.json`** and in logs. If a program fails to attach, treat **defend** as **degraded** and inspect those rows and stderr—do not assume silent fallback implies the same defense story on every kernel.
 
 ### File integrity
 

--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -905,7 +905,13 @@ func Run(ctx context.Context, cfg config.Config) error {
 			if runnerEnv != RunnerEnvStandard {
 				meta.RunnerEnv = runnerEnv
 			}
-			meta.Coverage = buildCoverageReport(bpfSt, tlsSNIGate, ioUringRd.R != nil)
+			// H14 v0.4.0 — IPv6 cgroup6 hooks (defend object) enforce only when
+			// defend mode is active AND at least one AAAA resolved into the
+			// allowed_ipv6 LPM trie. An empty trie in defend mode is the
+			// "block-all IPv6" posture; we still surface that as enforce
+			// because the hook denies every non-loopback IPv6 destination.
+			ipv6Enforced := cfg.Mode == config.ModeDefend && hasDefend
+			meta.Coverage = buildCoverageReport(bpfSt, tlsSNIGate, ioUringRd.R != nil, ipv6Enforced)
 			if err := telemetry.AppendJSONL(cfg.EventsLogPath, meta, signer); err != nil {
 				slog.Warn("meta jsonl", "err", err)
 			}

--- a/internal/agent/agent_linux_digest.go
+++ b/internal/agent/agent_linux_digest.go
@@ -91,18 +91,25 @@ func capabilityEnabled(gate bool, bpf []telemetry.BPFStatus, hookName string) bo
 // TCP and IPv4 UDP sendmsg are always wired by the agent's cgroup hooks, so
 // they are reported as `true` independent of probe attach status; the BPF
 // status rows on the same MetaEvent already carry the per-probe outcomes.
-// IPv6 and QUIC/HTTP3 are reported as `false` until the underlying probes
-// land. TLSSNI uses the same gate+hook composition as the `tls_sni`
-// capability flag so a degraded BPF probe demotes coverage to "none".
-func buildCoverageReport(bpf []telemetry.BPFStatus, tlsSNIGate, ioUringAttached bool) *telemetry.CoverageReport {
+// IPv6 is "enforce" in defend mode with a populated allowed_ipv6 LPM trie
+// (H14 v0.4.0 — P2-1 cgroup/connect6+sendmsg6 hooks attached and AAAA
+// resolutions programmed); "off" otherwise. QUIC/HTTP3 is reported as
+// `false` until the underlying probe lands. TLSSNI uses the same gate+hook
+// composition as the `tls_sni` capability flag so a degraded BPF probe
+// demotes coverage to "none".
+func buildCoverageReport(bpf []telemetry.BPFStatus, tlsSNIGate, ioUringAttached, ipv6Enforced bool) *telemetry.CoverageReport {
 	tls := "none"
 	if capabilityEnabled(tlsSNIGate, bpf, "raw_tp/sys_enter (connect, sendto, http sniff, tls)") {
 		tls = "full"
 	}
+	ipv6 := telemetry.CoverageIPv6Off
+	if ipv6Enforced {
+		ipv6 = telemetry.CoverageIPv6Enforce
+	}
 	return &telemetry.CoverageReport{
 		IPv4TCP:        true,
 		IPv4UDPSendmsg: true,
-		IPv6:           false,
+		IPv6:           ipv6,
 		QUICHTTP3:      false,
 		TLSSNI:         tls,
 		IoUring:        ioUringAttached,

--- a/internal/agent/coverage_report_linux_test.go
+++ b/internal/agent/coverage_report_linux_test.go
@@ -10,7 +10,8 @@ import (
 
 // TestBuildCoverageReport covers the H5 v0.2.9 telemetry-stub composition:
 // - IPv4 TCP / UDP sendmsg always true (always-wired cgroup hooks)
-// - IPv6 / QUICHTTP3 always false (probes not yet implemented)
+// - QUICHTTP3 always false (probe not yet implemented)
+// - IPv6 (H14): "enforce" when defend mode + cgroup6 hooks loaded, "off" otherwise
 // - TLSSNI flips on gate + non-degraded probe; "none" otherwise
 // - IoUring tracks ioUringRd.R != nil at MetaEvent build time
 func TestBuildCoverageReport(t *testing.T) {
@@ -19,12 +20,14 @@ func TestBuildCoverageReport(t *testing.T) {
 	const tlsSniffHook = "raw_tp/sys_enter (connect, sendto, http sniff, tls)"
 
 	cases := []struct {
-		name        string
-		bpf         []telemetry.BPFStatus
-		tlsGate     bool
-		ioUring     bool
-		wantTLSSNI  string
-		wantIoUring bool
+		name         string
+		bpf          []telemetry.BPFStatus
+		tlsGate      bool
+		ioUring      bool
+		ipv6Enforced bool
+		wantTLSSNI   string
+		wantIoUring  bool
+		wantIPv6     string
 	}{
 		{
 			name:        "default detect — gate off",
@@ -33,6 +36,7 @@ func TestBuildCoverageReport(t *testing.T) {
 			ioUring:     false,
 			wantTLSSNI:  "none",
 			wantIoUring: false,
+			wantIPv6:    telemetry.CoverageIPv6Off,
 		},
 		{
 			name:        "gate on + probe ok → full",
@@ -41,6 +45,7 @@ func TestBuildCoverageReport(t *testing.T) {
 			ioUring:     false,
 			wantTLSSNI:  "full",
 			wantIoUring: false,
+			wantIPv6:    telemetry.CoverageIPv6Off,
 		},
 		{
 			name:        "gate on + probe degraded → none",
@@ -49,6 +54,7 @@ func TestBuildCoverageReport(t *testing.T) {
 			ioUring:     false,
 			wantTLSSNI:  "none",
 			wantIoUring: false,
+			wantIPv6:    telemetry.CoverageIPv6Off,
 		},
 		{
 			name:        "gate on + probe missing from bpf list → none",
@@ -57,6 +63,7 @@ func TestBuildCoverageReport(t *testing.T) {
 			ioUring:     false,
 			wantTLSSNI:  "none",
 			wantIoUring: false,
+			wantIPv6:    telemetry.CoverageIPv6Off,
 		},
 		{
 			name:        "io_uring attached → true",
@@ -65,12 +72,23 @@ func TestBuildCoverageReport(t *testing.T) {
 			ioUring:     true,
 			wantTLSSNI:  "full",
 			wantIoUring: true,
+			wantIPv6:    telemetry.CoverageIPv6Off,
+		},
+		{
+			name:         "defend mode IPv6 enforced → enforce",
+			bpf:          []telemetry.BPFStatus{{Name: tlsSniffHook, OK: true}},
+			tlsGate:      true,
+			ioUring:      false,
+			ipv6Enforced: true,
+			wantTLSSNI:   "full",
+			wantIoUring:  false,
+			wantIPv6:     telemetry.CoverageIPv6Enforce,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := buildCoverageReport(tc.bpf, tc.tlsGate, tc.ioUring)
+			got := buildCoverageReport(tc.bpf, tc.tlsGate, tc.ioUring, tc.ipv6Enforced)
 			if got == nil {
 				t.Fatal("expected non-nil CoverageReport")
 			}
@@ -80,8 +98,8 @@ func TestBuildCoverageReport(t *testing.T) {
 			if !got.IPv4UDPSendmsg {
 				t.Errorf("IPv4UDPSendmsg = false, want true (always-wired cgroup hook)")
 			}
-			if got.IPv6 {
-				t.Errorf("IPv6 = true, want false until probe ships")
+			if got.IPv6 != tc.wantIPv6 {
+				t.Errorf("IPv6 = %q, want %q", got.IPv6, tc.wantIPv6)
 			}
 			if got.QUICHTTP3 {
 				t.Errorf("QUICHTTP3 = true, want false until probe ships")

--- a/internal/policy/ipv6_bypass.go
+++ b/internal/policy/ipv6_bypass.go
@@ -1,0 +1,55 @@
+package policy
+
+import "net"
+
+// IPv6BypassesDefend reports whether an IPv6 destination address is always
+// allowed past defend-mode enforcement, irrespective of the AAAA-resolved
+// `allowed_ipv6` LPM trie contents.
+//
+// This is the userspace mirror of the BPF helpers `cg_ipv6_is_loopback` and
+// `cg_ipv6_is_link_local` in bpf/trace_defend_cgroup.inc. The classification
+// matters in two places:
+//   - The BPF cgroup/connect6 + cgroup/sendmsg6 programs short-circuit and
+//     return 1 (allow) before consulting the LPM trie when this function
+//     would return true. Test runners' localhost IPv6 traffic and IPv6
+//     neighbour-discovery / mDNS / SLAAC stay unblocked.
+//   - Userspace allowlist compilation does NOT need to insert ::1/128 or
+//     fe80::/10 into the `allowed_ipv6` trie — the BPF program bypasses
+//     them upstream of the lookup.
+//
+// Keep this function and the C helpers in lockstep. Drift means either
+// localhost IPv6 starts getting denied (false-negative bypass) or arbitrary
+// fe80:: traffic gets implicitly allowed at runtime when it shouldn't have
+// been (false-positive bypass).
+//
+// Classes that bypass enforcement:
+//   - ::1 (loopback, RFC 4291 §2.5.3)
+//   - fe80::/10 (link-local unicast, RFC 4291 §2.5.6) — covers fe80:: through
+//     febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+//
+// Any other class (including ::, unique-local fc00::/7, multicast ff00::/8,
+// and globally routable 2000::/3) is NOT bypassed: those addresses go
+// through the LPM trie and are denied if absent. IPv4-mapped IPv6 inputs
+// (::ffff:0:0/96) are not considered bypass either — they should never
+// reach the IPv6 cgroup hook in practice (the kernel routes them through
+// the IPv4 path) but defensive coding treats them as ordinary IPv6.
+func IPv6BypassesDefend(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	if ip.To4() != nil {
+		return false
+	}
+	ip16 := ip.To16()
+	if ip16 == nil {
+		return false
+	}
+	if ip16.IsLoopback() {
+		return true
+	}
+	// fe80::/10: first 10 bits are 1111111010, equivalently the first byte is
+	// 0xfe and the high 2 bits of the second byte are 0b10 (i.e. byte[1] & 0xc0
+	// == 0x80). Matches the BPF check `(user_ip6[0] & htonl(0xffc00000))
+	// == htonl(0xfe800000)`.
+	return ip16[0] == 0xfe && (ip16[1]&0xc0) == 0x80
+}

--- a/internal/policy/ipv6_bypass_test.go
+++ b/internal/policy/ipv6_bypass_test.go
@@ -1,0 +1,69 @@
+package policy
+
+import (
+	"net"
+	"testing"
+)
+
+// TestIPv6BypassesDefend pins the userspace mirror of the BPF
+// cg_ipv6_is_loopback / cg_ipv6_is_link_local helpers (H14 v0.4.0).
+// Drift here is a defend-bypass risk — either localhost stops working or
+// fe80:: traffic starts slipping past the LPM trie unenforced.
+func TestIPv6BypassesDefend(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ip   string
+		want bool
+	}{
+		// Loopback (RFC 4291 §2.5.3) — bypass.
+		{"loopback ::1", "::1", true},
+
+		// Link-local fe80::/10 — every variant must bypass.
+		{"link-local fe80::1", "fe80::1", true},
+		{"link-local fe80:: lower bound", "fe80::", true},
+		{"link-local febf:: upper bound (still /10)", "febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff", true},
+		{"link-local fe80::1%eth0 (zone stripped by ParseIP)", "fe80::1", true},
+
+		// fec0::/10 (deprecated site-local) is OUTSIDE fe80::/10 — must NOT bypass.
+		{"site-local fec0::1 (out of fe80::/10)", "fec0::1", false},
+		// fe00::/10 starts at fe00 which is below fe80 — must NOT bypass.
+		{"fe00::1 below fe80::/10", "fe00::1", false},
+
+		// Unspecified, unique-local, multicast, global — all enforced.
+		{"unspecified ::", "::", false},
+		{"unique-local fc00::1", "fc00::1", false},
+		{"unique-local fd00::1", "fd00::1", false},
+		{"multicast ff02::1", "ff02::1", false},
+		{"global 2001:db8::1", "2001:db8::1", false},
+		{"global 2606:4700::1 (Cloudflare)", "2606:4700::1", false},
+
+		// IPv4 inputs are rejected — the IPv6 hook never sees them.
+		{"IPv4 1.2.3.4 not classified as IPv6 bypass", "1.2.3.4", false},
+		{"IPv4 127.0.0.1 not classified as IPv6 bypass", "127.0.0.1", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ip := net.ParseIP(tc.ip)
+			if ip == nil {
+				t.Fatalf("ParseIP(%q) returned nil", tc.ip)
+			}
+			got := IPv6BypassesDefend(ip)
+			if got != tc.want {
+				t.Errorf("IPv6BypassesDefend(%q) = %v, want %v", tc.ip, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIPv6BypassesDefend_NilSafe pins the nil handling — net.ParseIP returns
+// nil for malformed input, and a caller threading that into IPv6BypassesDefend
+// should get a definite "no bypass" answer.
+func TestIPv6BypassesDefend_NilSafe(t *testing.T) {
+	t.Parallel()
+	if IPv6BypassesDefend(nil) {
+		t.Fatal("IPv6BypassesDefend(nil) returned true, want false")
+	}
+}

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -112,21 +112,43 @@ type MetaEvent struct {
 // consumers can reason about the observation envelope without re-deriving it
 // from individual probe-attach rows.
 //
-// IPv6 and QUICHTTP3 are wired as `false` for v0.2.9 because the underlying
-// probes are not yet implemented in the agent. They ship as explicit fields
-// (not omitempty) so consumers can rely on the shape being stable as those
+// QUICHTTP3 is wired as `false` for v0.2.9 because the underlying probe is
+// not yet implemented in the agent. It ships as an explicit field (not
+// omitempty) so consumers can rely on the shape being stable as those
 // probes land.
+//
+// IPv6 (H14 v0.4.0): tri-state enforcement label. P2-1 added defend-mode
+// `cgroup/connect6` + `cgroup/sendmsg6` hooks that look up the AAAA-resolved
+// `allowed_ipv6` LPM trie and return EPERM on non-loopback misses; this
+// field now distinguishes that enforcement state from a pre-Phase-2 stub.
+// Valid values:
+//   - `"enforce"`: defend mode is active and the allowed_ipv6 LPM trie
+//     was programmed from AAAA resolutions (non-loopback IPv6 destinations
+//     are blocked unless they match the allowlist).
+//   - `"observe-only"`: an IPv6 visibility hook attached but did not
+//     enforce (reserved for the H7 detect-mode observer once it lands;
+//     not emitted by the current code path).
+//   - `"off"`: no IPv6 enforcement or observation on this run — detect
+//     mode today, or defend mode where no AAAA records resolved.
 type CoverageReport struct {
-	IPv4TCP        bool `json:"ipv4_tcp"`
-	IPv4UDPSendmsg bool `json:"ipv4_udp_sendmsg"`
-	IPv6           bool `json:"ipv6"`
-	QUICHTTP3      bool `json:"quic_http3"`
+	IPv4TCP        bool   `json:"ipv4_tcp"`
+	IPv4UDPSendmsg bool   `json:"ipv4_udp_sendmsg"`
+	IPv6           string `json:"ipv6"`
+	QUICHTTP3      bool   `json:"quic_http3"`
 	// TLSSNI is "full" when the TLS ClientHello sniff probe attached and the
 	// tls_sni feature gate is on, "none" otherwise. "partial" is reserved for
 	// future probe variants that capture some-but-not-all SNI sources.
 	TLSSNI  string `json:"tls_sni_full"`
 	IoUring bool   `json:"io_uring"`
 }
+
+// IPv6 coverage label values for CoverageReport.IPv6 (H14 v0.4.0). Kept as
+// string constants so callers don't drift the on-disk JSON.
+const (
+	CoverageIPv6Off         = "off"
+	CoverageIPv6ObserveOnly = "observe-only"
+	CoverageIPv6Enforce     = "enforce"
+)
 
 // MetaGitHub holds non-secret GitHub Actions context.
 type MetaGitHub struct {

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -267,15 +267,16 @@ func TestTCPStateName(t *testing.T) {
 }
 
 // TestCoverageReportJSON locks the on-disk shape of the H5 telemetry stub.
-// The field set ships at v0.2.9 even though IPv6 / QUICHTTP3 are wired as
-// false — consumers can rely on the keys being present and stable as those
+// The field set ships at v0.2.9 even though QUICHTTP3 is wired as false
+// and IPv6 is a tri-state string (H14: "off" / "observe-only" / "enforce")
+// — consumers can rely on the keys being present and stable as those
 // probes land in later releases.
 func TestCoverageReportJSON(t *testing.T) {
 	t.Parallel()
 	cr := CoverageReport{
 		IPv4TCP:        true,
 		IPv4UDPSendmsg: true,
-		IPv6:           false,
+		IPv6:           CoverageIPv6Enforce,
 		QUICHTTP3:      false,
 		TLSSNI:         "full",
 		IoUring:        true,
@@ -287,7 +288,7 @@ func TestCoverageReportJSON(t *testing.T) {
 	for _, needle := range []string{
 		`"ipv4_tcp":true`,
 		`"ipv4_udp_sendmsg":true`,
-		`"ipv6":false`,
+		`"ipv6":"enforce"`,
 		`"quic_http3":false`,
 		`"tls_sni_full":"full"`,
 		`"io_uring":true`,
@@ -302,6 +303,27 @@ func TestCoverageReportJSON(t *testing.T) {
 	}
 	if got != cr {
 		t.Fatalf("round-trip mismatch: got %+v want %+v", got, cr)
+	}
+}
+
+// TestCoverageReportIPv6OffSerialization confirms the H14 default ("off")
+// round-trips through JSON without omitempty truncating it. Detect-mode
+// runs ship this value today.
+func TestCoverageReportIPv6OffSerialization(t *testing.T) {
+	t.Parallel()
+	cr := CoverageReport{
+		IPv4TCP:        true,
+		IPv4UDPSendmsg: true,
+		IPv6:           CoverageIPv6Off,
+		QUICHTTP3:      false,
+		TLSSNI:         "none",
+	}
+	b, err := json.Marshal(cr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(b, []byte(`"ipv6":"off"`)) {
+		t.Fatalf(`expected "ipv6":"off" in %s`, string(b))
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements **H14 — IPv6 block Phase 2** from the v0.4.0 hardening roadmap. The defend-mode BPF / userspace plumbing for blocking non-allowlisted IPv6 egress already landed in P2-1 (PR #164): `bpf/trace_defend_cgroup.inc` carries `cgroup/connect6` + `cgroup/sendmsg6` hooks that consult an AAAA-populated `allowed_ipv6` LPM trie and return EPERM on miss, `bpf/defend_lpm_v6_key.h` declares the trie key, `internal/policy/allowlist.go` resolves AAAA records in parallel, and `internal/agent/agent_linux_policy_maps.go` populates the trie. This PR closes the three remaining H14 gaps relative to that baseline:

- the public coverage telemetry now carries a meaningful **`ipv6` enforcement label** ("enforce" / "off") instead of the v0.2.9 stub `bool: false`,
- a Go-side unit test pins the **loopback / link-local bypass classification** that the BPF program relies on,
- **README** and **SECURITY.md** drop the "IPv6 is unsupported in defend" wording that was true at v0.2.9 and now reflect the H14 enforcement story.

## What changed

- **`internal/telemetry/event.go`** — `CoverageReport.IPv6` changes type from `bool` to `string` with three named values (`telemetry.CoverageIPv6Off`, `…ObserveOnly`, `…Enforce`). The "observe-only" tier is reserved for the standalone detect-mode IPv6 observer (H7, separately tracked in PR #199) and is not emitted by the current agent. The field stays in the same JSON position (`"ipv6": …`) with no `omitempty` so consumers can rely on the key always being present.

- **`internal/agent/agent_linux_digest.go`** — `buildCoverageReport` grows an `ipv6Enforced bool` parameter. When true it sets `CoverageReport.IPv6 = "enforce"`; otherwise `"off"`. No change to the other coverage cells (IPv4 TCP/UDP, TLS SNI, io_uring) — the agent's "Coverage scope" digest table already reads its IPv6 row from the digest-side renderer (`ipv6CoverageCell` in `internal/report/digest.go`), which is unchanged.

- **`internal/agent/agent_linux.go`** — the single `buildCoverageReport` caller computes `ipv6Enforced := cfg.Mode == config.ModeDefend && hasDefend`. An empty `allowed_ipv6` trie is still reported as `"enforce"` because the cgroup6 hook denies every non-loopback IPv6 destination in that posture (the existing digest renderer already labels it `✓ gated (defend block-all — empty allowed_ipv6)`). When the hooks are not loaded (detect mode, or kernel rejected the program), `hasDefend` is false and the label degrades to `"off"`.

- **`internal/agent/coverage_report_linux_test.go`** — `TestBuildCoverageReport` grows a sixth row pinning the defend-mode `"enforce"` outcome, plus an `ipv6Enforced` column on every existing row so detect-mode and probe-degraded paths regress against the `"off"` value. The IPv4 / TLS / io_uring assertions are unchanged.

- **`internal/telemetry/event_test.go`** — `TestCoverageReportJSON` now exercises `"ipv6":"enforce"` and a sibling `TestCoverageReportIPv6OffSerialization` locks the default `"off"` shape.

- **`internal/policy/ipv6_bypass.go` (new)** — `IPv6BypassesDefend(net.IP) bool` is the userspace mirror of the BPF helpers `cg_ipv6_is_loopback` and `cg_ipv6_is_link_local` in `bpf/trace_defend_cgroup.inc`. The function is documentation + a regression anchor: production code does not consult it (the BPF program is authoritative), but a Go test asserts the exact classification (`::1` and `fe80::/10` bypass; everything else — including `fec0::1`, `fe00::1`, `2001:db8::1`, `fc00::1`, `ff02::1`, `::` — does not). Drift here is a defend-bypass risk in either direction.

- **`internal/policy/ipv6_bypass_test.go` (new)** — table-test for `IPv6BypassesDefend` covering loopback, the fe80::/10 lower and upper bounds, the adjacent fec0::/10 and fe00::/10 ranges that must NOT bypass, unique-local fc00::/7, multicast ff00::/8, global 2000::/3, the unspecified `::`, and IPv4 inputs (which the IPv6 hook never sees but the helper defensively rejects).

- **`README.md`** — "At a glance" defend row now reads "Block IPv4 and IPv6 egress not on the allowlist (cgroup `connect4`/`sendmsg4` + `connect6`/`sendmsg6`; QUIC payloads remain uninspected)". The Requirements row for IP versions describes the H14 enforcement scope, the `::1` / `fe80::/10` always-bypass rule, and the explicit detect-mode IPv6 gap.

- **`SECURITY.md`** — the Coverage Boundaries table splits the old `IPv6 (all)` row into `IPv6 TCP (connect6)` and `IPv6 UDP (sendmsg6)`, both `✗` in detect / `✓` in defend with the H14 attribution. The "Why IPv4-only" paragraph is replaced by a "Defend-mode IPv6 enforcement (H14, v0.4.0)" paragraph spelling out the LPM-trie path, the always-bypass classes, and the still-open detect-mode gap. The "Operational implications", "What a job adversary can do", "Guarantees vs best-effort", and "Defend hooks" sections are updated in lockstep so no stale "IPv6 is unsupported" claim survives.

## Why no BPF or policy-compile changes

The BPF cgroup6 hooks (`defend_cgroup_connect6`, `defend_cgroup_sendmsg6`) already do the LPM lookup against `allowed_ipv6` and emit deny events on miss (P2-1, merged at `f243dcf`). `IPv6Set` already lives on `CompileResult` and is populated from parallel AAAA lookups bounded by `coldstepDomainLookupConcurrencyLimit = 32`; `populateAllowedIPv6Map` in `agent_linux_policy_maps.go` programs the trie. Reworking any of those would be churn, not progress — the H14 spec items that named those changes were satisfied by P2-1 ahead of v0.4.0.

What was left was the public-surface alignment: telemetry shape, docs, and a pinned regression for the loopback/link-local classifier. That is the scope of this PR.

## Constraints honored

- No new BPF programs, maps, or wire-format changes — `lpm_v6_key`, `allowed_ipv6`, and the cgroup6 hooks are unchanged.
- No schema bump — `telemetry.SchemaVersion` is unchanged. The `CoverageReport.IPv6` type change is a JSON value-shape adjustment (`bool` → `string`) within the same key; downstream consumers that parsed the v0.2.9 stub as `bool false` need to update to a string-typed reader, but the field has never carried a meaningful value before v0.4.0.
- No new `enforce` mode references — defend/detect remain the only public mode names.

## Validation

- `bash scripts/check-gofmt.sh` — clean on the modified files.
- `bash scripts/check-encoding.sh` — pass.
- `go vet ./...` on the non-BPF subset (BPF-stub packages require `go generate` on Linux) — pass.
- `go test ./internal/policy/... ./internal/telemetry/... -count=1` — pass.
- BPF compile + verifier load, defend integration, and the cross-architecture matrix are validated by `coldstep-ci-runner.yml` (`unit`, `unit-arm64`, `integration`, `detect-mode`, `defend-mode`).

## Follow-ups (out of scope)

- **H7 detect-mode IPv6 observation** (PR #199, branch `feat/h7-ipv6-detect-warn`) ships a standalone `internal/bpf/traceipv6` package that attaches cgroup/connect6+sendmsg6 in detect mode as observe-only. When that lands, `buildCoverageReport` should grow a second signal so the label can flip to `telemetry.CoverageIPv6ObserveOnly` in detect-mode runs where the observer attached. The constant is already defined.
- **Cgroup6 attach BPFStatus rows.** The current code logs at `slog.Info` when `cgroup/connect6` / `sendmsg6` fail to attach but does not append `BPFStatus` rows, so a degraded IPv6 path is not visible in the digest's BPF section. Tracking separately.
