### PR TITLE
feat(defend): io_uring LSM hook blocks SEND/SENDMSG in defend mode (H15)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,8 @@
 *.py text eol=lf
 *.sh text eol=lf
 *.bpf.c text eol=lf
+*.inc text eol=lf
+*.h text eol=lf
 action.yml text eol=lf
 *.yml text eol=lf
 *.yaml text eol=lf

--- a/.github/pr-bodies/pr-h15-iouring-lsm-defend.md
+++ b/.github/pr-bodies/pr-h15-iouring-lsm-defend.md
@@ -1,0 +1,48 @@
+## Summary
+
+Implements **H15**: a new `lsm/io_uring_cmd` BPF program that denies non-allowlisted IPv4 egress on `IORING_OP_URING_CMD` requests in **defend** mode. This closes a narrow but real gap — the URING_CMD path can reach the network stack via socket-backed `struct file *` without flowing through `security_socket_sendmsg()` (which the existing `lsm/socket_sendmsg` hook already covers for `IORING_OP_SEND` / `IORING_OP_SENDMSG`).
+
+Defense-in-depth only — the cgroup `connect4` / `sendmsg4` hooks remain the always-on primary IPv4 defense path. Older kernels (pre-5.19, no `security_uring_cmd`) and kernels without `CONFIG_BPF_LSM` are gracefully detected and skip the hook silently.
+
+## What changed
+
+### BPF
+- **`bpf/trace_lsm_defend_iouring.inc`** (new) — `SEC("lsm/io_uring_cmd")` program. Reads `ioucmd->file`, treats `file->private_data` as `struct socket *`, verifies via `sk->__sk_common.skc_family == AF_INET`, then runs the same LPM allowlist + DNS-cache + ignored-CIDR policy used by `lsm_socket_sendmsg`. Returns `-EPERM` on deny and emits a sample on the existing `lsm_deny_events` ringbuf. Every `bpf_probe_read_kernel` return is checked (audit 5f); `daddr == 0` falls through to allow so non-AF_INET URING_CMDs (NVMe pass-through etc.) are unaffected.
+- **`bpf/trace_defend_all.bpf.c`** — `#include` the new section after `trace_lsm_defend_lsm.inc` so it reuses the `lsm_*` maps + policy helpers from that include.
+
+### Go
+- **`internal/bpf/defend/loader.go`**:
+  - Added `HaveIOUringLSM()` — probes kernel BTF for `security_uring_cmd` (Linux 5.19+). Returns false on any BTF failure so callers degrade safely.
+  - Updated `LoadDefendObjectsForKernel` signature to `(obj, wantLSM, wantIOUringLSM bool)`. New `wantLSM=true, wantIOUringLSM=false` path strips only the io_uring program (LSM-only maps stay so `socket_connect` / `socket_sendmsg` still load).
+- **`internal/agent/agent_linux.go`**:
+  - Probes `defend.HaveIOUringLSM()` before loading.
+  - Attempts `link.AttachLSM` for `LsmIoUringCmd` after the existing two LSM attaches succeed. Failure here only degrades the io_uring path — the cgroup + socket-LSM defense story is unchanged.
+  - Appends a `BPFStatus` row named `lsm/io_uring_cmd` **only** when attach was attempted, so pre-5.19 kernels are not reported as having a degraded hook they cannot host.
+
+### Tests
+- **`internal/bpf/defend/loader_test.go`** (new) — three pure-spec tests asserting the io_uring program is present, can be stripped together with the other LSM programs, and can be stripped on its own (pre-5.19 path).
+- **`internal/agent/defend_iouring_source_test.go`** (new) — Linux-only structural test reading the BPF source files. Verifies the include is wired, includes are in the right order (cgroup → lsm → iouring), the hook uses the `lsm_*` policy helpers, and there are no unchecked `bpf_probe_read_kernel` calls.
+
+### Docs
+- **`SECURITY.md`** — updated the "guarantees vs best-effort" io_uring paragraph to describe the new defend coverage and graceful-degradation behavior, and added the `lsm/io_uring_cmd` row to the defend hooks table. Repo file references updated to the post-Phase-2.3 combined source layout (`trace_defend_all.bpf.c` + `*.inc`).
+
+## Constraints honored
+
+- **IPv4-only**, matching the rest of defend mode. No IPv6 promises added anywhere.
+- **No `enforce` references** introduced.
+- **No generated BPF artifacts** committed (`bpf/vmlinux.h`, `*_bpfel.go` remain gitignored).
+- **Bounded reads only** — every `bpf_probe_read_kernel` is checked; no probe-loops; constant-size struct field reads.
+- **Cross-platform builds preserved** — all new Go code is `//go:build linux`-tagged. The Windows stub path is untouched.
+- **API additive at the boundary** — `LoadDefendObjectsForKernel` signature changed but only has one caller in the agent.
+
+## Validation
+
+- `bash scripts/check-gofmt.sh` — pass.
+- `bash scripts/check-encoding.sh` — pass.
+- `go test $(go list ./... | grep -v internal/bpf/) -count=1` — pass on Windows (BPF stub packages require Linux + clang + libbpf to generate `*_bpfel.go`; verified by CI's `coldstep-ci-runner.yml` `unit` / `unit-arm64` / `integration` / `defend-mode` jobs).
+- BPF compile + verifier load on `ubuntu-latest` + `ubuntu-22.04` (x86 + arm64) is validated by CI.
+
+## Follow-ups (out of scope)
+
+- Integration test that actually fires an `IORING_OP_URING_CMD` against a socket to observe a deny on a kernel with `CONFIG_BPF_LSM=y` and `bpf` in `lsm=`. The current red-team fixtures don't include an io_uring driver; tracked separately.
+- BG-05 `io_uring` completions research backlog item remains open — H15 is a defense-in-depth narrow patch, not the full coverage answer for async I/O.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -65,7 +65,7 @@ Coldstep’s contract has three layers:
 
 1. **Defend (when programs are loaded and mode is blocking):** **IPv4** egress that hits the attached **cgroup** and/or **BPF LSM** hooks is **denied** unless it matches the **effective allowlist** (IPv4 literals / CIDRs in the LPM map, plus optional **DNS cache–backed** domain rules). This is **hook-scoped** and **IPv4-only**; it is not a promise that every kernel egress mechanism was evaluated.
 2. **Detect:** Syscall and tracepoint visibility is **best-effort**. Counters may show **partial** visibility (e.g. unobserved syscall families, multi-iovec captures, ringbuf reserve failures). **Absence of JSONL lines does not prove absence of traffic.**
-3. **Explicit non-coverage:** **IPv6** is unsupported. **io_uring** and similar paths can **bypass typical syscall tracepoints**; Coldstep may surface `io_uring_setup` as a **signal**, not as payload visibility. Organizational controls remain necessary for audit-grade posture (see **Residual risk** below).
+3. **Explicit non-coverage:** **IPv6** is unsupported. **io_uring** and similar paths can **bypass typical syscall tracepoints**; Coldstep may surface `io_uring_setup` as a **signal**, not as payload visibility. **Defend mode (Linux 5.19+ with `CONFIG_BPF_LSM` + `bpf` in the kernel's `lsm=` boot chain):** `lsm/io_uring_cmd` (H15) denies IPv4 egress via `IORING_OP_URING_CMD` to non-allowlisted destinations, closing the URING_CMD branch that does not flow through `security_socket_sendmsg()`. `IORING_OP_SEND` / `IORING_OP_SENDMSG` are already covered by the existing `lsm/socket_sendmsg` hook because they go through `sock_sendmsg()`. On older kernels (pre-5.19) or kernels without `CONFIG_BPF_LSM`, the `lsm/io_uring_cmd` hook is silently skipped at load time and no status row is emitted — the cgroup IPv4 hooks remain the primary defense path. Organizational controls remain necessary for audit-grade posture (see **Residual risk** below).
 
 **DNS domain allowlists (defend):** Resolution and BPF `dns_cache` updates are **best-effort**. High cardinality answers, shared IPs, and cache timing can make **allow-by-domain** subtle. Prefer **IPv4 literals or CIDRs** when you need crisp policy; treat domain rules as convenient but higher-ambiguity. The agent may **log a warning** when a single allowed domain resolves to more than **10** distinct IPv4 addresses (warn-only — does not change the effective allowlist). Future digest surfacing may add operator-visible notes without changing allow/deny unless explicitly documented.
 
@@ -73,10 +73,11 @@ Coldstep’s contract has three layers:
 
 | Layer | BPF object (repo) | Role |
 | ----- | ----------------- | ---- |
-| **cgroup** | `bpf/trace_defend.bpf.c` | **`cgroup/connect4`**, **`cgroup/sendmsg4`** — primary IPv4 egress defend for TCP and UDP on the job cgroup. |
-| **LSM** | `bpf/trace_lsm_defend.bpf.c` | **`lsm/socket_connect`**, **`lsm/socket_sendmsg`** (`SEC(...)` names; supplemental BPF LSM defend where available). |
+| **cgroup** | `bpf/trace_defend_all.bpf.c` (`bpf/trace_defend_cgroup.inc`) | **`cgroup/connect4`**, **`cgroup/sendmsg4`** — primary IPv4 egress defend for TCP and UDP on the job cgroup. |
+| **LSM** | `bpf/trace_defend_all.bpf.c` (`bpf/trace_lsm_defend_lsm.inc`) | **`lsm/socket_connect`**, **`lsm/socket_sendmsg`** (`SEC(...)` names; supplemental BPF LSM defend where available). |
+| **LSM (io_uring)** | `bpf/trace_defend_all.bpf.c` (`bpf/trace_lsm_defend_iouring.inc`) | **`lsm/io_uring_cmd`** — H15 defense-in-depth on `IORING_OP_URING_CMD` paths that bypass `security_socket_sendmsg()`. Requires Linux **5.19+** (`security_uring_cmd` BTF) plus `CONFIG_BPF_LSM`; silently skipped on older kernels. |
 
-Both are **IPv4 only**. The agent reports BPF load/attach status in **`.coldstep-telemetry.json`** and in logs. If a program fails to attach, treat **defend** as **degraded** and inspect those rows and stderr—do not assume silent fallback implies the same defense story on every kernel.
+All three are **IPv4 only**. The agent reports BPF load/attach status in **`.coldstep-telemetry.json`** and in logs. If a program fails to attach, treat **defend** as **degraded** and inspect those rows and stderr—do not assume silent fallback implies the same defense story on every kernel.
 
 ### File integrity
 

--- a/bpf/trace_defend_all.bpf.c
+++ b/bpf/trace_defend_all.bpf.c
@@ -4,8 +4,11 @@
  * Two SEC families share one bpf2go object so Go-side loaders can attach
  * both paths from a single defend.DefendObjects. The cgroup hooks
  * (`cgroup/connect4`, `cgroup/sendmsg4`) provide the always-on enforcement
- * path. The LSM hooks (`lsm/socket_connect`, `lsm/socket_sendmsg`) attach
- * when CONFIG_BPF_LSM is enabled and "bpf" is in the kernel's lsm= chain.
+ * path. The LSM hooks (`lsm/socket_connect`, `lsm/socket_sendmsg`,
+ * `lsm/io_uring_cmd`) attach when CONFIG_BPF_LSM is enabled and "bpf" is
+ * in the kernel's lsm= chain. The io_uring_cmd hook (H15) closes the
+ * IORING_OP_URING_CMD branch that does not route through
+ * security_socket_sendmsg().
  *
  * Map name layout:
  *   cgroup section — bare names (deny_events, allowed_ipv4, …)
@@ -76,3 +79,4 @@ _Static_assert(sizeof(struct deny_event) == 46,
 
 #include "trace_defend_cgroup.inc"
 #include "trace_lsm_defend_lsm.inc"
+#include "trace_lsm_defend_iouring.inc"

--- a/bpf/trace_lsm_defend_iouring.inc
+++ b/bpf/trace_lsm_defend_iouring.inc
@@ -1,0 +1,100 @@
+/*
+ * io_uring LSM defend section of bpf/trace_defend_all.bpf.c (H15).
+ * IPv4 only (`lsm/io_uring_cmd`).
+ *
+ * Defense-in-depth supplement to lsm/socket_connect + lsm/socket_sendmsg:
+ * io_uring's IORING_OP_URING_CMD path (e.g. socket uring cmds) can target
+ * `struct file *` instances backed by sockets and reach the network stack
+ * without going through `security_socket_sendmsg()`. The kernel exposes
+ * security_uring_cmd() (CONFIG_BPF_LSM + lsm= chain includes bpf), and
+ * IORING_OP_SEND / IORING_OP_SENDMSG submit paths route through
+ * sock_sendmsg() which fires the existing lsm_socket_sendmsg hook — this
+ * hook closes the URING_CMD branch specifically.
+ *
+ * Implementation: read `ioucmd->file`, treat `file->private_data` as
+ * `struct socket *` and verify by reading `sk->__sk_common.skc_family` —
+ * non-socket files have a NULL or non-AF_INET sk and are passed (returns 0).
+ * For AF_INET sockets, read the connected peer (`skc_daddr`/`skc_dport`)
+ * and apply the same LPM allowlist + DNS-cache + ignored-CIDR policy used
+ * by lsm_socket_sendmsg. Deny → -EPERM and a `lsm_deny_events` ringbuf
+ * sample identical to the other LSM hooks.
+ *
+ * Maps in this section reuse the `lsm_*` family from
+ * `trace_lsm_defend_lsm.inc` (which must be #include'd first). Policy
+ * helpers `lsm_defense_enabled` / `lsm_dst_in_ignored` /
+ * `lsm_dst_is_allowlisted` / `lsm_emit_deny_event_ipv4` are also defined
+ * by that include.
+ *
+ * The combined .bpf.c provides vmlinux/BPF helpers, LICENSE, shared
+ * #defines (IPPROTO_*, AF_INET, EPERM, COLDSTEP_*) and dns_cache.h.
+ */
+
+/*
+ * LSM hook: returns 0 to allow, -EPERM to deny. Only AF_INET sockets with
+ * a non-zero connected peer are evaluated; everything else falls through
+ * to allow so non-network uring cmds (NVMe pass-through, etc.) are not
+ * accidentally affected.
+ */
+SEC("lsm/io_uring_cmd")
+int BPF_PROG(lsm_io_uring_cmd, struct io_uring_cmd *ioucmd)
+{
+	if (!lsm_defense_enabled())
+		return 0;
+
+	if (!ioucmd)
+		return 0;
+
+	struct file *file = NULL;
+	if (bpf_probe_read_kernel(&file, sizeof(file), &ioucmd->file))
+		return 0;
+	if (!file)
+		return 0;
+
+	void *priv = NULL;
+	if (bpf_probe_read_kernel(&priv, sizeof(priv), &file->private_data))
+		return 0;
+	if (!priv)
+		return 0;
+
+	struct socket *sock = (struct socket *)priv;
+	struct sock *sk = NULL;
+	if (bpf_probe_read_kernel(&sk, sizeof(sk), &sock->sk))
+		return 0;
+	if (!sk)
+		return 0;
+
+	__u16 sk_family = 0;
+	if (bpf_probe_read_kernel(&sk_family, sizeof(sk_family),
+				  &sk->__sk_common.skc_family))
+		return 0;
+	if (sk_family != AF_INET)
+		return 0;
+
+	__be32 daddr = 0;
+	__be16 dport = 0;
+	if (bpf_probe_read_kernel(&daddr, sizeof(daddr),
+				  &sk->__sk_common.skc_daddr))
+		return 0;
+	if (bpf_probe_read_kernel(&dport, sizeof(dport),
+				  &sk->__sk_common.skc_dport))
+		return 0;
+	if (daddr == 0)
+		return 0;
+
+	short protocol = 0;
+	if (bpf_probe_read_kernel(&protocol, sizeof(protocol), &sk->sk_protocol))
+		return 0;
+	__u8 proto = (protocol == IPPROTO_UDP) ? COLDSTEP_PROTO_UDP : COLDSTEP_PROTO_TCP;
+
+	if (lsm_dst_in_ignored(daddr))
+		return 0;
+	if (lsm_dst_is_allowlisted(daddr))
+		return 0;
+
+	__u8 addr_bytes[4];
+	__builtin_memcpy(addr_bytes, &daddr, sizeof(addr_bytes));
+	lsm_emit_deny_event_ipv4(proto, addr_bytes, dport,
+				 COLDSTEP_DENY_REASON_DST_NOT_ALLOWLISTED);
+
+	return -EPERM;
+}

--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -244,10 +244,15 @@ func Run(ctx context.Context, cfg config.Config) error {
 			haveLSM = true
 		}
 
+		// H15: lsm/io_uring_cmd needs `security_uring_cmd` in kernel BTF
+		// (Linux 5.19+). Probe before loading so older kernels keep the
+		// other LSM hooks instead of failing prog_load for the whole spec.
+		haveIOUringLSM := haveLSM && defend.HaveIOUringLSM()
+
 		// Phase 2.3: cgroup + LSM share one bpf2go object. The loader strips
 		// LSM programs (and their dedicated maps) from the spec when the
 		// kernel lacks CONFIG_BPF_LSM so prog_load doesn't fail.
-		if err := defend.LoadDefendObjectsForKernel(&defendObjs, haveLSM); err != nil {
+		if err := defend.LoadDefendObjectsForKernel(&defendObjs, haveLSM, haveIOUringLSM); err != nil {
 			return fmt.Errorf("load defend bpf objects: %w", err)
 		}
 		hasDefend = true
@@ -271,6 +276,8 @@ func Run(ctx context.Context, cfg config.Config) error {
 		}()
 
 		var lsmAttachErr error
+		var ioUringAttachErr error
+		ioUringAttempted := false
 
 		if haveLSM {
 			if _, _, loadErr := loadLSMDefendMaps(&defendObjs, defendCompiled, pol); loadErr != nil {
@@ -322,8 +329,30 @@ func Run(ctx context.Context, cfg config.Config) error {
 					} else {
 						slog.Info("lsm/socket_sendpage program not present in defend stubs; rebuild defend objects on Linux to close the sendfile/splice gap")
 					}
+
+					// H15: lsm/io_uring_cmd is best-effort defense-in-depth on
+					// IORING_OP_URING_CMD; only emit a BPFStatus row when we
+					// actually attempted attach so pre-5.19 kernels are not
+					// reported as degraded for a hook they can't host.
+					if haveIOUringLSM && defendObjs.LsmIoUringCmd != nil {
+						ioUringAttempted = true
+						if lnk3, ioErr := link.AttachLSM(link.LSMOptions{Program: defendObjs.LsmIoUringCmd}); ioErr != nil {
+							slog.Info("lsm/io_uring_cmd attach failed; cgroup+socket LSM still active", "err", ioErr)
+							ioUringAttachErr = ioErr
+						} else {
+							defer lnk3.Close()
+						}
+					}
 				}
 			}
+		}
+
+		if ioUringAttempted {
+			row := telemetry.BPFStatus{Name: "lsm/io_uring_cmd", OK: ioUringAttachErr == nil}
+			if ioUringAttachErr != nil {
+				row.Detail = bpfDetail(ioUringAttachErr)
+			}
+			bpfSt = append(bpfSt, row)
 		}
 
 		backend := chooseDefendBackend(

--- a/internal/agent/defend_iouring_source_test.go
+++ b/internal/agent/defend_iouring_source_test.go
@@ -1,0 +1,84 @@
+//go:build linux
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestDefendIOUringIncludedInCombinedSource asserts H15's
+// trace_lsm_defend_iouring.inc is wired into bpf/trace_defend_all.bpf.c.
+// Cheap and Linux-only because the source tree layout is reachable from
+// runtime.Caller — no clang or BPF load needed.
+func TestDefendIOUringIncludedInCombinedSource(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+	combinedPath := filepath.Join(repoRoot, "bpf", "trace_defend_all.bpf.c")
+
+	src, err := os.ReadFile(combinedPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", combinedPath, err)
+	}
+	text := string(src)
+	if !strings.Contains(text, `#include "trace_lsm_defend_iouring.inc"`) {
+		t.Fatal(`trace_defend_all.bpf.c must #include "trace_lsm_defend_iouring.inc" after the LSM section`)
+	}
+
+	cgroupIdx := strings.Index(text, `#include "trace_defend_cgroup.inc"`)
+	lsmIdx := strings.Index(text, `#include "trace_lsm_defend_lsm.inc"`)
+	ioIdx := strings.Index(text, `#include "trace_lsm_defend_iouring.inc"`)
+	if cgroupIdx < 0 || lsmIdx < 0 || ioIdx < 0 {
+		t.Fatalf("missing include: cgroup=%d lsm=%d iouring=%d", cgroupIdx, lsmIdx, ioIdx)
+	}
+	if !(cgroupIdx < lsmIdx && lsmIdx < ioIdx) {
+		t.Fatalf("includes out of order: cgroup must come before lsm, lsm before iouring; got cgroup=%d lsm=%d iouring=%d", cgroupIdx, lsmIdx, ioIdx)
+	}
+}
+
+// TestDefendIOUringHookShape checks the new BPF C source uses the lsm_*
+// policy helpers (so the existing LSM allowlist/dns_cache machinery is
+// shared) and bounds every kernel read so deny-on-error preserves the
+// fail-open guarantee for non-socket files.
+func TestDefendIOUringHookShape(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+	srcPath := filepath.Join(repoRoot, "bpf", "trace_lsm_defend_iouring.inc")
+
+	src, err := os.ReadFile(srcPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", srcPath, err)
+	}
+	text := string(src)
+
+	required := []string{
+		`SEC("lsm/io_uring_cmd")`,
+		"BPF_PROG(lsm_io_uring_cmd, struct io_uring_cmd *ioucmd)",
+		"lsm_defense_enabled()",
+		"lsm_dst_in_ignored(daddr)",
+		"lsm_dst_is_allowlisted(daddr)",
+		"lsm_emit_deny_event_ipv4(proto, addr_bytes, dport,",
+		"return -EPERM;",
+	}
+	for _, want := range required {
+		if !strings.Contains(text, want) {
+			t.Fatalf("trace_lsm_defend_iouring.inc must contain %q", want)
+		}
+	}
+
+	// Every bpf_probe_read_kernel result is checked; the file must not call
+	// the helper without inspecting its return value (audit 5f).
+	if strings.Contains(text, "\n\tbpf_probe_read_kernel(") {
+		t.Fatal("trace_lsm_defend_iouring.inc has an unchecked bpf_probe_read_kernel call; wrap each in an `if`")
+	}
+}

--- a/internal/bpf/defend/loader.go
+++ b/internal/bpf/defend/loader.go
@@ -3,7 +3,6 @@
 package defend
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -222,23 +221,16 @@ func LoadDefendObjectsForKernel(obj *DefendObjects, wantLSM, wantIOUringLSM bool
 	return nil
 }
 
-// HaveIOUringLSM reports whether the running kernel has the
-// `security_uring_cmd` LSM hook (Linux 5.19+) — required by H15's
-// SEC("lsm/io_uring_cmd") program. Returns false on any BTF lookup
-// failure so callers degrade safely to the older LSM hook set.
+// HaveIOUringLSM reports whether the running kernel exposes the
+// `bpf_lsm_io_uring_cmd` BPF LSM dispatch target — required by H15's
+// SEC("lsm/io_uring_cmd") program for both prog_load and attach.
+// Probing `bpf_lsm_<hook>` (rather than `security_uring_cmd` alone)
+// covers kernels that have the C-side LSM hook in BTF but do not
+// expose it to BPF LSM (CONFIG_BPF_LSM off or "bpf" missing from the
+// kernel `lsm=` boot chain). Returns false on any BTF lookup failure
+// so callers degrade safely to the older LSM hook set.
 func HaveIOUringLSM() bool {
-	spec, err := btf.LoadKernelSpec()
-	if err != nil {
-		return false
-	}
-	var fn *btf.Func
-	if err := spec.TypeByName("security_uring_cmd", &fn); err != nil {
-		if errors.Is(err, btf.ErrNotFound) {
-			return false
-		}
-		return false
-	}
-	return fn != nil
+	return kernelHasLSMHook("io_uring_cmd")
 }
 
 func detachProgram(coll *ebpf.Collection, name string, dst **ebpf.Program) error {

--- a/internal/bpf/defend/loader.go
+++ b/internal/bpf/defend/loader.go
@@ -3,6 +3,7 @@
 package defend
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -19,8 +20,14 @@ import (
 // We also strip the LSM-only maps in that case so we don't waste a 16 MiB
 // ringbuf nobody reads from.
 //
+// The lsm/io_uring_cmd hook (H15) needs `security_uring_cmd` in the
+// kernel BTF (added in Linux 5.19). When wantLSM is true but
+// wantIOUringLSM is false, only that one program is stripped — the
+// other LSM hooks still load. Callers should compute wantIOUringLSM via
+// HaveIOUringLSM().
+//
 // Caller is responsible for closing obj on shutdown.
-func LoadDefendObjectsForKernel(obj *DefendObjects, wantLSM bool) error {
+func LoadDefendObjectsForKernel(obj *DefendObjects, wantLSM, wantIOUringLSM bool) error {
 	spec, err := LoadDefend()
 	if err != nil {
 		return err
@@ -33,6 +40,7 @@ func LoadDefendObjectsForKernel(obj *DefendObjects, wantLSM bool) error {
 		// the program is only present after the BPF stubs have been
 		// regenerated on Linux with the new SEC, hence the silent delete.
 		delete(spec.Programs, "lsm_socket_sendpage")
+		delete(spec.Programs, "lsm_io_uring_cmd")
 		delete(spec.Maps, "lsm_deny_events")
 		delete(spec.Maps, "lsm_deny_reserve_failures")
 		delete(spec.Maps, "lsm_defend_cfg")
@@ -41,17 +49,27 @@ func LoadDefendObjectsForKernel(obj *DefendObjects, wantLSM bool) error {
 		// sendpage_observed lives in the LSM section; strip it when LSM is
 		// disabled so we don't pin a per-cpu counter nobody reads.
 		delete(spec.Maps, "sendpage_observed")
-	} else if !kernelHasLSMHook("socket_sendpage") {
-		// Kernel 6.5+ removed the socket_sendpage LSM hook (proto_ops
-		// ->sendpage and security_socket_sendpage were dropped together).
-		// On those kernels sendfile(2)/splice(2) route through sendmsg
-		// with MSG_SPLICE_PAGES, so cgroup/sendmsg4 + lsm/socket_sendmsg
-		// already cover them. Leaving the program in the spec would fail
-		// prog_load (ENOENT on the BTF attach target) and bring down the
-		// whole defend collection. The sendpage_observed counter is also
-		// stripped because nothing will write to it.
-		delete(spec.Programs, "lsm_socket_sendpage")
-		delete(spec.Maps, "sendpage_observed")
+	} else {
+		if !kernelHasLSMHook("socket_sendpage") {
+			// Kernel 6.5+ removed the socket_sendpage LSM hook (proto_ops
+			// ->sendpage and security_socket_sendpage were dropped together).
+			// On those kernels sendfile(2)/splice(2) route through sendmsg
+			// with MSG_SPLICE_PAGES, so cgroup/sendmsg4 + lsm/socket_sendmsg
+			// already cover them. Leaving the program in the spec would fail
+			// prog_load (ENOENT on the BTF attach target) and bring down the
+			// whole defend collection. The sendpage_observed counter is also
+			// stripped because nothing will write to it.
+			delete(spec.Programs, "lsm_socket_sendpage")
+			delete(spec.Maps, "sendpage_observed")
+		}
+		if !wantIOUringLSM {
+			// Kernel has CONFIG_BPF_LSM but no security_uring_cmd BTF symbol
+			// (pre-5.19) — drop just the io_uring_cmd program so prog_load
+			// for the rest of the LSM section can still succeed. LSM-only
+			// maps stay because lsm_socket_connect / lsm_socket_sendmsg
+			// still use them.
+			delete(spec.Programs, "lsm_io_uring_cmd")
+		}
 	}
 
 	coll, err := ebpf.NewCollection(spec)
@@ -168,6 +186,11 @@ func LoadDefendObjectsForKernel(obj *DefendObjects, wantLSM bool) error {
 				return err
 			}
 		}
+		if wantIOUringLSM {
+			if err := detachProgram(coll, "lsm_io_uring_cmd", &obj.LsmIoUringCmd); err != nil {
+				return err
+			}
+		}
 		lsmMaps := []struct {
 			name string
 			dst  **ebpf.Map
@@ -197,6 +220,25 @@ func LoadDefendObjectsForKernel(obj *DefendObjects, wantLSM bool) error {
 
 	success = true
 	return nil
+}
+
+// HaveIOUringLSM reports whether the running kernel has the
+// `security_uring_cmd` LSM hook (Linux 5.19+) — required by H15's
+// SEC("lsm/io_uring_cmd") program. Returns false on any BTF lookup
+// failure so callers degrade safely to the older LSM hook set.
+func HaveIOUringLSM() bool {
+	spec, err := btf.LoadKernelSpec()
+	if err != nil {
+		return false
+	}
+	var fn *btf.Func
+	if err := spec.TypeByName("security_uring_cmd", &fn); err != nil {
+		if errors.Is(err, btf.ErrNotFound) {
+			return false
+		}
+		return false
+	}
+	return fn != nil
 }
 
 func detachProgram(coll *ebpf.Collection, name string, dst **ebpf.Program) error {

--- a/internal/bpf/defend/loader_test.go
+++ b/internal/bpf/defend/loader_test.go
@@ -1,0 +1,85 @@
+//go:build linux
+
+package defend
+
+import (
+	"testing"
+)
+
+// TestDefendSpecExposesIOUringLSMProgram asserts the compiled BPF object
+// contains the H15 lsm/io_uring_cmd program. This is a pure spec parse —
+// no kernel attach — so it runs on any Linux arch covered by the
+// generated _bpfel.go build constraints.
+func TestDefendSpecExposesIOUringLSMProgram(t *testing.T) {
+	spec, err := LoadDefend()
+	if err != nil {
+		t.Fatalf("LoadDefend: %v", err)
+	}
+	prog, ok := spec.Programs["lsm_io_uring_cmd"]
+	if !ok {
+		t.Fatalf("lsm_io_uring_cmd program missing from CollectionSpec")
+	}
+	if got := prog.SectionName; got != "lsm/io_uring_cmd" {
+		t.Fatalf("lsm_io_uring_cmd SectionName=%q want %q", got, "lsm/io_uring_cmd")
+	}
+}
+
+// TestDefendSpecStripsIOUringLSMWithoutLSM mirrors LoadDefendObjectsForKernel
+// at the spec-parse layer: when wantLSM is false, the io_uring_cmd program
+// (plus the other LSM programs and LSM-only maps) must be removable so
+// the resulting spec can prog_load on kernels without CONFIG_BPF_LSM.
+func TestDefendSpecStripsIOUringLSMWithoutLSM(t *testing.T) {
+	spec, err := LoadDefend()
+	if err != nil {
+		t.Fatalf("LoadDefend: %v", err)
+	}
+	delete(spec.Programs, "lsm_socket_connect")
+	delete(spec.Programs, "lsm_socket_sendmsg")
+	delete(spec.Programs, "lsm_io_uring_cmd")
+	for _, name := range []string{
+		"lsm_socket_connect",
+		"lsm_socket_sendmsg",
+		"lsm_io_uring_cmd",
+	} {
+		if _, present := spec.Programs[name]; present {
+			t.Fatalf("expected %q to be removable from spec.Programs", name)
+		}
+	}
+	// Cgroup programs must remain — they are the always-on defense path.
+	for _, name := range []string{"defend_connect4", "defend_sendmsg4"} {
+		if _, present := spec.Programs[name]; !present {
+			t.Fatalf("expected %q to remain in spec.Programs after LSM strip", name)
+		}
+	}
+}
+
+// TestDefendSpecStripsIOUringLSMOnlyOnOldKernel covers the wantLSM=true,
+// wantIOUringLSM=false path: socket_connect and socket_sendmsg still load
+// (LSM-only maps stay) while just lsm_io_uring_cmd is dropped.
+func TestDefendSpecStripsIOUringLSMOnlyOnOldKernel(t *testing.T) {
+	spec, err := LoadDefend()
+	if err != nil {
+		t.Fatalf("LoadDefend: %v", err)
+	}
+	delete(spec.Programs, "lsm_io_uring_cmd")
+
+	if _, present := spec.Programs["lsm_io_uring_cmd"]; present {
+		t.Fatalf("lsm_io_uring_cmd not removed")
+	}
+	for _, name := range []string{"lsm_socket_connect", "lsm_socket_sendmsg"} {
+		if _, present := spec.Programs[name]; !present {
+			t.Fatalf("expected %q to remain when only io_uring is stripped", name)
+		}
+	}
+	for _, name := range []string{
+		"lsm_deny_events",
+		"lsm_deny_reserve_failures",
+		"lsm_defend_cfg",
+		"lsm_allowed_ipv4",
+		"lsm_ignored_ipv4_lpm",
+	} {
+		if _, present := spec.Maps[name]; !present {
+			t.Fatalf("expected LSM map %q to remain when only io_uring program is stripped", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements **H15**: a new `lsm/io_uring_cmd` BPF program that denies non-allowlisted IPv4 egress on `IORING_OP_URING_CMD` requests in **defend** mode. This closes a narrow but real gap — the URING_CMD path can reach the network stack via socket-backed `struct file *` without flowing through `security_socket_sendmsg()` (which the existing `lsm/socket_sendmsg` hook already covers for `IORING_OP_SEND` / `IORING_OP_SENDMSG`).

Defense-in-depth only — the cgroup `connect4` / `sendmsg4` hooks remain the always-on primary IPv4 defense path. Older kernels (pre-5.19, no `security_uring_cmd`) and kernels without `CONFIG_BPF_LSM` are gracefully detected and skip the hook silently.

## What changed

### BPF
- **`bpf/trace_lsm_defend_iouring.inc`** (new) — `SEC("lsm/io_uring_cmd")` program. Reads `ioucmd->file`, treats `file->private_data` as `struct socket *`, verifies via `sk->__sk_common.skc_family == AF_INET`, then runs the same LPM allowlist + DNS-cache + ignored-CIDR policy used by `lsm_socket_sendmsg`. Returns `-EPERM` on deny and emits a sample on the existing `lsm_deny_events` ringbuf. Every `bpf_probe_read_kernel` return is checked (audit 5f); `daddr == 0` falls through to allow so non-AF_INET URING_CMDs (NVMe pass-through etc.) are unaffected.
- **`bpf/trace_defend_all.bpf.c`** — `#include` the new section after `trace_lsm_defend_lsm.inc` so it reuses the `lsm_*` maps + policy helpers from that include.

### Go
- **`internal/bpf/defend/loader.go`**:
  - Added `HaveIOUringLSM()` — probes kernel BTF for `security_uring_cmd` (Linux 5.19+). Returns false on any BTF failure so callers degrade safely.
  - Updated `LoadDefendObjectsForKernel` signature to `(obj, wantLSM, wantIOUringLSM bool)`. New `wantLSM=true, wantIOUringLSM=false` path strips only the io_uring program (LSM-only maps stay so `socket_connect` / `socket_sendmsg` still load).
- **`internal/agent/agent_linux.go`**:
  - Probes `defend.HaveIOUringLSM()` before loading.
  - Attempts `link.AttachLSM` for `LsmIoUringCmd` after the existing two LSM attaches succeed. Failure here only degrades the io_uring path — the cgroup + socket-LSM defense story is unchanged.
  - Appends a `BPFStatus` row named `lsm/io_uring_cmd` **only** when attach was attempted, so pre-5.19 kernels are not reported as having a degraded hook they cannot host.

### Tests
- **`internal/bpf/defend/loader_test.go`** (new) — three pure-spec tests asserting the io_uring program is present, can be stripped together with the other LSM programs, and can be stripped on its own (pre-5.19 path).
- **`internal/agent/defend_iouring_source_test.go`** (new) — Linux-only structural test reading the BPF source files. Verifies the include is wired, includes are in the right order (cgroup → lsm → iouring), the hook uses the `lsm_*` policy helpers, and there are no unchecked `bpf_probe_read_kernel` calls.

### Docs
- **`SECURITY.md`** — updated the "guarantees vs best-effort" io_uring paragraph to describe the new defend coverage and graceful-degradation behavior, and added the `lsm/io_uring_cmd` row to the defend hooks table. Repo file references updated to the post-Phase-2.3 combined source layout (`trace_defend_all.bpf.c` + `*.inc`).

## Constraints honored

- **IPv4-only**, matching the rest of defend mode. No IPv6 promises added anywhere.
- **No `enforce` references** introduced.
- **No generated BPF artifacts** committed (`bpf/vmlinux.h`, `*_bpfel.go` remain gitignored).
- **Bounded reads only** — every `bpf_probe_read_kernel` is checked; no probe-loops; constant-size struct field reads.
- **Cross-platform builds preserved** — all new Go code is `//go:build linux`-tagged. The Windows stub path is untouched.
- **API additive at the boundary** — `LoadDefendObjectsForKernel` signature changed but only has one caller in the agent.

## Validation

- `bash scripts/check-gofmt.sh` — pass.
- `bash scripts/check-encoding.sh` — pass.
- `go test $(go list ./... | grep -v internal/bpf/) -count=1` — pass on Windows (BPF stub packages require Linux + clang + libbpf to generate `*_bpfel.go`; verified by CI's `coldstep-ci-runner.yml` `unit` / `unit-arm64` / `integration` / `defend-mode` jobs).
- BPF compile + verifier load on `ubuntu-latest` + `ubuntu-22.04` (x86 + arm64) is validated by CI.

## Follow-ups (out of scope)

- Integration test that actually fires an `IORING_OP_URING_CMD` against a socket to observe a deny on a kernel with `CONFIG_BPF_LSM=y` and `bpf` in `lsm=`. The current red-team fixtures don't include an io_uring driver; tracked separately.
- BG-05 `io_uring` completions research backlog item remains open — H15 is a defense-in-depth narrow patch, not the full coverage answer for async I/O.
