### PR TITLE
feat(H17): learning-mode poisoning protections — DGA heuristics, observation window gate, diff flag

### DIFF
--- a/.github/pr-bodies/h17-learning-mode-protections.md
+++ b/.github/pr-bodies/h17-learning-mode-protections.md
@@ -1,0 +1,51 @@
+## Summary
+
+Implements **H17** (learning-mode poisoning protections) for the v0.4.0 hardening roadmap. The detect-mode JSONL → report-model → allowlist pipeline now carries explicit per-domain risk metadata so reviewers can spot the two shapes that most often slip a compromise into `allow:`:
+
+- **DGA-shaped destinations** — leftmost DNS label ≥ 12 chars at Shannon entropy ≥ 3.5 bits/char, or 16+ chars of lowercase hex (UUID / hash style).
+- **Single-observation destinations** — domains seen exactly once across the entire JSONL stream, which is the classic fingerprint of a briefly-poisoned learning run.
+
+The existing hard gates (`--min-observation-hours`, `diff --fail-on-new-domain`) stay where they are. H17 adds the **reviewer-facing** surface around them: a `risk_hint` on every flagged entry, observation metadata for sorting / triage, and an `assert-integrity` warning block in the GitHub Actions UI.
+
+## What changed
+
+- **`internal/report/model/report.go`** — `SuspiciousDomain` grows three H17 fields:
+  - `ObservationCount int` (`json:"observation_count"`) — connection-event count for the domain, mirroring the existing `Occurrences`. New canonical name for downstream consumers; the legacy `occurrences` field stays on the wire for backward compatibility.
+  - `FirstSeenTS time.Time` (`json:"first_seen_ts"`) — earliest event timestamp for the domain. Set from the JSONL `ts` field; lets reviewers sort by recency.
+  - `RiskHint string` (`json:"risk_hint,omitempty"`) — one of `suspicious-dga`, `single-observation`, or empty. DGA wins when both fire (e.g. a once-seen DGA host).
+
+- **`internal/report/model/suspicious.go`** —
+  - New exported `HasHighEntropyLabel(domain string) bool`. Returns true when the leftmost label is `[0-9a-f]{16,}` OR (length ≥ 12 AND Shannon entropy ≥ 3.5 bits/char). IP literals and empty input return false.
+  - New `RiskHintSuspiciousDGA` / `RiskHintSingleObservation` consts mirror the wire values.
+  - `BuildSuspiciousDomains` now tracks `firstSeen` per domain and populates `ObservationCount` / `FirstSeenTS` / `RiskHint` on each emitted row. The existing `high_entropy` reason keeps its looser 8-char floor so borderline entries still surface; the stricter 12-char `RiskHint` floor only fires the headline `suspicious-dga` tag.
+
+- **`internal/report/model/suspicious_test.go`** — adds `TestHasHighEntropyLabel` (known-good `github.com`, `api.example.com`, `cdn3.example.com`, …; known-bad `a3b8c1d9e2f4a1b2.cdn.example.com`, `1a2b3c4d5e6f7890abcd.evil.io`, `deadbeefcafebabe.example.com`; borderline 11-char label must NOT fire) and `TestBuildSuspiciousDomainsSetsRiskHintAndObservationFields` (DGA host gets `risk_hint=suspicious-dga` with the right observation count; rare host gets `risk_hint=single-observation`).
+
+- **`cmd/coldstep-report/build_model.go`** — `--min-observation-hours` now emits the H17-spec stderr line `coldstep-report: observation window is X minutes; --min-observation-hours requires Y hours (H17)` alongside the existing `::warning` annotation. Architecture is unchanged (build-model writes the model with `short_observation_window=true`; the hard fail still lives in `assert-integrity` so the model JSON remains inspectable on failure).
+
+- **`cmd/coldstep-report/assert_integrity.go`** — new `reportLearningModeReviewerHints` helper emits a warn-only `::warning title=Coldstep learning-mode reviewer hints (H17)::N DGA-shaped / M single-observation destination(s)` annotation followed by one `::warning::DGA-shaped destination: …` / `::warning::Single-observation destination: …` line per flagged domain. Integrity verdict is **not** changed — these are reviewer hints, not a gate. Hard fails remain `short_observation_window`, BPF tamper, and the existing required-types / canary checks.
+
+- **`cmd/coldstep-report/learning_poisoning_test.go`** — `TestAssertIntegrityEmitsLearningModeReviewerHints` captures stdout and asserts the H17 banner plus both per-domain rows render when the model carries a DGA + single-observation entry under a `verdict=pass` integrity result.
+
+- **`QUICK_START.md`** — new "Building a safe allowlist (H17 learning-mode poisoning protections)" subsection under the existing promotion workflow. Documents the `risk_hint` taxonomy (`suspicious-dga`, `single-observation`), how `assert-integrity` surfaces them as warn-only annotations, and the recommended bar (≥ 24h window, baseline diff with `--fail-on-new-domain`, manual review of every `risk_hint` entry).
+
+## Constraints honored
+
+- No new BPF programs or maps — pure Go + report-model surface.
+- No `enforce` references introduced.
+- Legacy `occurrences` field preserved on the wire alongside the new `observation_count`; existing JSONL consumers keep working.
+- `assert-integrity` exit-code semantics unchanged for clean / canary-missing / required-type-missing inputs; H17 hints add stdout lines only.
+- Generated BPF artifacts (`bpf/vmlinux.h`, `internal/bpf/**/*_bpfel.go`, `*_bpfeb.go`) and local-only trees (`plans/`, `docs/`, `design/`, `knowledge/`, `AGENTS.md`) untouched.
+
+## Validation
+
+- `gofmt -l` — pass (touched files).
+- `bash scripts/check-encoding.sh` — pass.
+- `go vet ./internal/report/... ./cmd/coldstep-report/...` — pass.
+- `go test ./internal/report/... ./cmd/coldstep-report/... -count=1` — pass (includes the three new H17 tests).
+- Linux-only BPF compile + verifier + integration are validated by CI's `coldstep-ci-runner.yml` (`unit`, `unit-arm64`, `integration`, `detect-mode`, `defend-mode`).
+
+## Follow-ups (out of scope)
+
+- A `--fail-on-risk-hint` flag for `assert-integrity` would let teams that want allowlist-promotion CI to fail when any `risk_hint` entry is present. Today the workflow uses `--fail-on-new-domain` for that role; deferred until a real consumer asks.
+- `website/` quick-start mirror copy will be touched in the post-tag website-bump PR per `RELEASE_PROCESS.md`; this PR keeps the repo-side `QUICK_START.md` consistent.

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -38,6 +38,21 @@ Recommended workflow:
 
 `build-model` additionally flags **suspicious domains** in the report model (`suspicious_domains` field): high-entropy subdomains (Shannon entropy > 3.5 bits/char on labels longer than 8 chars), domains observed only once across the entire run, and HTTP/TLS observations on non-standard ports. `render-summary` surfaces a `[!WARNING]` block when any are present so reviewers see them before approving the diff.
 
+### Building a safe allowlist (H17 learning-mode poisoning protections)
+
+Even with the workflow above, **two specific shapes of destination warrant manual review** before they land in `allow:` — and `coldstep-report` now tags them on each flagged entry via `suspicious_domains[].risk_hint`:
+
+| `risk_hint` | What it means | Why to review by hand |
+| :----------- | :------------- | :-------------------- |
+| **`suspicious-dga`** | The leftmost DNS label is ≥ 12 chars of high-entropy text (Shannon ≥ 3.5 bits/char) **or** a 16+-char lowercase hex string (DGA / hash-style). | DGA-shaped labels are characteristic of malware C2 and ephemeral exfil endpoints. Even one observation is enough to want a human to confirm whether the host is a legitimate object-store / CDN URL or attacker infrastructure. |
+| **`single-observation`** | The domain was seen exactly once across the entire JSONL stream (`observation_count == 1`). | Attackers who briefly poisoned a learning run leave exactly this fingerprint. Compare against a longer-window baseline before promoting. |
+
+`assert-integrity` does **not** fail on either hint — it emits a `::warning title=Coldstep learning-mode reviewer hints (H17)::…` annotation listing each flagged entry so reviewers see them in the GitHub Actions UI. The hard gates are still `--min-observation-hours` and `diff --fail-on-new-domain`. Recommended bar before promoting any new domain:
+
+- **≥ 24h observation window** (`coldstep-report build-model --min-observation-hours 24`). Shorter windows are inherently easier to poison.
+- **Baseline diff with `--fail-on-new-domain`** on the PR that edits `allow:` / `allow-file`. This is the only step that catches a domain a single human reviewer might wave through.
+- **Manual review of every `risk_hint` entry.** `suspicious-dga` and `single-observation` rows are reviewer-driven by design — there is no automated way to tell good ephemeral URLs from bad ones.
+
 ---
 
 ## Bare minimum

--- a/cmd/coldstep-report/assert_integrity.go
+++ b/cmd/coldstep-report/assert_integrity.go
@@ -48,6 +48,12 @@ func assertIntegrity(args []string) error {
 		return errors.New("integrity gate verdict=fail (short_observation_window)")
 	}
 
+	// H17: warn-only surface for single-observation and DGA-shaped
+	// destinations. The poisoning gate is the diff/window check above —
+	// these are reviewer hints (allowlist promotion of a once-seen or
+	// DGA-shaped domain warrants a second look), not a hard fail.
+	reportLearningModeReviewerHints(m.SuspiciousDomains)
+
 	switch m.CapabilityEval.Verdict {
 	case integrity.VerdictPass:
 		fmt.Printf("Coldstep Integrity Pass: verdict=%s score=%d\n", m.CapabilityEval.Verdict, m.CapabilityEval.Score)
@@ -68,5 +74,39 @@ func assertIntegrity(args []string) error {
 		return errors.New("integrity gate verdict=fail")
 	default:
 		return fmt.Errorf("missing or unsupported capability_eval.verdict: %q", m.CapabilityEval.Verdict)
+	}
+}
+
+// reportLearningModeReviewerHints prints a warn-only section listing
+// destinations that the H17 poisoning heuristic flagged for manual
+// review (DGA-shaped left labels and once-seen domains). Empty input
+// stays silent. The integrity verdict is not changed — this is a
+// reviewer hint, not a gate. Sorted DGA-first so the highest-priority
+// reviewer signal sorts to the top of the section.
+func reportLearningModeReviewerHints(rows []model.SuspiciousDomain) {
+	if len(rows) == 0 {
+		return
+	}
+	var dga, single []model.SuspiciousDomain
+	for _, r := range rows {
+		switch r.RiskHint {
+		case model.RiskHintSuspiciousDGA:
+			dga = append(dga, r)
+		case model.RiskHintSingleObservation:
+			single = append(single, r)
+		}
+	}
+	if len(dga) == 0 && len(single) == 0 {
+		return
+	}
+	fmt.Printf(
+		"::warning title=Coldstep learning-mode reviewer hints (H17)::%d DGA-shaped / %d single-observation destination(s) — review before promoting to allowlist\n",
+		len(dga), len(single),
+	)
+	for _, r := range dga {
+		fmt.Printf("::warning::DGA-shaped destination: %s (observation_count=%d)\n", r.Domain, r.ObservationCount)
+	}
+	for _, r := range single {
+		fmt.Printf("::warning::Single-observation destination: %s\n", r.Domain)
 	}
 }

--- a/cmd/coldstep-report/build_model.go
+++ b/cmd/coldstep-report/build_model.go
@@ -72,6 +72,12 @@ func buildModel(args []string) error {
 	short := false
 	if *minObs > 0 && observationHours < *minObs {
 		short = true
+		minutes := int(math.Round(observationHours * 60))
+		fmt.Fprintf(
+			os.Stderr,
+			"coldstep-report: observation window is %d minutes; --min-observation-hours requires %g hours (H17)\n",
+			minutes, *minObs,
+		)
 		fmt.Fprintf(
 			os.Stderr,
 			"::warning title=Coldstep short observation window::observation window %.2fh is shorter than --min-observation-hours=%.2f; allowlist promotion is risky (P1-2)\n",

--- a/cmd/coldstep-report/learning_poisoning_test.go
+++ b/cmd/coldstep-report/learning_poisoning_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -181,6 +183,35 @@ func TestDiffSummaryNewDomainsIgnoresBareIPs(t *testing.T) {
 	}
 }
 
+func TestAssertIntegrityEmitsLearningModeReviewerHints(t *testing.T) {
+	tmp := t.TempDir()
+	in := filepath.Join(tmp, "model.json")
+	body := `{
+		"schema_version":"3.0",
+		"capability_eval":{"verdict":"pass","score":95,"reasons":[]},
+		"suspicious_domains":[
+			{"domain":"a3b8c1d9e2f4a1b2.cdn.example.com","reasons":["high_entropy"],"observation_count":4,"risk_hint":"suspicious-dga"},
+			{"domain":"only-once.example.com","reasons":["rare"],"observation_count":1,"risk_hint":"single-observation"}
+		]
+	}`
+	if err := os.WriteFile(in, []byte(body), 0o644); err != nil {
+		t.Fatalf("setup fixture: %v", err)
+	}
+	out, err := captureStdout(t, func() error { return assertIntegrity([]string{"--in=" + in}) })
+	if err != nil {
+		t.Fatalf("assertIntegrity = %v; want nil (verdict=pass, hints are warn-only)", err)
+	}
+	if !strings.Contains(out, "learning-mode reviewer hints (H17)") {
+		t.Fatalf("stdout missing H17 reviewer-hints banner: %s", out)
+	}
+	if !strings.Contains(out, "a3b8c1d9e2f4a1b2.cdn.example.com") {
+		t.Errorf("stdout missing DGA-shaped domain row: %s", out)
+	}
+	if !strings.Contains(out, "only-once.example.com") {
+		t.Errorf("stdout missing single-observation domain row: %s", out)
+	}
+}
+
 func TestRenderSummaryShowsSuspiciousDomainsWarning(t *testing.T) {
 	tmp := t.TempDir()
 	in := writeModelMapFixture(t, tmp, map[string]any{
@@ -224,6 +255,27 @@ func TestRenderSummaryShowsShortWindowWarning(t *testing.T) {
 	if !strings.Contains(string(raw), "Observation window only") {
 		t.Fatalf("summary missing short-window warning: %s", string(raw))
 	}
+}
+
+// captureStdout swaps os.Stdout for a pipe, runs fn, restores stdout, and
+// returns whatever fn wrote. Used to assert reviewer-hint output without
+// shelling out.
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	fnErr := fn()
+	w.Close()
+	os.Stdout = orig
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("drain pipe: %v", err)
+	}
+	return buf.String(), fnErr
 }
 
 func readModelOrFail(t *testing.T, path string) map[string]any {

--- a/internal/report/model/report.go
+++ b/internal/report/model/report.go
@@ -1,6 +1,9 @@
 package model
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 type Report struct {
 	SchemaVersion    string                `json:"schema_version"`
@@ -36,13 +39,23 @@ type Report struct {
 
 // SuspiciousDomain captures why a destination was flagged during build-model.
 // Reasons is a non-empty, sorted, de-duped set of: "high_entropy",
-// "rare", "port_anomaly".
+// "rare", "port_anomaly". RiskHint is a single headline tag for human
+// reviewers (H17 learning-mode-poisoning protections): "suspicious-dga"
+// when the leftmost DNS label looks DGA-generated (see
+// HasHighEntropyLabel), otherwise "single-observation" when the domain
+// was seen exactly once, otherwise empty. ObservationCount mirrors the
+// connection-event count for the domain and FirstSeenTS marks the
+// earliest event timestamp; both are emitted on every flagged entry so
+// allowlist promotion reviewers can sort by recency / volume.
 type SuspiciousDomain struct {
-	Domain      string   `json:"domain"`
-	Reasons     []string `json:"reasons"`
-	Entropy     float64  `json:"entropy,omitempty"`
-	Occurrences int      `json:"occurrences,omitempty"`
-	Ports       []int    `json:"ports,omitempty"`
+	Domain           string    `json:"domain"`
+	Reasons          []string  `json:"reasons"`
+	Entropy          float64   `json:"entropy,omitempty"`
+	Occurrences      int       `json:"occurrences,omitempty"`
+	ObservationCount int       `json:"observation_count"`
+	FirstSeenTS      time.Time `json:"first_seen_ts"`
+	RiskHint         string    `json:"risk_hint,omitempty"`
+	Ports            []int     `json:"ports,omitempty"`
 }
 
 type RunMeta struct {

--- a/internal/report/model/suspicious.go
+++ b/internal/report/model/suspicious.go
@@ -2,8 +2,10 @@ package model
 
 import (
 	"math"
+	"regexp"
 	"sort"
 	"strings"
+	"time"
 )
 
 // suspiciousReasonHighEntropy etc. are the closed reason set surfaced in
@@ -22,9 +24,63 @@ const (
 //     leaving human-readable subdomains alone.
 //   - 8-char minimum avoids false-positives on short labels like "api",
 //     "www", "cdn3" that can clear the entropy threshold by accident.
+//
+// The H17 RiskHint computation (HasHighEntropyLabel) uses a stricter
+// 12-char floor so the headline "suspicious-dga" tag fires only on
+// clearly DGA-shaped labels — the existing high_entropy reason keeps
+// the looser 8-char bar so reviewers still see borderline cases listed.
 const (
 	highEntropyMinLabelLen    = 8
 	highEntropyMinBitsPerChar = 3.5
+	dgaMinLabelLen            = 12
+)
+
+// hexHashLabelPattern matches a leftmost DNS label that is 16+ chars of
+// pure lowercase hex — typical of git-style hashes, UUIDs collapsed to
+// hex, or DGA outputs that map to hex alphabets. HasHighEntropyLabel
+// treats a match as suspicious independent of the entropy threshold so
+// "deadbeef…" / "0123…" style labels that would otherwise underflow the
+// 3.5 bits/char bar still raise the H17 flag.
+var hexHashLabelPattern = regexp.MustCompile(`^[0-9a-f]{16,}$`)
+
+// HasHighEntropyLabel reports whether the leftmost DNS label of domain
+// is suspicious by the H17 learning-mode-poisoning heuristic: either
+//
+//   - label length >= dgaMinLabelLen (12) AND Shannon entropy
+//     >= highEntropyMinBitsPerChar (3.5 bits/char), or
+//   - the label is 16+ chars of lowercase hex (hexHashLabelPattern).
+//
+// IP literals and empty inputs return false. The check is intentionally
+// independent of the BuildSuspiciousDomains reason set so callers
+// (build-model RiskHint computation, assert-integrity warnings) can use
+// it on already-flagged entries without re-walking the event stream.
+func HasHighEntropyLabel(domain string) bool {
+	host := strings.TrimSpace(strings.ToLower(domain))
+	if host == "" {
+		return false
+	}
+	if !looksLikeDomain(host) {
+		return false
+	}
+	label := leftmostLabel(host)
+	if label == "" {
+		return false
+	}
+	if hexHashLabelPattern.MatchString(label) {
+		return true
+	}
+	if len([]rune(label)) >= dgaMinLabelLen && labelShannonEntropy(host) >= highEntropyMinBitsPerChar {
+		return true
+	}
+	return false
+}
+
+// RiskHint constants mirror SuspiciousDomain.RiskHint values surfaced
+// by build-model. Stable; consumers (render-summary, assert-integrity)
+// match on them.
+const (
+	RiskHintSingleObservation = "single-observation"
+	RiskHintSuspiciousDGA     = "suspicious-dga"
 )
 
 // standardEgressPorts is the closed allowlist of "common" destination
@@ -51,6 +107,7 @@ type domainStats struct {
 	occurrences int
 	httpish     bool
 	ports       map[int]struct{}
+	firstSeen   time.Time
 }
 
 // BuildSuspiciousDomains scans egress events (tcp, udp, http, tls) and
@@ -97,6 +154,13 @@ func BuildSuspiciousDomains(events []Event) []SuspiciousDomain {
 		if port > 0 {
 			s.ports[port] = struct{}{}
 		}
+		if ts := e.AsString("ts"); ts != "" {
+			if t, err := parseEventTS(ts); err == nil {
+				if s.firstSeen.IsZero() || t.Before(s.firstSeen) {
+					s.firstSeen = t
+				}
+			}
+		}
 	}
 
 	out := make([]SuspiciousDomain, 0)
@@ -122,9 +186,16 @@ func BuildSuspiciousDomains(events []Event) []SuspiciousDomain {
 			continue
 		}
 		sd := SuspiciousDomain{
-			Domain:      host,
-			Reasons:     sortedKeys(reasons),
-			Occurrences: s.occurrences,
+			Domain:           host,
+			Reasons:          sortedKeys(reasons),
+			Occurrences:      s.occurrences,
+			ObservationCount: s.occurrences,
+			FirstSeenTS:      s.firstSeen.UTC(),
+		}
+		if HasHighEntropyLabel(host) {
+			sd.RiskHint = RiskHintSuspiciousDGA
+		} else if s.occurrences == 1 {
+			sd.RiskHint = RiskHintSingleObservation
 		}
 		if _, ok := reasons[suspiciousReasonHighEntropy]; ok {
 			sd.Entropy = roundTo(entropy, 4)

--- a/internal/report/model/suspicious_test.go
+++ b/internal/report/model/suspicious_test.go
@@ -85,6 +85,83 @@ func TestBuildSuspiciousDomainsSkipsBareIPs(t *testing.T) {
 	}
 }
 
+func TestHasHighEntropyLabel(t *testing.T) {
+	cases := []struct {
+		name   string
+		domain string
+		want   bool
+	}{
+		// Known-good (H17 spec): ordinary FQDNs must not trip the DGA heuristic.
+		{"plain github", "github.com", false},
+		{"api subdomain", "api.example.com", false},
+		{"short cdn", "cdn3.example.com", false},
+		{"www", "www.example.org", false},
+		{"long readable subdomain", "kubernetes-clusters.example.com", false},
+		{"empty", "", false},
+		{"bare ipv4", "1.2.3.4", false},
+		// Known-bad: high-entropy DGA / hex-hash style left-labels.
+		{"base32-like 16char", "a3b8c1d9e2f4a1b2.cdn.example.com", true},
+		{"long hex 20char", "1a2b3c4d5e6f7890abcd.evil.io", true},
+		{"hex hash 16char", "deadbeefcafebabe.example.com", true},
+		// Borderline: 11-char label clears entropy but underflows the
+		// stricter 12-char DGA floor — should NOT fire here even though
+		// the legacy 8-char high_entropy reason might.
+		{"borderline 11 char", "abcdefghijk.example.com", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := HasHighEntropyLabel(c.domain)
+			if got != c.want {
+				t.Fatalf("HasHighEntropyLabel(%q) = %v; want %v", c.domain, got, c.want)
+			}
+		})
+	}
+}
+
+func TestBuildSuspiciousDomainsSetsRiskHintAndObservationFields(t *testing.T) {
+	events := []Event{
+		{"type": "tls", "ts": "2026-05-18T10:00:00Z", "sni": "abcdefghijklmnop.example.com", "dport": 443},
+		{"type": "tls", "ts": "2026-05-18T10:00:01Z", "sni": "abcdefghijklmnop.example.com", "dport": 443},
+		{"type": "tls", "ts": "2026-05-18T10:00:02Z", "sni": "rare.example.com", "dport": 443},
+		{"type": "tls", "ts": "2026-05-18T10:00:03Z", "sni": "common.example.com", "dport": 443},
+		{"type": "tls", "ts": "2026-05-18T10:00:04Z", "sni": "common.example.com", "dport": 443},
+	}
+	rows := BuildSuspiciousDomains(events)
+
+	var dga, rare *SuspiciousDomain
+	for i := range rows {
+		switch rows[i].Domain {
+		case "abcdefghijklmnop.example.com":
+			dga = &rows[i]
+		case "rare.example.com":
+			rare = &rows[i]
+		}
+	}
+	if dga == nil {
+		t.Fatalf("rows missing DGA-shaped domain: %v", rows)
+	}
+	if rare == nil {
+		t.Fatalf("rows missing single-observation domain: %v", rows)
+	}
+
+	if dga.RiskHint != RiskHintSuspiciousDGA {
+		t.Errorf("dga RiskHint = %q; want %q", dga.RiskHint, RiskHintSuspiciousDGA)
+	}
+	if dga.ObservationCount != 2 {
+		t.Errorf("dga ObservationCount = %d; want 2", dga.ObservationCount)
+	}
+	wantFirst, _ := parseEventTS("2026-05-18T10:00:00Z")
+	if !dga.FirstSeenTS.Equal(wantFirst) {
+		t.Errorf("dga FirstSeenTS = %v; want %v", dga.FirstSeenTS, wantFirst)
+	}
+	if rare.RiskHint != RiskHintSingleObservation {
+		t.Errorf("rare RiskHint = %q; want %q", rare.RiskHint, RiskHintSingleObservation)
+	}
+	if rare.ObservationCount != 1 {
+		t.Errorf("rare ObservationCount = %d; want 1", rare.ObservationCount)
+	}
+}
+
 func TestSuspiciousDomainCountsByReason(t *testing.T) {
 	rows := []SuspiciousDomain{
 		{Domain: "a", Reasons: []string{"high_entropy", "rare"}},


### PR DESCRIPTION
## Summary

Implements **H17** (learning-mode poisoning protections) for the v0.4.0 hardening roadmap. The detect-mode JSONL → report-model → allowlist pipeline now carries explicit per-domain risk metadata so reviewers can spot the two shapes that most often slip a compromise into `allow:`:

- **DGA-shaped destinations** — leftmost DNS label ≥ 12 chars at Shannon entropy ≥ 3.5 bits/char, or 16+ chars of lowercase hex (UUID / hash style).
- **Single-observation destinations** — domains seen exactly once across the entire JSONL stream, which is the classic fingerprint of a briefly-poisoned learning run.

The existing hard gates (`--min-observation-hours`, `diff --fail-on-new-domain`) stay where they are. H17 adds the **reviewer-facing** surface around them: a `risk_hint` on every flagged entry, observation metadata for sorting / triage, and an `assert-integrity` warning block in the GitHub Actions UI.

## What changed

- **`internal/report/model/report.go`** — `SuspiciousDomain` grows three H17 fields:
  - `ObservationCount int` (`json:"observation_count"`) — connection-event count for the domain, mirroring the existing `Occurrences`. New canonical name for downstream consumers; the legacy `occurrences` field stays on the wire for backward compatibility.
  - `FirstSeenTS time.Time` (`json:"first_seen_ts"`) — earliest event timestamp for the domain. Set from the JSONL `ts` field; lets reviewers sort by recency.
  - `RiskHint string` (`json:"risk_hint,omitempty"`) — one of `suspicious-dga`, `single-observation`, or empty. DGA wins when both fire (e.g. a once-seen DGA host).

- **`internal/report/model/suspicious.go`** —
  - New exported `HasHighEntropyLabel(domain string) bool`. Returns true when the leftmost label is `[0-9a-f]{16,}` OR (length ≥ 12 AND Shannon entropy ≥ 3.5 bits/char). IP literals and empty input return false.
  - New `RiskHintSuspiciousDGA` / `RiskHintSingleObservation` consts mirror the wire values.
  - `BuildSuspiciousDomains` now tracks `firstSeen` per domain and populates `ObservationCount` / `FirstSeenTS` / `RiskHint` on each emitted row. The existing `high_entropy` reason keeps its looser 8-char floor so borderline entries still surface; the stricter 12-char `RiskHint` floor only fires the headline `suspicious-dga` tag.

- **`internal/report/model/suspicious_test.go`** — adds `TestHasHighEntropyLabel` (known-good `github.com`, `api.example.com`, `cdn3.example.com`, …; known-bad `a3b8c1d9e2f4a1b2.cdn.example.com`, `1a2b3c4d5e6f7890abcd.evil.io`, `deadbeefcafebabe.example.com`; borderline 11-char label must NOT fire) and `TestBuildSuspiciousDomainsSetsRiskHintAndObservationFields` (DGA host gets `risk_hint=suspicious-dga` with the right observation count; rare host gets `risk_hint=single-observation`).

- **`cmd/coldstep-report/build_model.go`** — `--min-observation-hours` now emits the H17-spec stderr line `coldstep-report: observation window is X minutes; --min-observation-hours requires Y hours (H17)` alongside the existing `::warning` annotation. Architecture is unchanged (build-model writes the model with `short_observation_window=true`; the hard fail still lives in `assert-integrity` so the model JSON remains inspectable on failure).

- **`cmd/coldstep-report/assert_integrity.go`** — new `reportLearningModeReviewerHints` helper emits a warn-only `::warning title=Coldstep learning-mode reviewer hints (H17)::N DGA-shaped / M single-observation destination(s)` annotation followed by one `::warning::DGA-shaped destination: …` / `::warning::Single-observation destination: …` line per flagged domain. Integrity verdict is **not** changed — these are reviewer hints, not a gate. Hard fails remain `short_observation_window`, BPF tamper, and the existing required-types / canary checks.

- **`cmd/coldstep-report/learning_poisoning_test.go`** — `TestAssertIntegrityEmitsLearningModeReviewerHints` captures stdout and asserts the H17 banner plus both per-domain rows render when the model carries a DGA + single-observation entry under a `verdict=pass` integrity result.

- **`QUICK_START.md`** — new "Building a safe allowlist (H17 learning-mode poisoning protections)" subsection under the existing promotion workflow. Documents the `risk_hint` taxonomy (`suspicious-dga`, `single-observation`), how `assert-integrity` surfaces them as warn-only annotations, and the recommended bar (≥ 24h window, baseline diff with `--fail-on-new-domain`, manual review of every `risk_hint` entry).

## Constraints honored

- No new BPF programs or maps — pure Go + report-model surface.
- No `enforce` references introduced.
- Legacy `occurrences` field preserved on the wire alongside the new `observation_count`; existing JSONL consumers keep working.
- `assert-integrity` exit-code semantics unchanged for clean / canary-missing / required-type-missing inputs; H17 hints add stdout lines only.
- Generated BPF artifacts (`bpf/vmlinux.h`, `internal/bpf/**/*_bpfel.go`, `*_bpfeb.go`) and local-only trees (`plans/`, `docs/`, `design/`, `knowledge/`, `AGENTS.md`) untouched.

## Validation

- `gofmt -l` — pass (touched files).
- `bash scripts/check-encoding.sh` — pass.
- `go vet ./internal/report/... ./cmd/coldstep-report/...` — pass.
- `go test ./internal/report/... ./cmd/coldstep-report/... -count=1` — pass (includes the three new H17 tests).
- Linux-only BPF compile + verifier + integration are validated by CI's `coldstep-ci-runner.yml` (`unit`, `unit-arm64`, `integration`, `detect-mode`, `defend-mode`).

## Follow-ups (out of scope)

- A `--fail-on-risk-hint` flag for `assert-integrity` would let teams that want allowlist-promotion CI to fail when any `risk_hint` entry is present. Today the workflow uses `--fail-on-new-domain` for that role; deferred until a real consumer asks.
- `website/` quick-start mirror copy will be touched in the post-tag website-bump PR per `RELEASE_PROCESS.md`; this PR keeps the repo-side `QUICK_START.md` consistent.
