### PR TITLE
chore(website): bump coldstep pin to v0.3.0

### DIFF
--- a/.github/pr-bodies/pr-docs-v0.3.0-website.md
+++ b/.github/pr-bodies/pr-docs-v0.3.0-website.md
@@ -1,0 +1,22 @@
+## Summary
+
+Train 2 of the v0.3.0 release: bump `website/index.html` from `v0.2.9` to `v0.3.0` now that the tag is published on GitHub Releases (`coldstep-io/coldstep@v0.3.0`).
+
+Pin-only change. No agent / BPF / action / report code touched.
+
+### Files changed
+
+| Surface | Before | After |
+| :------ | :----- | :---- |
+| Quickstart YAML snippet (`<pre><code>` block) | `coldstep-io/coldstep@v0.2.9` | `coldstep-io/coldstep@v0.3.0` |
+| Modes section prose (`<code>coldstep-io/coldstep@v0.2.9</code>`) | v0.2.9 | v0.3.0 |
+
+### Why this is a separate PR
+
+Per `RELEASE_PROCESS.md` Consumer Pin Standard, the marketing site must never advertise a tag that does not exist on GitHub Releases — visitors would copy a broken `uses:` pin. The release-train PR deliberately left `website/` at v0.2.9 so this follow-up could land *after* the tag is real on Releases.
+
+### Test plan
+
+- [x] `grep -n "v0.3.0" website/index.html` → both expected occurrences (quickstart YAML block + Modes prose).
+- [x] `grep -n "v0.2.9" website/index.html` → no matches.
+- [ ] `coldstep-pages.yml` deploys on merge to `main` and the site shows `coldstep-io/coldstep@v0.3.0` in both spots.

--- a/website/index.html
+++ b/website/index.html
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: coldstep-io/coldstep@v0.2.9
+      - uses: coldstep-io/coldstep@v0.3.0
 </code></pre>
             </div>
           </div>
@@ -116,7 +116,7 @@ jobs:
           <div class="inner">
             <h2 id="modes-heading">Two modes, one agent</h2>
             <p class="section-intro">
-              Pin a release tag (e.g. <code>coldstep-io/coldstep@v0.2.9</code>) rather than tracking
+              Pin a release tag (e.g. <code>coldstep-io/coldstep@v0.3.0</code>) rather than tracking
               <code>@main</code>. The legacy <code>enforce</code> mode string is rejected — use
               <code>defend</code>.
             </p>


### PR DESCRIPTION
## Summary

Train 2 of the v0.3.0 release: bump `website/index.html` from `v0.2.9` to `v0.3.0` now that the tag is published on GitHub Releases (`coldstep-io/coldstep@v0.3.0`).

Pin-only change. No agent / BPF / action / report code touched.

### Files changed

| Surface | Before | After |
| :------ | :----- | :---- |
| Quickstart YAML snippet (`<pre><code>` block) | `coldstep-io/coldstep@v0.2.9` | `coldstep-io/coldstep@v0.3.0` |
| Modes section prose (`<code>coldstep-io/coldstep@v0.2.9</code>`) | v0.2.9 | v0.3.0 |

### Why this is a separate PR

Per `RELEASE_PROCESS.md` Consumer Pin Standard, the marketing site must never advertise a tag that does not exist on GitHub Releases — visitors would copy a broken `uses:` pin. The release-train PR deliberately left `website/` at v0.2.9 so this follow-up could land *after* the tag is real on Releases.

### Test plan

- [x] `grep -n "v0.3.0" website/index.html` → both expected occurrences (quickstart YAML block + Modes prose).
- [x] `grep -n "v0.2.9" website/index.html` → no matches.
- [ ] `coldstep-pages.yml` deploys on merge to `main` and the site shows `coldstep-io/coldstep@v0.3.0` in both spots.
