### PR TITLE
feat: publish coldstep-report-linux-amd64 as release asset (#219)

### DIFF
--- a/.github/pr-bodies/feat-publish-report-binary.md
+++ b/.github/pr-bodies/feat-publish-report-binary.md
@@ -1,0 +1,25 @@
+## Summary
+
+- Publish `coldstep-report-linux-amd64` as a GitHub Release asset alongside the existing `coldstep-linux-amd64`, with matching build provenance + SBOM attestations.
+- Extend `supply-chain-attest.yml`: the `coldstep-report` Go binary (already built by `scripts/build-agent-linux.sh`) is now copied, attested, uploaded to the tag's Release, and included in the `supply-chain-artifacts-*` workflow artifact.
+- Update `coldstep-demo.yml` (`detect-mode` job) with a `build-model` + `render-html` + `actions/upload-artifact` block that demos the consumer pattern: download `coldstep-report-linux-amd64` from the matching Release, then ship the rendered HTML as a clickable artifact. The new steps fail-soft (`continue-on-error`) until `COLDSTEP_AGENT_VERSION` points at a tag carrying the asset.
+- `RELEASE_PROCESS.md`: note the new asset in the section 5 / section 7 checklists (asset list + consumer sanity check).
+
+Closes #219.
+
+## Why
+
+`coldstep-report` is the post-run report pipeline (`build-model`, `assert-integrity`, `render-summary`, `render-html`, `diff`, `rdns-enrich`, `otx-enrich`, `render-ip-summary`). Before this PR it was only consumable by repos willing to clone the source and rebuild on every run — not viable for external demos. Publishing it as a Release asset turns "telemetry happened" into "open the HTML and see exactly what your CI dialed out to" for consumers like `coldstep-io/coldstep-demo`.
+
+## Notes on the release-upload step
+
+- Agent binary stays the hard requirement under immutable-release rejection (existing `::error` on missing `coldstep-linux-amd64`).
+- Report binary is best-effort under the same rejection path (new `::warning` if missing) — a stale report asset must not block the tag if the agent is already present.
+- Both binaries are passed in a single `gh release upload --clobber` so they cannot diverge across re-runs of the workflow on the same tag.
+
+## Test plan
+
+- [ ] CI 22-check sweep on this PR (gofmt, encoding, vet, unit, unit-arm64, integration, action_bundle, detect-mode, defend-mode, …). `supply-chain-attest` is tag-triggered so it does not fire on PR; YAML diff is reviewed below.
+- [ ] Inspect `supply-chain-attest.yml` diff: confirm `bin/coldstep-report` is built, attested (provenance + SBOM), included in the workflow artifact, and uploaded to the Release alongside `coldstep-linux-amd64`.
+- [ ] After merge + next `v*` tag: confirm `gh release view <tag>` lists both `coldstep-linux-amd64` and `coldstep-report-linux-amd64`.
+- [ ] After the new tag is live, bump `COLDSTEP_AGENT_VERSION` to it in the release PR and run `coldstep-demo` (`workflow_dispatch`) — verify the `coldstep-detect-html-report` artifact appears on the run.

--- a/.github/workflows/coldstep-demo.yml
+++ b/.github/workflows/coldstep-demo.yml
@@ -5,7 +5,9 @@
 # after defend. example.com is pinned to TEST-NET-1 (192.0.2.1) so curl is deterministically denied.
 #
 # Agent binary: download `coldstep-linux-amd64` from the repo GitHub Release for `COLDSTEP_AGENT_VERSION`
-# (`supply-chain-attest.yml`). Both jobs pass `release-path`; report tooling uses `build-coldstep-report-linux.sh`.
+# (`supply-chain-attest.yml`). Both jobs pass `release-path`. Report tooling is built from source via
+# `build-coldstep-report-linux.sh`; the trailing "Render HTML report" step also demos the consumer pattern
+# (download `coldstep-report-linux-amd64` from the same release — issue #219) and uploads an HTML artifact.
 
 name: coldstep-demo
 
@@ -287,6 +289,60 @@ jobs:
           retention-days: 14
           include-hidden-files: true
           overwrite: true
+
+      # Issue #219 consumer pattern demo: download coldstep-report-linux-amd64 from the same Release that
+      # publishes the agent, render an HTML report from the JSONL, upload it as a clickable artifact.
+      # Fail-soft on the download because the asset only exists for tags from v0.4.1 onward; once
+      # COLDSTEP_AGENT_VERSION points at a tag with the asset, the subsequent build-model + render-html
+      # steps activate. Until then, the warning is the only signal.
+      - name: Download coldstep-report binary from GitHub Release
+        if: always()
+        id: download-coldstep-report
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p bin-release
+          for attempt in 1 2 3; do
+            if gh release download "${COLDSTEP_AGENT_VERSION}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --pattern 'coldstep-report-linux-amd64' \
+              --dir bin-release; then
+              break
+            fi
+            if [[ "${attempt}" -eq 3 ]]; then
+              echo "::warning title=coldstep-report binary missing::coldstep-report-linux-amd64 not present on release ${COLDSTEP_AGENT_VERSION} (issue #219 ships this from v0.4.1 onward)"
+              exit 0
+            fi
+            sleep $((attempt * 5))
+          done
+          if [[ -f bin-release/coldstep-report-linux-amd64 ]]; then
+            chmod +x bin-release/coldstep-report-linux-amd64
+            echo "available=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Render HTML report from JSONL
+        if: always() && steps.download-coldstep-report.outputs.available == 'true'
+        env:
+          COLDSTEP_REPORT_CURRENT_JSONL: ${{ github.workspace }}/.coldstep-events.jsonl
+          COLDSTEP_REPORT_MODEL_OUT: ${{ github.workspace }}/.coldstep-report-model.json
+          COLDSTEP_DETECT_PROFILE: enhanced
+        run: |
+          set -euo pipefail
+          ./bin-release/coldstep-report-linux-amd64 build-model
+          COLDSTEP_REPORT_MODEL_IN="${GITHUB_WORKSPACE}/.coldstep-report-model.json" \
+          COLDSTEP_REPORT_HTML_OUT="${GITHUB_WORKSPACE}/coldstep-detect-report.html" \
+            ./bin-release/coldstep-report-linux-amd64 render-html
+
+      - name: Upload detect HTML report
+        if: always() && steps.download-coldstep-report.outputs.available == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: coldstep-detect-html-report
+          path: ${{ github.workspace }}/coldstep-detect-report.html
+          retention-days: 14
+          if-no-files-found: warn
 
       - name: List workspace Coldstep artifacts
         if: always()

--- a/.github/workflows/supply-chain-attest.yml
+++ b/.github/workflows/supply-chain-attest.yml
@@ -74,6 +74,11 @@ jobs:
         with:
           subject-path: '${{ github.workspace }}/bin/coldstep'
 
+      - name: Attest — build provenance (coldstep-report binary)
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26  # v4
+        with:
+          subject-path: '${{ github.workspace }}/bin/coldstep-report'
+
       - name: Attest — build provenance (action bundle tarball)
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26  # v4
         with:
@@ -85,14 +90,23 @@ jobs:
           subject-path: '${{ github.workspace }}/bin/coldstep'
           sbom-path: '${{ github.workspace }}/sbom-go.cdx.json'
 
+      - name: Attest — SBOM for coldstep-report binary subject
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26  # v4
+        with:
+          subject-path: '${{ github.workspace }}/bin/coldstep-report'
+          sbom-path: '${{ github.workspace }}/sbom-go.cdx.json'
+
       - name: Attest — SBOM for action bundle subject
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26  # v4
         with:
           subject-path: '${{ github.workspace }}/coldstep-action-bundle.tar.gz'
           sbom-path: '${{ github.workspace }}/sbom-action.cdx.json'
 
-      # One published binary per tag; demo workflows download this instead of compiling on every run.
+      # Published binaries per tag; demo / consumer workflows download these instead of compiling on every run.
       # Immutable releases may reject uploads: fail if coldstep-linux-amd64 is still missing (otherwise demos see "no assets to download").
+      # coldstep-report-linux-amd64 (added per issue #219) is treated as best-effort under immutable-release rejection — agent is the
+      # hard requirement; the report binary unlocks consumer render-html flows but a stale missing report asset must not block the
+      # tag if the agent is already present.
       - name: Upload Linux agent to GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
         env:
@@ -101,16 +115,22 @@ jobs:
           set -euo pipefail
           cp bin/coldstep coldstep-linux-amd64
           chmod +x coldstep-linux-amd64
+          cp bin/coldstep-report coldstep-report-linux-amd64
+          chmod +x coldstep-report-linux-amd64
           tag="${GITHUB_REF_NAME}"
           if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
             rc=0
-            out="$(gh release upload "${tag}" coldstep-linux-amd64 --repo "${GITHUB_REPOSITORY}" --clobber 2>&1)" || rc=$?
+            out="$(gh release upload "${tag}" coldstep-linux-amd64 coldstep-report-linux-amd64 --repo "${GITHUB_REPOSITORY}" --clobber 2>&1)" || rc=$?
             if [[ "$rc" -ne 0 ]]; then
               if echo "$out" | grep -qiE 'immutable release|Cannot upload assets'; then
                 has_bin="$(gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" --json assets --jq '[.assets[].name] | any(. == "coldstep-linux-amd64")' 2>/dev/null || echo false)"
                 if [[ "${has_bin}" != "true" ]]; then
                   echo "::error title=Missing coldstep-linux-amd64::Release ${tag} rejected uploads and has no coldstep-linux-amd64 asset. Delete or fix the empty/immutable release, or attach bin/coldstep as coldstep-linux-amd64 from the supply-chain-artifacts artifact, then re-run this workflow on the tag."
                   exit 1
+                fi
+                has_report="$(gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" --json assets --jq '[.assets[].name] | any(. == "coldstep-report-linux-amd64")' 2>/dev/null || echo false)"
+                if [[ "${has_report}" != "true" ]]; then
+                  echo "::warning title=Missing coldstep-report-linux-amd64::Release ${tag} rejected uploads and has no coldstep-report-linux-amd64 asset. Attach bin/coldstep-report as coldstep-report-linux-amd64 from the supply-chain-artifacts artifact, or supersede with a higher version."
                 fi
                 echo "::warning title=Skipped release binary re-upload::Release ${tag} rejected upload; coldstep-linux-amd64 already present."
                 exit 0
@@ -119,10 +139,10 @@ jobs:
               exit "$rc"
             fi
           else
-            gh release create "${tag}" coldstep-linux-amd64 \
+            gh release create "${tag}" coldstep-linux-amd64 coldstep-report-linux-amd64 \
               --repo "${GITHUB_REPOSITORY}" \
               --title "${tag}" \
-              --notes "Linux amd64 eBPF agent (ubuntu-latest). Composite action and SBOMs: see repository and workflow artifacts."
+              --notes "Linux amd64 eBPF agent and coldstep-report CLI (ubuntu-latest). Composite action and SBOMs: see repository and workflow artifacts."
           fi
 
       - name: Upload attestable artifacts
@@ -131,6 +151,7 @@ jobs:
           name: supply-chain-artifacts-${{ github.run_id }}
           path: |
             bin/coldstep
+            bin/coldstep-report
             coldstep-action-bundle.tar.gz
             sbom-go.cdx.json
             sbom-action.cdx.json

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -61,7 +61,7 @@ If **Upload Linux agent** hits **immutable Release** / **HTTP 422**, the workflo
 
 ## 5. Confirm GitHub Release
 
-- **Releases → `vX.Y.Z`** should list **`coldstep-linux-amd64`** (when upload succeeded).
+- **Releases → `vX.Y.Z`** should list **`coldstep-linux-amd64`** (when upload succeeded) and, from **v0.4.1** onward, **`coldstep-report-linux-amd64`** (issue **#219** — consumer report CLI). The agent asset is the hard requirement; the report asset is best-effort under immutable-release rejection (see workflow logs for `::warning title=Missing coldstep-report-linux-amd64`).
 - Optional notes: paste the **`CHANGELOG.md`** section for that version.
 - For a **pre-release** (soak / validation first): on the Release, check **Set as pre-release**; clear it when promoting to **Latest**.
 
@@ -72,6 +72,7 @@ If **Upload Linux agent** hits **immutable Release** / **HTTP 422**, the workflo
 ## 7. Consumer sanity check
 
 - `gh release download vX.Y.Z --repo coldstep-io/coldstep --pattern 'coldstep-linux-amd64' --dir /tmp`
+- From **v0.4.1** onward also verify the report binary is present: `gh release download vX.Y.Z --repo coldstep-io/coldstep --pattern 'coldstep-report-linux-amd64' --dir /tmp` (issue **#219**).
 - Demo workflows use **`gh release download "${COLDSTEP_AGENT_VERSION}"`** — version **must match** the tag that has the asset.
 
 ---


### PR DESCRIPTION
## Summary

- Publish `coldstep-report-linux-amd64` as a GitHub Release asset alongside the existing `coldstep-linux-amd64`, with matching build provenance + SBOM attestations.
- Extend `supply-chain-attest.yml`: the `coldstep-report` Go binary (already built by `scripts/build-agent-linux.sh`) is now copied, attested, uploaded to the tag's Release, and included in the `supply-chain-artifacts-*` workflow artifact.
- Update `coldstep-demo.yml` (`detect-mode` job) with a `build-model` + `render-html` + `actions/upload-artifact` block that demos the consumer pattern: download `coldstep-report-linux-amd64` from the matching Release, then ship the rendered HTML as a clickable artifact. The new steps fail-soft (`continue-on-error`) until `COLDSTEP_AGENT_VERSION` points at a tag carrying the asset.
- `RELEASE_PROCESS.md`: note the new asset in the section 5 / section 7 checklists (asset list + consumer sanity check).

Closes #219.

## Why

`coldstep-report` is the post-run report pipeline (`build-model`, `assert-integrity`, `render-summary`, `render-html`, `diff`, `rdns-enrich`, `otx-enrich`, `render-ip-summary`). Before this PR it was only consumable by repos willing to clone the source and rebuild on every run — not viable for external demos. Publishing it as a Release asset turns "telemetry happened" into "open the HTML and see exactly what your CI dialed out to" for consumers like `coldstep-io/coldstep-demo`.

## Notes on the release-upload step

- Agent binary stays the hard requirement under immutable-release rejection (existing `::error` on missing `coldstep-linux-amd64`).
- Report binary is best-effort under the same rejection path (new `::warning` if missing) — a stale report asset must not block the tag if the agent is already present.
- Both binaries are passed in a single `gh release upload --clobber` so they cannot diverge across re-runs of the workflow on the same tag.

## Test plan

- [ ] CI 22-check sweep on this PR (gofmt, encoding, vet, unit, unit-arm64, integration, action_bundle, detect-mode, defend-mode, …). `supply-chain-attest` is tag-triggered so it does not fire on PR; YAML diff is reviewed below.
- [ ] Inspect `supply-chain-attest.yml` diff: confirm `bin/coldstep-report` is built, attested (provenance + SBOM), included in the workflow artifact, and uploaded to the Release alongside `coldstep-linux-amd64`.
- [ ] After merge + next `v*` tag: confirm `gh release view <tag>` lists both `coldstep-linux-amd64` and `coldstep-report-linux-amd64`.
- [ ] After the new tag is live, bump `COLDSTEP_AGENT_VERSION` to it in the release PR and run `coldstep-demo` (`workflow_dispatch`) — verify the `coldstep-detect-html-report` artifact appears on the run.
