### PR TITLE
fix(action): poll agent exit instead of fixed 400ms sleep in runStop

### DIFF
--- a/.github/pr-bodies/fix-runstop-pidalive-poll.md
+++ b/.github/pr-bodies/fix-runstop-pidalive-poll.md
@@ -1,0 +1,15 @@
+## Summary
+
+- Replace the fixed 400ms sleep after `SIGTERM` in `runStop` (`cmd/coldstep-action/main.go`) with a `pidAlive` poll loop: tick every 100ms, time out after 10s.
+- Add a `waitForAgentExit(pid, timeout, tick) bool` helper that logs the exit verdict — `"agent pid=N exited cleanly after Tms"` vs. `"agent pid=N still alive after 10s; proceeding with digest read anyway"` — so post-step output distinguishes a clean drain from a hung agent.
+- Add three unit tests (`TestWaitForAgentExit_*`) covering the fast-exit, timeout, and bad-input branches. The timeout test lives in a new `main_linux_test.go` because `Signal(0)` against the current PID is portable liveness only on Linux.
+
+## Why
+
+Bug #8 from the post-v0.4.0 bug hunt. Symptom: on defend-mode runs the agent's shutdown drain (BPF ringbuf flush + digest write) regularly exceeded the hard-coded 400ms window, and `runStop` would race ahead to read `.coldstep-detect.md` while the file was still being written — surfacing truncated digests in the Job Summary and PR comment. The 10s upper bound matches the existing defend-mode drain budget (the integration tests' `10*time.Second` deadlines and the LSM ringbuf reader's shutdown window), so we wait long enough on slow runners without hanging forever on a stuck agent.
+
+## Test plan
+
+- [ ] `go test ./cmd/coldstep-action/... -count=1` — including the new `TestWaitForAgentExit_*` cases
+- [ ] `bash scripts/check-gofmt.sh`
+- [ ] CI sweep on Linux (gofmt, encoding, vet, staticcheck, unit, unit-arm64, integration, action_bundle, detect-mode, defend-mode)

--- a/cmd/coldstep-action/main.go
+++ b/cmd/coldstep-action/main.go
@@ -367,9 +367,15 @@ func runStop(cfg stopConfig) error {
 			if p, perr := os.FindProcess(pid); perr == nil {
 				_ = p.Signal(syscall.SIGTERM)
 			}
+			// Poll for the agent to exit instead of using a fixed sleep. The
+			// previous 400ms hard sleep was shorter than the agent's actual
+			// shutdown drain on defend-mode runs (BPF ringbuf flush + digest
+			// write), producing truncated `.coldstep-detect.md` files. The 10s
+			// upper bound matches the defend-mode drain budget so we wait long
+			// enough on slow runners without hanging forever on a stuck agent.
+			waitForAgentExit(pid, 10*time.Second, 100*time.Millisecond)
 		}
 	}
-	time.Sleep(400 * time.Millisecond)
 
 	body := ""
 	if raw, err := os.ReadFile(detectLog); err == nil {
@@ -592,6 +598,29 @@ func pidAlive(pid int) bool {
 	}
 	err = p.Signal(syscall.Signal(0))
 	return err == nil
+}
+
+// waitForAgentExit polls pidAlive at the given tick until the agent process
+// is gone or the timeout elapses. Emits one stderr line either way so logs
+// distinguish a clean drain from a hung agent. Returns true when the agent
+// exited within the budget.
+func waitForAgentExit(pid int, timeout, tick time.Duration) bool {
+	if pid <= 0 || timeout <= 0 || tick <= 0 {
+		return false
+	}
+	start := time.Now()
+	deadline := start.Add(timeout)
+	for {
+		if !pidAlive(pid) {
+			fmt.Fprintf(os.Stderr, "coldstep: agent pid=%d exited cleanly after %s\n", pid, time.Since(start).Round(time.Millisecond))
+			return true
+		}
+		if !time.Now().Before(deadline) {
+			fmt.Fprintf(os.Stderr, "coldstep: agent pid=%d still alive after %s; proceeding with digest read anyway\n", pid, timeout)
+			return false
+		}
+		time.Sleep(tick)
+	}
 }
 
 func sanitizeDigestForMarkdown(body string) string {

--- a/cmd/coldstep-action/main_linux_test.go
+++ b/cmd/coldstep-action/main_linux_test.go
@@ -1,0 +1,28 @@
+//go:build linux
+
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// On Linux, sending signal 0 to the current process succeeds, so pidAlive(self)
+// is true. That lets us exercise the timeout branch of waitForAgentExit
+// deterministically. The equivalent behaviour on Windows differs (Signal(0) is
+// not a portable liveness probe), so this test stays Linux-only — the
+// production path it covers runs only inside the action on GitHub-hosted
+// Linux runners.
+func TestWaitForAgentExit_ReturnsFalseOnTimeout(t *testing.T) {
+	self := os.Getpid()
+	start := time.Now()
+	ok := waitForAgentExit(self, 150*time.Millisecond, 30*time.Millisecond)
+	elapsed := time.Since(start)
+	if ok {
+		t.Fatalf("waitForAgentExit(selfPID) = true; want false (self is alive)")
+	}
+	if elapsed < 100*time.Millisecond {
+		t.Errorf("waitForAgentExit returned too early: %s", elapsed)
+	}
+}

--- a/cmd/coldstep-action/main_test.go
+++ b/cmd/coldstep-action/main_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSanitizeDigestForMarkdown_BOM(t *testing.T) {
@@ -333,5 +334,34 @@ func TestClassifyReadyStatus(t *testing.T) {
 			t.Fatalf("classifyReadyStatus(%q) = (%v,%v,%v,%v) want (%v,%v,%v,%v)",
 				tc.raw, r, f, m, i, tc.wantReady, tc.wantFail, tc.wantMal, tc.wantInc)
 		}
+	}
+}
+
+// Bug #8: replace the fixed 400ms post-SIGTERM sleep with a poll loop that
+// waits up to the timeout for the agent to exit.
+func TestWaitForAgentExit_ReturnsTrueWhenPidGone(t *testing.T) {
+	// PID 0 (and negative pids) cannot be alive; the helper short-circuits to
+	// false. Use a fake high pid that is overwhelmingly unlikely to be in use.
+	const fakePID = 0x6ff7c001
+	start := time.Now()
+	ok := waitForAgentExit(fakePID, 1*time.Second, 10*time.Millisecond)
+	elapsed := time.Since(start)
+	if !ok {
+		t.Fatalf("waitForAgentExit(fakePID) = false; want true (pid not in use)")
+	}
+	if elapsed >= 250*time.Millisecond {
+		t.Errorf("waitForAgentExit took %s; expected <250ms for a dead pid", elapsed)
+	}
+}
+
+func TestWaitForAgentExit_RejectsZeroAndNegative(t *testing.T) {
+	if waitForAgentExit(0, time.Second, 10*time.Millisecond) {
+		t.Errorf("waitForAgentExit(0) = true; want false")
+	}
+	if waitForAgentExit(-1, time.Second, 10*time.Millisecond) {
+		t.Errorf("waitForAgentExit(-1) = true; want false")
+	}
+	if waitForAgentExit(1234, 0, 10*time.Millisecond) {
+		t.Errorf("waitForAgentExit(timeout=0) = true; want false")
 	}
 }


### PR DESCRIPTION
## Summary

- Replace the fixed 400ms sleep after `SIGTERM` in `runStop` (`cmd/coldstep-action/main.go`) with a `pidAlive` poll loop: tick every 100ms, time out after 10s.
- Add a `waitForAgentExit(pid, timeout, tick) bool` helper that logs the exit verdict — `"agent pid=N exited cleanly after Tms"` vs. `"agent pid=N still alive after 10s; proceeding with digest read anyway"` — so post-step output distinguishes a clean drain from a hung agent.
- Add three unit tests (`TestWaitForAgentExit_*`) covering the fast-exit, timeout, and bad-input branches. The timeout test lives in a new `main_linux_test.go` because `Signal(0)` against the current PID is portable liveness only on Linux.

## Why

Bug #8 from the post-v0.4.0 bug hunt. Symptom: on defend-mode runs the agent's shutdown drain (BPF ringbuf flush + digest write) regularly exceeded the hard-coded 400ms window, and `runStop` would race ahead to read `.coldstep-detect.md` while the file was still being written — surfacing truncated digests in the Job Summary and PR comment. The 10s upper bound matches the existing defend-mode drain budget (the integration tests' `10*time.Second` deadlines and the LSM ringbuf reader's shutdown window), so we wait long enough on slow runners without hanging forever on a stuck agent.

## Test plan

- [ ] `go test ./cmd/coldstep-action/... -count=1` — including the new `TestWaitForAgentExit_*` cases
- [ ] `bash scripts/check-gofmt.sh`
- [ ] CI sweep on Linux (gofmt, encoding, vet, staticcheck, unit, unit-arm64, integration, action_bundle, detect-mode, defend-mode)
