### PR TITLE
fix(agent): guard dns drift watch against cancelled-context false positives

### DIFF
--- a/internal/agent/dns_drift.go
+++ b/internal/agent/dns_drift.go
@@ -68,6 +68,9 @@ func runDNSDriftWatch(
 			return
 		}
 		updated := policy.ReResolve(ctx, original, resolver, maxAttempts)
+		if ctx.Err() != nil {
+			return
+		}
 		dr := policy.Diff(original, updated)
 		if len(dr.AddedIPs) == 0 && len(dr.RemovedIPs) == 0 {
 			if onClean != nil {


### PR DESCRIPTION
## Summary

`runDNSDriftWatch` (added in #205, H16) calls `policy.ReResolve(ctx, original, resolver, maxAttempts)` and then immediately diffs the result against the original snapshot. If `ctx` is cancelled mid-resolve — for example because the agent is shutting down — `ReResolve` returns early with a partial / empty IPv4 set. Without a post-call cancellation check, the loop then runs `policy.Diff` against that truncated set, treats every original IP as "removed", and fires a false `dns_drift` event (and slog warning) on the way out instead of returning cleanly.

This adds the one-line `if ctx.Err() != nil { return }` guard immediately after the `ReResolve` call and before any diff/report logic, so a context cancellation during re-resolution is treated as a clean shutdown rather than a spurious drift signal.

## Test plan

- [ ] CI: gofmt / encoding / vet / staticcheck / unit / integration green