### PR TITLE
fix(report): treat empty baseline as unavailable in BuildDiff

### DIFF
--- a/.github/pr-bodies/fix-builddiff-empty-baseline.md
+++ b/.github/pr-bodies/fix-builddiff-empty-baseline.md
@@ -1,0 +1,15 @@
+## Summary
+
+- Fix `model.BuildDiff` so an empty (length-0) baseline is treated as "no comparison data," not "everything in current is brand-new traffic."
+- The previous guard checked `baseline == nil`. `model.LoadEvents` returns a non-nil empty slice (`make([]Event, 0, 64)`) when the baseline JSONL file exists but is empty or contains no parseable events — that path slipped past the nil-check and flagged every current egress fingerprint as `traffic_new`.
+- Pin the behaviour with `TestDiffWithEmptyNonNilBaselineReportsUnavailable`: a non-nil empty `[]Event{}` baseline must return `status="unavailable"`, `reason="no_baseline_provided"`, and zero `traffic_new` / `traffic_gone` / `traffic_changed` entries.
+
+## Why
+
+Bug #1 from the post-v0.4.0 bug hunt. Symptom in the wild: a workflow with a malformed or empty baseline JSONL produces a diff section that screams "100% of egress is new" even though the runs are identical, which is exactly the opposite of what an unavailable baseline should mean — and would noisily defeat any downstream diff-based gating.
+
+## Test plan
+
+- [ ] `go test ./internal/report/model/... -count=1` — includes the new regression test alongside the existing `TestDiffWithoutBaselineReportsUnavailable` and `TestDiffWithBaselineIncludesNewGoneChangedAndIndicators`
+- [ ] `bash scripts/check-gofmt.sh`
+- [ ] CI sweep on Linux (gofmt, encoding, vet, unit, unit-arm64, integration, action_bundle, detect-mode, defend-mode)

--- a/internal/report/model/builders.go
+++ b/internal/report/model/builders.go
@@ -187,7 +187,10 @@ func BuildEgressSankey(events []Event) []SankeyEdge {
 }
 
 func BuildDiff(current []Event, baseline []Event) DiffPayload {
-	if baseline == nil {
+	// An empty (or nil) baseline is "no comparison data," not "everything in
+	// current is new" — LoadEvents returns a non-nil empty slice for an empty
+	// or unparseable JSONL file, so guard on length rather than nil-ness.
+	if len(baseline) == 0 {
 		return DiffPayload{
 			Status:         "unavailable",
 			Reason:         "no_baseline_provided",

--- a/internal/report/model/builders_test.go
+++ b/internal/report/model/builders_test.go
@@ -90,6 +90,34 @@ func TestDiffWithoutBaselineReportsUnavailable(t *testing.T) {
 	}
 }
 
+// Regression: a non-nil but empty baseline (e.g. LoadEvents on an empty
+// JSONL file returns []Event{}, not nil) must report unavailable instead of
+// marking every current event as "new" traffic.
+func TestDiffWithEmptyNonNilBaselineReportsUnavailable(t *testing.T) {
+	current := []Event{
+		{"type": "tcp", "fqdn": "example.com", "dst": "1.1.1.1"},
+		{"type": "tls", "fqdn": "example.org", "dst": "2.2.2.2"},
+	}
+	baseline := []Event{} // non-nil, length 0
+
+	d := BuildDiff(current, baseline)
+	if d.Status != "unavailable" {
+		t.Errorf("diff.status = %q; want unavailable", d.Status)
+	}
+	if d.Reason != "no_baseline_provided" {
+		t.Errorf("diff.reason = %q; want no_baseline_provided", d.Reason)
+	}
+	if len(d.TrafficNew) != 0 {
+		t.Errorf("traffic_new = %d entries; want 0 for empty baseline", len(d.TrafficNew))
+	}
+	if len(d.TrafficGone) != 0 {
+		t.Errorf("traffic_gone = %d entries; want 0 for empty baseline", len(d.TrafficGone))
+	}
+	if len(d.TrafficChanged) != 0 {
+		t.Errorf("traffic_changed = %d entries; want 0 for empty baseline", len(d.TrafficChanged))
+	}
+}
+
 func TestDiffWithBaselineIncludesNewGoneChangedAndIndicators(t *testing.T) {
 	current := []Event{
 		{"type": "tcp", "fqdn": "new.example", "dst": "1.1.1.1"},


### PR DESCRIPTION
## Summary

- Fix `model.BuildDiff` so an empty (length-0) baseline is treated as "no comparison data," not "everything in current is brand-new traffic."
- The previous guard checked `baseline == nil`. `model.LoadEvents` returns a non-nil empty slice (`make([]Event, 0, 64)`) when the baseline JSONL file exists but is empty or contains no parseable events — that path slipped past the nil-check and flagged every current egress fingerprint as `traffic_new`.
- Pin the behaviour with `TestDiffWithEmptyNonNilBaselineReportsUnavailable`: a non-nil empty `[]Event{}` baseline must return `status="unavailable"`, `reason="no_baseline_provided"`, and zero `traffic_new` / `traffic_gone` / `traffic_changed` entries.

## Why

Bug #1 from the post-v0.4.0 bug hunt. Symptom in the wild: a workflow with a malformed or empty baseline JSONL produces a diff section that screams "100% of egress is new" even though the runs are identical, which is exactly the opposite of what an unavailable baseline should mean — and would noisily defeat any downstream diff-based gating.

## Test plan

- [ ] `go test ./internal/report/model/... -count=1` — includes the new regression test alongside the existing `TestDiffWithoutBaselineReportsUnavailable` and `TestDiffWithBaselineIncludesNewGoneChangedAndIndicators`
- [ ] `bash scripts/check-gofmt.sh`
- [ ] CI sweep on Linux (gofmt, encoding, vet, unit, unit-arm64, integration, action_bundle, detect-mode, defend-mode)
