### PR TITLE
feat(H19): QUIC/HTTP3 heuristic — UDP port 443 possible-quic flag + coverage counter

### DIFF
--- a/.github/pr-bodies/pr-h19-quic-http3-heuristic.md
+++ b/.github/pr-bodies/pr-h19-quic-http3-heuristic.md
@@ -1,0 +1,49 @@
+## Summary
+
+Implements **H19** from the v0.4.0 roadmap: surface UDP/443 egress as a heuristic QUIC/HTTP3 signal so operators can see how much of a run fell into the encrypted-transport visibility gap without inferring it from raw UDP JSONL.
+
+Full QUIC ClientHello parsing is structurally out of scope — it would require QUIC crypto decryption (same architectural limit as ECH). H19 instead flags the underlying `udp` event when `dport == 443`, ticks a per-run counter, and exposes both on the coverage surface that already names every other observation gap.
+
+## What changed
+
+- **`internal/telemetry/event.go`** — new `UDPEvent.PossibleQUIC bool` (json `possible_quic,omitempty`). Rides on the existing udp JSONL line so consumers can triage which UDP rows are likely QUIC/HTTP3 without re-deriving the predicate. Also adds `CoverageReport.QuicObserved uint64` (json `quic_observed,omitempty`) — the per-run total, surfaced on the shutdown `MetaEvent.coverage` block alongside the existing IPv4 / IPv6 / TLS-SNI / io_uring rows.
+
+- **`internal/agent/agent_linux_ring_read.go`** — in `readUDPRing`, set `ev.PossibleQUIC = port == 443` and call `stats.addQUICObserved()` for each true case. Decoupled from the older `IsQUICCandidate` predicate (which keeps the non-loopback-IPv4 gate for the `quic_candidate` JSONL emitter) so the H19 counter mirrors exactly the per-event flag.
+
+- **`internal/agent/agent_linux_state.go`** — new `quicObservedN uint64` field + `addQUICObserved()` / `quicObservedTotal()` helpers under the existing `runStats.mu`. Counts UDP events whose dport is 443; read once at shutdown.
+
+- **`internal/agent/agent_linux_digest.go`** — `buildCoverageReport` gains a `quicObserved uint64` arg so the shutdown `MetaEvent.coverage.quic_observed` field is populated; the startup meta calls it with `0`. `buildDigestInput` propagates `stats.quicObservedTotal()` into the new `DigestInput.QuicObservedCount`.
+
+- **`internal/report/digest_types.go`** — new `DigestInput.QuicObservedCount uint64` (mirrors `CoverageReport.QuicObserved`).
+
+- **`internal/report/digest.go`** — `quicCoverageCell` now renders `⚠️ QUIC/HTTP3 (UDP 443) — N events observed (heuristic, not enforced)` when `QuicObservedCount > 0` (falling back to the older candidate cell when only `QUICCandidateCount` is populated). Technical-details fold gains a `**note: possible-quic**` line explaining that detection is heuristic and that full ClientHello parsing requires QUIC crypto decryption.
+
+- **`SECURITY.md`** — Coverage Boundaries row for QUIC / HTTP3 flips from "UDP event only" to "heuristic observation only (UDP port 443 flagged as `possible-quic`; not enforced)" and references the new JSONL field + `MetaEvent.coverage.quic_observed` so the threat-model doc and the runtime surface speak the same language.
+
+- **`internal/telemetry/event_test.go`** — `TestUDPEventPossibleQUIC_OmitEmpty` (false→omitted, true→`"possible_quic":true`) and `TestCoverageReportQuicObserved_OmitEmpty` (zero→omitted, non-zero→`"quic_observed":N`).
+
+- **`internal/agent/coverage_report_linux_test.go`** — added `quic observed propagates to report (H19)` case to the existing `buildCoverageReport` table test; also asserts `QuicObserved` round-trips through every case.
+
+- **`internal/agent/agent_linux_test.go`** — `TestRunStats_AddQUICObserved` exercises the counter, and `TestUDPEvent_PossibleQUIC_PortPredicate` pins the `dport == 443` rule against 443 / 80 / 53 / 0 / 4433 / 8443 with a JSONL omit-empty check on each.
+
+- **`internal/report/digest_test.go`** — `TestBuildDetectMarkdown_CoverageScopeTable_QUICRowH19` locks the new cell wording and the technical-details note.
+
+## Constraints honored
+
+- **No new BPF programs or maps.** H19 is a pure userspace heuristic on the existing UDP ring; no clang / verifier work required.
+- **No new IPv6 promises.** Heuristic fires on the IPv4 udp ring only (consistent with the rest of coldstep's IPv4-only hooks).
+- **`PossibleQUIC` is `omitempty`.** Every udp JSONL line that the agent already emits stays byte-identical on `dport != 443` runs — no schema churn for clean runs.
+- **`CoverageReport.QuicObserved` is `omitempty`.** A run without UDP/443 egress leaves the field absent rather than serializing `"quic_observed":0`.
+- **No `enforce` references introduced.** Agent only emits `mode: detect|defend`.
+
+## Validation
+
+- `bash scripts/check-gofmt.sh` — pass.
+- `bash scripts/check-encoding.sh` — pass.
+- `go test ./internal/telemetry/... ./internal/report/...  -count=1` — pass on Windows (cross-platform packages).
+- `internal/agent` Linux-only tests + BPF compile + verifier load are validated by CI's `coldstep-ci-runner.yml` (`unit`, `unit-arm64`, `integration`, `detect-mode`, `defend-mode`).
+
+## Follow-ups (out of scope)
+
+- **Full QUIC ClientHello parse / Initial-packet header inspection.** Requires QUIC crypto decryption (HKDF over the connection ID) which is structurally outside what an eBPF + userspace correlator can do without a full QUIC stack. Documented as an architectural limit in `SECURITY.md` and in the digest's `possible-quic` note.
+- **UDP/443 destination ranking.** A `Top QUIC destinations` slice (analog of the existing `Top destinations` table) is plausible once enough operators ask for it, but H19 keeps the surface to per-event flag + coverage row to avoid prejudging the right aggregation.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,7 +28,7 @@ coldstep observes and enforces a **deliberately scoped** subset of egress. Trust
 | IPv4 UDP (`write` on connected socket) | partial | ✓ | `write(2)` on a connected UDP socket may not emit a per-message event; cgroup `sendmsg4` still enforces |
 | IPv6 TCP (`connect6`) | ✗ | ✓ | Defend mode attaches `cgroup/connect6` + AAAA-resolved `allowed_ipv6` LPM trie (H14, v0.4.0). `::1` (loopback) and `fe80::/10` (link-local) always bypass. Detect mode does not observe IPv6. |
 | IPv6 UDP (`sendmsg6`) | ✗ | ✓ | Defend mode attaches `cgroup/sendmsg6` against the same `allowed_ipv6` trie. Detect mode does not observe IPv6. |
-| QUIC / HTTP3 (UDP/443) | UDP event only | ✓ (port/IP) | Inner QUIC framing not inspected; SNI not extracted |
+| QUIC / HTTP3 (UDP/443) | heuristic observation only (UDP port 443 flagged as `possible-quic`; not enforced) | ✓ (port/IP) | Inner QUIC framing not inspected; SNI not extracted. The H19 heuristic sets `possible_quic:true` on the underlying `udp` JSONL event and increments `MetaEvent.coverage.quic_observed`; full QUIC ClientHello parsing requires QUIC crypto decryption and is out of scope. |
 | TLS via io_uring | partial (enhanced) | ✗ | io_uring detection gated behind `detect-profile: enhanced` (raw_tp/io_uring_submit_sqe); the sysctl `io-uring-disable` remains the primary defense |
 | Unix domain sockets | ✗ | ✗ | AF_UNIX not tracked |
 | Docker-in-Docker inner containers | ✗ | ✗ | Separate cgroup/network namespace |

--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -111,6 +111,13 @@ func Run(ctx context.Context, cfg config.Config) error {
 	// so the shutdown digest defer can surface IP count + unresolved domains.
 	var defendCompiled policy.CompileResult
 
+	// hasDefend / ioUringRd are forward-declared so the shutdown defer can
+	// surface CoverageReport.QuicObserved and ipv6Enforced state (H19 + H14)
+	// without needing to inspect later-populated locals; they are reassigned
+	// below at the load-attach sites.
+	var hasDefend bool
+	var ioUringRd ringReader
+
 	defer func() {
 		sum := stats.snapshotSummary(kernel, bpfSt)
 		sum.CompatWarnings = compatWarnings
@@ -165,6 +172,11 @@ func Run(ctx context.Context, cfg config.Config) error {
 				} else {
 					shutdownMeta.EventsFileSHA256 = sum
 				}
+				// H19: surface CoverageReport.QuicObserved on the shutdown meta
+				// so downstream consumers can read the per-run UDP/443
+				// "possible-quic" total without scanning every udp JSONL line.
+				ipv6EnforcedShutdown := cfg.Mode == config.ModeDefend && hasDefend
+				shutdownMeta.Coverage = buildCoverageReport(bpfSt, tlsSNIGate, ioUringRd.R != nil, ipv6EnforcedShutdown, stats.quicObservedTotal())
 				if err := telemetry.AppendJSONL(cfg.EventsLogPath, shutdownMeta, signer); err != nil {
 					slog.Warn("shutdown meta jsonl", "err", err)
 				}
@@ -200,7 +212,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 	dnsCache := NewDNSCache()
 	dnsCache.SetBPFFailureCallback(stats.addDNSCacheUpdateFailure)
 
-	var connRd, udpRd, httpRd, tlsRd, tcpStateRd, ioUringRd ringReader
+	var connRd, udpRd, httpRd, tlsRd, tcpStateRd ringReader
 	defer connRd.Close()
 	defer udpRd.Close()
 	defer httpRd.Close()
@@ -217,7 +229,6 @@ func Run(ctx context.Context, cfg config.Config) error {
 	var syscallObjs *traceconnect.TraceconnectObjects
 	var syscallLnk link.Link
 	var defendObjs defend.DefendObjects
-	var hasDefend bool
 	var hasLSM bool
 	var defendConnectLnk link.Link
 	var defendSendmsgLnk link.Link
@@ -911,7 +922,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 			// "block-all IPv6" posture; we still surface that as enforce
 			// because the hook denies every non-loopback IPv6 destination.
 			ipv6Enforced := cfg.Mode == config.ModeDefend && hasDefend
-			meta.Coverage = buildCoverageReport(bpfSt, tlsSNIGate, ioUringRd.R != nil, ipv6Enforced)
+			meta.Coverage = buildCoverageReport(bpfSt, tlsSNIGate, ioUringRd.R != nil, ipv6Enforced, 0)
 			if err := telemetry.AppendJSONL(cfg.EventsLogPath, meta, signer); err != nil {
 				slog.Warn("meta jsonl", "err", err)
 			}

--- a/internal/agent/agent_linux_digest.go
+++ b/internal/agent/agent_linux_digest.go
@@ -93,11 +93,12 @@ func capabilityEnabled(gate bool, bpf []telemetry.BPFStatus, hookName string) bo
 // status rows on the same MetaEvent already carry the per-probe outcomes.
 // IPv6 is "enforce" in defend mode with a populated allowed_ipv6 LPM trie
 // (H14 v0.4.0 — P2-1 cgroup/connect6+sendmsg6 hooks attached and AAAA
-// resolutions programmed); "off" otherwise. QUIC/HTTP3 is reported as
-// `false` until the underlying probe lands. TLSSNI uses the same gate+hook
+// resolutions programmed); "off" otherwise. QUIC/HTTP3 enforcement is
+// reported as `false` until the underlying probe lands; QuicObserved
+// carries the H19 UDP/443 heuristic count. TLSSNI uses the same gate+hook
 // composition as the `tls_sni` capability flag so a degraded BPF probe
 // demotes coverage to "none".
-func buildCoverageReport(bpf []telemetry.BPFStatus, tlsSNIGate, ioUringAttached, ipv6Enforced bool) *telemetry.CoverageReport {
+func buildCoverageReport(bpf []telemetry.BPFStatus, tlsSNIGate, ioUringAttached, ipv6Enforced bool, quicObserved uint64) *telemetry.CoverageReport {
 	tls := "none"
 	if capabilityEnabled(tlsSNIGate, bpf, "raw_tp/sys_enter (connect, sendto, http sniff, tls)") {
 		tls = "full"
@@ -111,6 +112,7 @@ func buildCoverageReport(bpf []telemetry.BPFStatus, tlsSNIGate, ioUringAttached,
 		IPv4UDPSendmsg: true,
 		IPv6:           ipv6,
 		QUICHTTP3:      false,
+		QuicObserved:   quicObserved,
 		TLSSNI:         tls,
 		IoUring:        ioUringAttached,
 	}
@@ -231,6 +233,7 @@ func buildDigestInput(
 		TCPDNSResponsesObserved:        stats.tcpDNSResponsesObserved(),
 		TCPDNSSkippedShortRead:         stats.tcpDNSSkippedShortRead(),
 		QUICCandidateCount:             stats.quicCandidateTotal(),
+		QuicObservedCount:              stats.quicObservedTotal(),
 		BPFAuditTotal:                  stats.bpfAuditTotal(),
 		BPFMapIntegrityFailures:        stats.bpfMapIntegrityFailures(),
 		BPFAuditRingbufReserveFailures: stats.bpfAuditRingbufReserveFailures(),

--- a/internal/agent/agent_linux_ring_read.go
+++ b/internal/agent/agent_linux_ring_read.go
@@ -625,6 +625,10 @@ func readUDPRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, dns
 		}, stats)
 
 		ipStr := ip.String()
+		possibleQUIC := port == 443
+		if possibleQUIC {
+			stats.addQUICObserved()
+		}
 		if cfg.EventsLogPath != "" {
 			jsonlMu.Lock()
 			n := seq.Next()
@@ -633,8 +637,9 @@ func readUDPRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, dns
 				PID: tgid, TGID: tgid, ThreadID: tid,
 				Comm: comm, Dst: ipStr, Dport: port,
 				DatagramLen: dgramLen, FQDN: fqdn, FQDNProvenance: fqdnProv,
-				Direction: "egress",
-				Policy:    string(cl),
+				Direction:    "egress",
+				Policy:       string(cl),
+				PossibleQUIC: possibleQUIC,
 			}
 			err := telemetry.AppendJSONL(cfg.EventsLogPath, ev, signer)
 			jsonlMu.Unlock()

--- a/internal/agent/agent_linux_state.go
+++ b/internal/agent/agent_linux_state.go
@@ -75,6 +75,7 @@ type runStats struct {
 	tcpDNSResponsesObservedN        int
 	tcpDNSSkippedShortReadN         int
 	quicCandidateN                  int
+	quicObservedN                   uint64 // H19: count of UDPEvent.PossibleQUIC=true
 	bpfAuditN                       int
 	bpfMapIntegrityFailuresN        int
 	bpfDNSCacheUpdateFailuresN      int
@@ -633,6 +634,23 @@ func (s *runStats) quicCandidateTotal() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.quicCandidateN
+}
+
+// addQUICObserved increments the per-run total of UDPEvent records whose
+// PossibleQUIC flag was set (H19 — UDP destination port 443). This is the
+// counter surfaced as CoverageReport.QuicObserved. It is a heuristic only:
+// QUIC payloads are encrypted and never inspected, so a non-zero value just
+// quantifies the UDP/443 visibility gap, not a confirmed QUIC flow count.
+func (s *runStats) addQUICObserved() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.quicObservedN++
+}
+
+func (s *runStats) quicObservedTotal() uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.quicObservedN
 }
 
 func (s *runStats) addBPFHeartbeatFailure() {

--- a/internal/agent/agent_linux_test.go
+++ b/internal/agent/agent_linux_test.go
@@ -1362,3 +1362,57 @@ func TestBuildDroppedEventsMap_NilDefendState(t *testing.T) {
 		t.Fatalf("deny key should be absent when defendState is nil, got %v", got)
 	}
 }
+
+// TestRunStats_AddQUICObserved exercises the H19 PossibleQUIC per-run
+// counter. The agent's UDP ring reader calls addQUICObserved exactly once
+// per UDPEvent whose dport == 443; quicObservedTotal is read at shutdown
+// and surfaced on CoverageReport.QuicObserved.
+func TestRunStats_AddQUICObserved(t *testing.T) {
+	stats := newRunStats()
+	if got := stats.quicObservedTotal(); got != 0 {
+		t.Fatalf("fresh runStats quicObservedTotal = %d, want 0", got)
+	}
+	stats.addQUICObserved()
+	stats.addQUICObserved()
+	stats.addQUICObserved()
+	if got := stats.quicObservedTotal(); got != 3 {
+		t.Fatalf("after 3 increments quicObservedTotal = %d, want 3", got)
+	}
+}
+
+// TestUDPEvent_PossibleQUIC_PortPredicate locks the H19 H19 rule: the
+// per-event flag is true exactly when DstPort == 443, mirroring the agent's
+// `possibleQUIC := port == 443` decision in readUDPRing. Non-443 ports
+// (including the common cleartext-HTTP and DNS-over-UDP ports) must leave
+// the flag false so the field stays omitempty in the JSONL.
+func TestUDPEvent_PossibleQUIC_PortPredicate(t *testing.T) {
+	cases := []struct {
+		port uint16
+		want bool
+	}{
+		{443, true},
+		{80, false},
+		{53, false},
+		{0, false},
+		{4433, false},
+		{8443, false},
+	}
+	for _, tc := range cases {
+		got := tc.port == 443
+		if got != tc.want {
+			t.Fatalf("PossibleQUIC predicate for dport=%d: got %v, want %v", tc.port, got, tc.want)
+		}
+		ev := telemetry.UDPEvent{Type: "udp", Dport: tc.port, PossibleQUIC: got}
+		b, err := json.Marshal(ev)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if tc.want {
+			if !strings.Contains(string(b), `"possible_quic":true`) {
+				t.Fatalf("dport=%d expected possible_quic:true in JSON, got %s", tc.port, b)
+			}
+		} else if strings.Contains(string(b), `possible_quic`) {
+			t.Fatalf("dport=%d should omit possible_quic, got %s", tc.port, b)
+		}
+	}
+}

--- a/internal/agent/coverage_report_linux_test.go
+++ b/internal/agent/coverage_report_linux_test.go
@@ -20,14 +20,16 @@ func TestBuildCoverageReport(t *testing.T) {
 	const tlsSniffHook = "raw_tp/sys_enter (connect, sendto, http sniff, tls)"
 
 	cases := []struct {
-		name         string
-		bpf          []telemetry.BPFStatus
-		tlsGate      bool
-		ioUring      bool
-		ipv6Enforced bool
-		wantTLSSNI   string
-		wantIoUring  bool
-		wantIPv6     string
+		name             string
+		bpf              []telemetry.BPFStatus
+		tlsGate          bool
+		ioUring          bool
+		ipv6Enforced     bool
+		quicObserved     uint64
+		wantTLSSNI       string
+		wantIoUring      bool
+		wantIPv6         string
+		wantQuicObserved uint64
 	}{
 		{
 			name:        "default detect — gate off",
@@ -84,11 +86,22 @@ func TestBuildCoverageReport(t *testing.T) {
 			wantIoUring:  false,
 			wantIPv6:     telemetry.CoverageIPv6Enforce,
 		},
+		{
+			name:             "quic observed propagates to report (H19)",
+			bpf:              []telemetry.BPFStatus{{Name: tlsSniffHook, OK: true}},
+			tlsGate:          false,
+			ioUring:          false,
+			quicObserved:     7,
+			wantTLSSNI:       "none",
+			wantIoUring:      false,
+			wantIPv6:         telemetry.CoverageIPv6Off,
+			wantQuicObserved: 7,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := buildCoverageReport(tc.bpf, tc.tlsGate, tc.ioUring, tc.ipv6Enforced)
+			got := buildCoverageReport(tc.bpf, tc.tlsGate, tc.ioUring, tc.ipv6Enforced, tc.quicObserved)
 			if got == nil {
 				t.Fatal("expected non-nil CoverageReport")
 			}
@@ -109,6 +122,9 @@ func TestBuildCoverageReport(t *testing.T) {
 			}
 			if got.IoUring != tc.wantIoUring {
 				t.Errorf("IoUring = %v, want %v", got.IoUring, tc.wantIoUring)
+			}
+			if got.QuicObserved != tc.wantQuicObserved {
+				t.Errorf("QuicObserved = %d, want %d", got.QuicObserved, tc.wantQuicObserved)
 			}
 		})
 	}

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -229,9 +229,16 @@ func ipv6CoverageCell(in DigestInput) string {
 
 // quicCoverageCell returns the QUIC/HTTP3 row text. QUIC payloads are
 // always encrypted at the transport layer so the row is structurally "✗
-// not observed"; when port-443 UDP candidates were seen the cell flips to
-// "⚠" so operators know flows fell into this gap on this run.
+// not observed"; when port-443 UDP egress was flagged on a UDP event the
+// cell flips to ⚠️ and names the per-run count so operators know how many
+// flows fell into the heuristic. H19: prefer QuicObservedCount (the
+// per-event PossibleQUIC flag total) so the cell tracks the same number
+// surfaced on CoverageReport.QuicObserved; fall back to the older
+// non-loopback-IPv4 QUICCandidateCount when only that is populated.
 func quicCoverageCell(in DigestInput) string {
+	if in.QuicObservedCount > 0 {
+		return fmt.Sprintf("⚠️ QUIC/HTTP3 (UDP 443) — %d events observed (heuristic, not enforced)", in.QuicObservedCount)
+	}
 	if in.QUICCandidateCount > 0 {
 		return "⚠ candidates observed (payload encrypted, not inspected)"
 	}
@@ -1070,6 +1077,9 @@ func writeKPISemantics(b *strings.Builder, in DigestInput, max int) {
 	}
 	if in.QUICCandidateCount > 0 {
 		b.WriteString("- **QUIC (port-443 UDP)** counts UDP egress to non-loopback IPv4 on port 443 — a heuristic for QUIC/HTTP3 flows. Payload content is encrypted at the transport layer and **not inspected** by the BPF probes; the JSONL `quic_candidate` event records pid, comm, and destination only. Use this to gauge how much of the run is invisible to HTTP/TLS sniff paths.\n")
+	}
+	if in.QuicObservedCount > 0 {
+		b.WriteString("- **note: possible-quic** — QUIC/HTTP3 detection is heuristic only — UDP port 443 traffic is flagged as possible QUIC. Full ClientHello parsing would require QUIC crypto decryption and is out of scope. Per-event flag rides on `udp` JSONL records as `possible_quic:true`; the per-run total is on `MetaEvent.coverage.quic_observed` (H19).\n")
 	}
 	if in.SendfileObserved > 0 || in.SpliceObserved > 0 || in.SendmmsgFirstOnly > 0 {
 		b.WriteString("- **sendfile / splice / sendmmsg partial-observe** counters (BG-01) name the IPv4-egress paths that emit destination/length telemetry but no HTTP/TLS payload sniff: `sendfile`/`splice` correlate destination via the cached `(tgid,fd)→tuple` map, and `sendmmsg` introspects only the first `mmsghdr` (messages 2..N are dropped). Per-path counts let operators see which arm drove the gap. Under **defend**, cgroup/LSM hooks may still apply to the underlying socket; under **detect**, this is visibility-only.\n")

--- a/internal/report/digest_test.go
+++ b/internal/report/digest_test.go
@@ -489,6 +489,29 @@ func TestBuildDetectMarkdown_CoverageScopeTable_QUICRowFlipsOnCandidate(t *testi
 	}
 }
 
+// TestBuildDetectMarkdown_CoverageScopeTable_QUICRowH19 locks the H19 cell
+// wording when QuicObservedCount is set. QuicObservedCount takes precedence
+// over the older QUICCandidateCount predicate so a single run carries the
+// heuristic phrasing in both the coverage row and the technical-details
+// "possible-quic" note.
+func TestBuildDetectMarkdown_CoverageScopeTable_QUICRowH19(t *testing.T) {
+	t.Parallel()
+	md := BuildDetectMarkdown(DigestInput{
+		BPF:               []telemetry.BPFStatus{{Name: "exec", OK: true}},
+		QuicObservedCount: 12,
+	})
+	for _, needle := range []string{
+		"| QUIC / HTTP3 | ⚠️ QUIC/HTTP3 (UDP 443) — 12 events observed (heuristic, not enforced) |",
+		"**note: possible-quic**",
+		"heuristic only",
+		"out of scope",
+	} {
+		if !strings.Contains(md, needle) {
+			t.Fatalf("missing %q in:\n%s", needle, md)
+		}
+	}
+}
+
 func TestBuildDetectMarkdown_NoForbiddenGFMTags(t *testing.T) {
 	// Job Summaries render GFM; <font>, <p align>, <sub>, <center> are not in
 	// the allowlist and would appear as literal text. This guards against

--- a/internal/report/digest_types.go
+++ b/internal/report/digest_types.go
@@ -306,6 +306,14 @@ type DigestInput struct {
 	// this run, classified as likely QUIC/HTTP3 flows. The payload is encrypted
 	// and not inspected — non-zero surfaces the visibility gap in the KPI table.
 	QUICCandidateCount int
+	// QuicObservedCount mirrors telemetry.CoverageReport.QuicObserved — the
+	// per-run total of UDPEvent records whose PossibleQUIC flag was set
+	// (destination port 443). H19: surfaced in the coverage scope table as
+	// the heuristic "QUIC/HTTP3 (UDP 443) — N events observed" cell and in
+	// the technical-details "possible-quic" note when non-zero. Distinct
+	// from QUICCandidateCount, which is the older non-loopback-IPv4-only
+	// predicate.
+	QuicObservedCount uint64
 	// TCPDNSResponsesObserved counts TCP DNS length-framed replies where the BPF
 	// path could inspect the QR bit (trace_dns.bpf.c read/recvfrom sys_exit).
 	TCPDNSResponsesObserved int

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -135,6 +135,12 @@ type CoverageReport struct {
 	IPv4UDPSendmsg bool   `json:"ipv4_udp_sendmsg"`
 	IPv6           string `json:"ipv6"`
 	QUICHTTP3      bool   `json:"quic_http3"`
+	// QuicObserved counts UDPEvent records where PossibleQUIC was set on
+	// this run (H19). It is the machine-readable twin of the digest's
+	// "QUIC/HTTP3 (UDP 443) — N events observed" coverage row; non-zero
+	// means port-443 UDP egress was seen and flagged as likely QUIC/HTTP3.
+	// Heuristic only — no QUIC framing is inspected.
+	QuicObserved uint64 `json:"quic_observed,omitempty"`
 	// TLSSNI is "full" when the TLS ClientHello sniff probe attached and the
 	// tls_sni feature gate is on, "none" otherwise. "partial" is reserved for
 	// future probe variants that capture some-but-not-all SNI sources.
@@ -331,7 +337,15 @@ type UDPEvent struct {
 	FQDNProvenance string `json:"fqdn_provenance,omitempty"`
 	Direction      string `json:"direction"`
 	Policy         string `json:"policy"`
-	Sig            string `json:"sig,omitempty"`
+	// PossibleQUIC marks UDP egress on destination port 443 as a likely
+	// QUIC/HTTP3 flow (H19). The flag is a userspace heuristic — full QUIC
+	// ClientHello parsing requires QUIC crypto decryption and is out of
+	// scope (same architectural limit as ECH). Operators reading the JSONL
+	// can use the flag to triage "what fell into the QUIC visibility gap"
+	// without re-deriving the predicate per consumer. The accompanying
+	// per-run total is surfaced on CoverageReport.QuicObserved.
+	PossibleQUIC bool   `json:"possible_quic,omitempty"`
+	Sig          string `json:"sig,omitempty"`
 }
 
 // HTTPEvent is one JSONL record for cleartext HTTP/1.x request prefix (BPF-capped).

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -266,6 +266,74 @@ func TestTCPStateName(t *testing.T) {
 	}
 }
 
+// TestUDPEventPossibleQUIC_OmitEmpty verifies the H19 PossibleQUIC flag
+// rides on UDPEvent as an omitempty bool — every emitter must be able to
+// leave the field zero without it appearing in the JSONL line. The flag is
+// rendered as `"possible_quic":true` only when the agent sets it for a
+// destination port-443 event.
+func TestUDPEventPossibleQUIC_OmitEmpty(t *testing.T) {
+	t.Parallel()
+	ev := UDPEvent{
+		Type:      "udp",
+		TS:        "2026-05-20T00:00:00Z",
+		Seq:       1,
+		PID:       100,
+		TGID:      100,
+		ThreadID:  100,
+		Comm:      "curl",
+		Dst:       "1.2.3.4",
+		Dport:     80,
+		Direction: "egress",
+		Policy:    "allowed",
+	}
+	b, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(b, []byte(`possible_quic`)) {
+		t.Fatalf("PossibleQUIC=false should be omitted, got %s", b)
+	}
+
+	ev.Dport = 443
+	ev.PossibleQUIC = true
+	b, err = json.Marshal(ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(b, []byte(`"possible_quic":true`)) {
+		t.Fatalf("PossibleQUIC=true should appear, got %s", b)
+	}
+	if !bytes.Contains(b, []byte(`"dport":443`)) {
+		t.Fatalf("dport should still serialize, got %s", b)
+	}
+}
+
+// TestCoverageReportQuicObserved_OmitEmpty pins H19 wiring of
+// CoverageReport.QuicObserved. The field is the per-run total of
+// UDPEvent.PossibleQUIC=true records and is omitted from JSON when zero so
+// older runs (or runs without any UDP/443 egress) don't carry a stray
+// "quic_observed":0 in their MetaEvent.coverage.
+func TestCoverageReportQuicObserved_OmitEmpty(t *testing.T) {
+	t.Parallel()
+	cr := CoverageReport{IPv4TCP: true, IPv4UDPSendmsg: true, TLSSNI: "none"}
+	b, err := json.Marshal(cr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(b, []byte(`quic_observed`)) {
+		t.Fatalf("zero QuicObserved should be omitted, got %s", b)
+	}
+
+	cr.QuicObserved = 7
+	b, err = json.Marshal(cr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(b, []byte(`"quic_observed":7`)) {
+		t.Fatalf("expected quic_observed:7, got %s", b)
+	}
+}
+
 // TestCoverageReportJSON locks the on-disk shape of the H5 telemetry stub.
 // The field set ships at v0.2.9 even though QUICHTTP3 is wired as false
 // and IPv6 is a tri-state string (H14: "off" / "observe-only" / "enforce")


### PR DESCRIPTION
## Summary

Implements **H19** from the v0.4.0 roadmap: surface UDP/443 egress as a heuristic QUIC/HTTP3 signal so operators can see how much of a run fell into the encrypted-transport visibility gap without inferring it from raw UDP JSONL.

Full QUIC ClientHello parsing is structurally out of scope — it would require QUIC crypto decryption (same architectural limit as ECH). H19 instead flags the underlying `udp` event when `dport == 443`, ticks a per-run counter, and exposes both on the coverage surface that already names every other observation gap.

## What changed

- **`internal/telemetry/event.go`** — new `UDPEvent.PossibleQUIC bool` (json `possible_quic,omitempty`). Rides on the existing udp JSONL line so consumers can triage which UDP rows are likely QUIC/HTTP3 without re-deriving the predicate. Also adds `CoverageReport.QuicObserved uint64` (json `quic_observed,omitempty`) — the per-run total, surfaced on the shutdown `MetaEvent.coverage` block alongside the existing IPv4 / IPv6 / TLS-SNI / io_uring rows.

- **`internal/agent/agent_linux_ring_read.go`** — in `readUDPRing`, set `ev.PossibleQUIC = port == 443` and call `stats.addQUICObserved()` for each true case. Decoupled from the older `IsQUICCandidate` predicate (which keeps the non-loopback-IPv4 gate for the `quic_candidate` JSONL emitter) so the H19 counter mirrors exactly the per-event flag.

- **`internal/agent/agent_linux_state.go`** — new `quicObservedN uint64` field + `addQUICObserved()` / `quicObservedTotal()` helpers under the existing `runStats.mu`. Counts UDP events whose dport is 443; read once at shutdown.

- **`internal/agent/agent_linux_digest.go`** — `buildCoverageReport` gains a `quicObserved uint64` arg so the shutdown `MetaEvent.coverage.quic_observed` field is populated; the startup meta calls it with `0`. `buildDigestInput` propagates `stats.quicObservedTotal()` into the new `DigestInput.QuicObservedCount`.

- **`internal/report/digest_types.go`** — new `DigestInput.QuicObservedCount uint64` (mirrors `CoverageReport.QuicObserved`).

- **`internal/report/digest.go`** — `quicCoverageCell` now renders `⚠️ QUIC/HTTP3 (UDP 443) — N events observed (heuristic, not enforced)` when `QuicObservedCount > 0` (falling back to the older candidate cell when only `QUICCandidateCount` is populated). Technical-details fold gains a `**note: possible-quic**` line explaining that detection is heuristic and that full ClientHello parsing requires QUIC crypto decryption.

- **`SECURITY.md`** — Coverage Boundaries row for QUIC / HTTP3 flips from "UDP event only" to "heuristic observation only (UDP port 443 flagged as `possible-quic`; not enforced)" and references the new JSONL field + `MetaEvent.coverage.quic_observed` so the threat-model doc and the runtime surface speak the same language.

- **`internal/telemetry/event_test.go`** — `TestUDPEventPossibleQUIC_OmitEmpty` (false→omitted, true→`"possible_quic":true`) and `TestCoverageReportQuicObserved_OmitEmpty` (zero→omitted, non-zero→`"quic_observed":N`).

- **`internal/agent/coverage_report_linux_test.go`** — added `quic observed propagates to report (H19)` case to the existing `buildCoverageReport` table test; also asserts `QuicObserved` round-trips through every case.

- **`internal/agent/agent_linux_test.go`** — `TestRunStats_AddQUICObserved` exercises the counter, and `TestUDPEvent_PossibleQUIC_PortPredicate` pins the `dport == 443` rule against 443 / 80 / 53 / 0 / 4433 / 8443 with a JSONL omit-empty check on each.

- **`internal/report/digest_test.go`** — `TestBuildDetectMarkdown_CoverageScopeTable_QUICRowH19` locks the new cell wording and the technical-details note.

## Constraints honored

- **No new BPF programs or maps.** H19 is a pure userspace heuristic on the existing UDP ring; no clang / verifier work required.
- **No new IPv6 promises.** Heuristic fires on the IPv4 udp ring only (consistent with the rest of coldstep's IPv4-only hooks).
- **`PossibleQUIC` is `omitempty`.** Every udp JSONL line that the agent already emits stays byte-identical on `dport != 443` runs — no schema churn for clean runs.
- **`CoverageReport.QuicObserved` is `omitempty`.** A run without UDP/443 egress leaves the field absent rather than serializing `"quic_observed":0`.
- **No `enforce` references introduced.** Agent only emits `mode: detect|defend`.

## Validation

- `bash scripts/check-gofmt.sh` — pass.
- `bash scripts/check-encoding.sh` — pass.
- `go test ./internal/telemetry/... ./internal/report/...  -count=1` — pass on Windows (cross-platform packages).
- `internal/agent` Linux-only tests + BPF compile + verifier load are validated by CI's `coldstep-ci-runner.yml` (`unit`, `unit-arm64`, `integration`, `detect-mode`, `defend-mode`).

## Follow-ups (out of scope)

- **Full QUIC ClientHello parse / Initial-packet header inspection.** Requires QUIC crypto decryption (HKDF over the connection ID) which is structurally outside what an eBPF + userspace correlator can do without a full QUIC stack. Documented as an architectural limit in `SECURITY.md` and in the digest's `possible-quic` note.
- **UDP/443 destination ranking.** A `Top QUIC destinations` slice (analog of the existing `Top destinations` table) is plausible once enough operators ask for it, but H19 keeps the surface to per-event flag + coverage row to avoid prejudging the right aggregation.
