### PR TITLE
fix(defend): fall back to cgroup-only on non-sendpage LSM load failure

### DIFF
--- a/.github/pr-bodies/fix-defend-lsm-load-fallback.md
+++ b/.github/pr-bodies/fix-defend-lsm-load-fallback.md
@@ -1,0 +1,21 @@
+## Summary
+
+- When `prog_load` rejects the LSM section of the defend collection for any reason **other than** the kernel-6.5+ `lsm_socket_sendpage` removal (which is already handled), `LoadDefendObjectsForKernel` now strips every LSM program + LSM-only map and reloads the cgroup-only collection — instead of bubbling the error up and disabling defend entirely.
+- Surface the degradation via a new `defend.LoadResult{LSMFellBack, LSMFallbackErr}` return value. The agent caller in `internal/agent/agent_linux.go` consumes it, flips local `haveLSM` to false so the LSM attach block is skipped, and emits a `lsm_load_failed_fallback_cgroup` `BPFStatus` row carrying the original `prog_load` error in `Detail`.
+- Factor the LSM strip into a shared `stripAllLSM(*ebpf.CollectionSpec)` helper used by both the initial `wantLSM=false` path and the new fallback retry, so the two stay in sync.
+- Update the function's caller-contract comment with the new return shape and what the caller MUST do on `LSMFellBack=true`.
+- Pin behaviour with two unit tests in `internal/bpf/defend/loader_test.go`: `TestStripAllLSM` (every LSM section gone, cgroup/shared sections intact) and `TestLoadResultZeroValueSafe` (caller-visible zero-value invariants).
+
+## Why
+
+Bug #2 from the post-v0.4.0 bug hunt. The pre-existing code only retried after a sendpage-specific `prog_load` rejection. Any other LSM-related failure — `CONFIG_BPF_LSM` absent despite `features.HaveProgramType(ebpf.LSM)` returning ok, kernel `lsm=` boot chain without `bpf`, BTF mismatch on `socket_connect` / `socket_sendmsg`, etc. — propagated to the caller and aborted defend mode. The cgroup `connect4` / `sendmsg4` hooks are independent of LSM, so losing LSM should degrade the backend to `defend+cgroup`, not the whole agent.
+
+Pairs with bug #3 (downgrade the backend label when LSM attaches but never fires) — together they make the LSM path opportunistic rather than load-bearing for defend mode.
+
+## Test plan
+
+- [ ] `go test ./internal/bpf/defend/... -count=1` on Linux — including the new `TestStripAllLSM` and `TestLoadResultZeroValueSafe`
+- [ ] `go test ./internal/agent/... -count=1` — caller-side compilation + non-defend tests stay green
+- [ ] `go build ./...` — caller in `agent_linux.go` consumes the new return signature
+- [ ] `bash scripts/check-gofmt.sh`
+- [ ] CI sweep on Linux (gofmt, encoding, vet, staticcheck, unit, unit-arm64, integration, action_bundle, detect-mode, defend-mode) — the defend-mode job is the one that actually exercises `prog_load` against the running kernel

--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -263,8 +263,31 @@ func Run(ctx context.Context, cfg config.Config) error {
 		// Phase 2.3: cgroup + LSM share one bpf2go object. The loader strips
 		// LSM programs (and their dedicated maps) from the spec when the
 		// kernel lacks CONFIG_BPF_LSM so prog_load doesn't fail.
-		if err := defend.LoadDefendObjectsForKernel(&defendObjs, haveLSM, haveIOUringLSM); err != nil {
+		//
+		// Bug #2: when prog_load rejects LSM for a non-sendpage reason
+		// (e.g. CONFIG_BPF_LSM absent despite the feature probe succeeding,
+		// `lsm=` boot chain without bpf), the loader silently strips every
+		// LSM section and reloads cgroup-only. Honour the LSMFellBack
+		// signal here: pretend the kernel never claimed LSM support so we
+		// skip the LSM attach block, and record the degradation as a
+		// BPFStatus row for the digest.
+		loadResult, err := defend.LoadDefendObjectsForKernel(&defendObjs, haveLSM, haveIOUringLSM)
+		if err != nil {
 			return fmt.Errorf("load defend bpf objects: %w", err)
+		}
+		if loadResult.LSMFellBack {
+			haveLSM = false
+			detail := "lsm prog_load failed; reloaded cgroup-only defend collection"
+			if loadResult.LSMFallbackErr != nil {
+				detail = fmt.Sprintf("%s: %v", detail, loadResult.LSMFallbackErr)
+			}
+			bpfSt = append(bpfSt, telemetry.BPFStatus{
+				Name:   "lsm_load_failed_fallback_cgroup",
+				OK:     false,
+				Detail: detail,
+			})
+			slog.Warn("defend: lsm prog_load failed; continuing with cgroup-only enforcement",
+				"err", loadResult.LSMFallbackErr)
 		}
 		hasDefend = true
 		defer func() {

--- a/internal/bpf/defend/loader.go
+++ b/internal/bpf/defend/loader.go
@@ -10,6 +10,25 @@ import (
 	"github.com/cilium/ebpf/btf"
 )
 
+// LoadResult carries non-error outcomes from LoadDefendObjectsForKernel that
+// the caller needs to surface in telemetry — primarily that wantLSM=true was
+// requested but the LSM section had to be stripped after a prog_load failure
+// so the cgroup-only path could still load.
+type LoadResult struct {
+	// LSMFellBack is true when wantLSM=true was requested but prog_load
+	// rejected the LSM section for a reason other than the kernel-6.5+
+	// socket_sendpage removal (which is handled silently), so the loader
+	// stripped all LSM programs and reloaded the cgroup-only collection.
+	// Callers should set their local haveLSM bool to false in this case,
+	// skip LSM attach, and emit a `lsm_load_failed_fallback_cgroup`
+	// BPFStatus row so the digest records the degraded posture.
+	LSMFellBack bool
+
+	// LSMFallbackErr is the original prog_load error that triggered the
+	// fallback. Empty when LSMFellBack is false.
+	LSMFallbackErr error
+}
+
 // LoadDefendObjectsForKernel populates obj with the cgroup defend programs
 // + shared/cgroup maps unconditionally, plus the LSM programs + LSM-only
 // maps when wantLSM is true.
@@ -25,29 +44,23 @@ import (
 // other LSM hooks still load. Callers should compute wantIOUringLSM via
 // HaveIOUringLSM().
 //
+// Return contract: a nil error means obj is populated and ready to be
+// closed by the caller. The returned LoadResult reports whether the LSM
+// section had to be stripped after a prog_load failure (LSMFellBack); when
+// true, the caller MUST treat haveLSM as false (do not attempt LSM attach)
+// and emit a `lsm_load_failed_fallback_cgroup` BPFStatus row. A non-nil
+// error means obj is untouched and the cgroup-only fallback could not be
+// constructed either — defend cannot start.
+//
 // Caller is responsible for closing obj on shutdown.
-func LoadDefendObjectsForKernel(obj *DefendObjects, wantLSM, wantIOUringLSM bool) error {
+func LoadDefendObjectsForKernel(obj *DefendObjects, wantLSM, wantIOUringLSM bool) (LoadResult, error) {
 	spec, err := LoadDefend()
 	if err != nil {
-		return err
+		return LoadResult{}, err
 	}
 
 	if !wantLSM {
-		delete(spec.Programs, "lsm_socket_connect")
-		delete(spec.Programs, "lsm_socket_sendmsg")
-		// lsm_socket_sendpage closes the sendfile/splice gap (kernel 5.15);
-		// the program is only present after the BPF stubs have been
-		// regenerated on Linux with the new SEC, hence the silent delete.
-		delete(spec.Programs, "lsm_socket_sendpage")
-		delete(spec.Programs, "lsm_io_uring_cmd")
-		delete(spec.Maps, "lsm_deny_events")
-		delete(spec.Maps, "lsm_deny_reserve_failures")
-		delete(spec.Maps, "lsm_defend_cfg")
-		delete(spec.Maps, "lsm_allowed_ipv4")
-		delete(spec.Maps, "lsm_ignored_ipv4_lpm")
-		// sendpage_observed lives in the LSM section; strip it when LSM is
-		// disabled so we don't pin a per-cpu counter nobody reads.
-		delete(spec.Maps, "sendpage_observed")
+		stripAllLSM(spec)
 	} else {
 		if !kernelHasLSMHook("socket_sendpage") {
 			// Kernel 6.5+ removed the socket_sendpage LSM hook (proto_ops
@@ -71,6 +84,7 @@ func LoadDefendObjectsForKernel(obj *DefendObjects, wantLSM, wantIOUringLSM bool
 		}
 	}
 
+	result := LoadResult{}
 	coll, err := ebpf.NewCollection(spec)
 	if err != nil {
 		// Defensive fallback: BTF lookup may have succeeded but prog_load
@@ -80,14 +94,34 @@ func LoadDefendObjectsForKernel(obj *DefendObjects, wantLSM, wantIOUringLSM bool
 		if wantLSM && isSendpageLoadFailure(err) {
 			spec2, err2 := LoadDefend()
 			if err2 != nil {
-				return err2
+				return LoadResult{}, err2
 			}
 			delete(spec2.Programs, "lsm_socket_sendpage")
 			delete(spec2.Maps, "sendpage_observed")
 			coll, err = ebpf.NewCollection(spec2)
+		} else if wantLSM {
+			// Non-sendpage LSM load failure (e.g. CONFIG_BPF_LSM absent
+			// despite features.HaveProgramType(ebpf.LSM) returning ok,
+			// `lsm=` boot chain without bpf, BTF mismatch on one of the
+			// other LSM hooks). Before this fallback, any such failure
+			// killed the whole defend collection and forced detect-mode-
+			// only operation, even though the cgroup path is independent.
+			// Strip every LSM section and reload — the cgroup connect4 /
+			// sendmsg4 enforcement still works.
+			origLoadErr := err
+			spec2, err2 := LoadDefend()
+			if err2 != nil {
+				return LoadResult{}, err2
+			}
+			stripAllLSM(spec2)
+			coll, err = ebpf.NewCollection(spec2)
+			if err == nil {
+				result.LSMFellBack = true
+				result.LSMFallbackErr = origLoadErr
+			}
 		}
 		if err != nil {
-			return err
+			return LoadResult{}, err
 		}
 	}
 	success := false
@@ -106,7 +140,7 @@ func LoadDefendObjectsForKernel(obj *DefendObjects, wantLSM, wantIOUringLSM bool
 	}
 	for _, p := range cgPrograms {
 		if err := detachProgram(coll, p.name, p.dst); err != nil {
-			return err
+			return LoadResult{}, err
 		}
 	}
 
@@ -141,7 +175,7 @@ func LoadDefendObjectsForKernel(obj *DefendObjects, wantLSM, wantIOUringLSM bool
 	}
 	for _, m := range cgAndSharedMaps {
 		if err := detachMap(coll, m.name, m.dst); err != nil {
-			return err
+			return LoadResult{}, err
 		}
 	}
 
@@ -172,7 +206,11 @@ func LoadDefendObjectsForKernel(obj *DefendObjects, wantLSM, wantIOUringLSM bool
 	// allowed_ipv6 map.
 	detachMapIfPresent(coll, "allowed_ipv6", &obj.AllowedIpv6)
 
-	if wantLSM {
+	// LSM section: present only when wantLSM was requested AND the fallback
+	// reload did not strip it. After a fallback, every LSM program/map was
+	// removed from the spec before NewCollection, so detachProgram would
+	// fail with "missing program" — skip the whole block.
+	if wantLSM && !result.LSMFellBack {
 		lsmPrograms := []struct {
 			name string
 			dst  **ebpf.Program
@@ -182,12 +220,12 @@ func LoadDefendObjectsForKernel(obj *DefendObjects, wantLSM, wantIOUringLSM bool
 		}
 		for _, p := range lsmPrograms {
 			if err := detachProgram(coll, p.name, p.dst); err != nil {
-				return err
+				return LoadResult{}, err
 			}
 		}
 		if wantIOUringLSM {
 			if err := detachProgram(coll, "lsm_io_uring_cmd", &obj.LsmIoUringCmd); err != nil {
-				return err
+				return LoadResult{}, err
 			}
 		}
 		lsmMaps := []struct {
@@ -202,7 +240,7 @@ func LoadDefendObjectsForKernel(obj *DefendObjects, wantLSM, wantIOUringLSM bool
 		}
 		for _, m := range lsmMaps {
 			if err := detachMap(coll, m.name, m.dst); err != nil {
-				return err
+				return LoadResult{}, err
 			}
 		}
 
@@ -218,7 +256,29 @@ func LoadDefendObjectsForKernel(obj *DefendObjects, wantLSM, wantIOUringLSM bool
 	}
 
 	success = true
-	return nil
+	return result, nil
+}
+
+// stripAllLSM removes every LSM program and LSM-only map from the spec so
+// the resulting collection loads on kernels without CONFIG_BPF_LSM (or with
+// `lsm=` boot chains that omit bpf). Shared between the wantLSM=false
+// initial path and the wantLSM=true post-load fallback.
+func stripAllLSM(spec *ebpf.CollectionSpec) {
+	delete(spec.Programs, "lsm_socket_connect")
+	delete(spec.Programs, "lsm_socket_sendmsg")
+	// lsm_socket_sendpage closes the sendfile/splice gap (kernel 5.15);
+	// the program is only present after the BPF stubs have been
+	// regenerated on Linux with the new SEC, hence the silent delete.
+	delete(spec.Programs, "lsm_socket_sendpage")
+	delete(spec.Programs, "lsm_io_uring_cmd")
+	delete(spec.Maps, "lsm_deny_events")
+	delete(spec.Maps, "lsm_deny_reserve_failures")
+	delete(spec.Maps, "lsm_defend_cfg")
+	delete(spec.Maps, "lsm_allowed_ipv4")
+	delete(spec.Maps, "lsm_ignored_ipv4_lpm")
+	// sendpage_observed lives in the LSM section; strip it when LSM is
+	// disabled so we don't pin a per-cpu counter nobody reads.
+	delete(spec.Maps, "sendpage_observed")
 }
 
 // HaveIOUringLSM reports whether the running kernel exposes the

--- a/internal/bpf/defend/loader_test.go
+++ b/internal/bpf/defend/loader_test.go
@@ -3,6 +3,7 @@
 package defend
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -50,6 +51,70 @@ func TestDefendSpecStripsIOUringLSMWithoutLSM(t *testing.T) {
 		if _, present := spec.Programs[name]; !present {
 			t.Fatalf("expected %q to remain in spec.Programs after LSM strip", name)
 		}
+	}
+}
+
+// TestStripAllLSM verifies the shared helper used by both the wantLSM=false
+// initial path and the wantLSM=true post-load fallback removes every LSM
+// program + LSM-only map while leaving cgroup and shared sections intact.
+func TestStripAllLSM(t *testing.T) {
+	spec, err := LoadDefend()
+	if err != nil {
+		t.Fatalf("LoadDefend: %v", err)
+	}
+	stripAllLSM(spec)
+
+	mustBeGone := []string{
+		"lsm_socket_connect",
+		"lsm_socket_sendmsg",
+		"lsm_socket_sendpage",
+		"lsm_io_uring_cmd",
+	}
+	for _, name := range mustBeGone {
+		if _, present := spec.Programs[name]; present {
+			t.Errorf("stripAllLSM: program %q still present", name)
+		}
+	}
+	mustBeGoneMaps := []string{
+		"lsm_deny_events",
+		"lsm_deny_reserve_failures",
+		"lsm_defend_cfg",
+		"lsm_allowed_ipv4",
+		"lsm_ignored_ipv4_lpm",
+		"sendpage_observed",
+	}
+	for _, name := range mustBeGoneMaps {
+		if _, present := spec.Maps[name]; present {
+			t.Errorf("stripAllLSM: map %q still present", name)
+		}
+	}
+	for _, name := range []string{"defend_connect4", "defend_sendmsg4"} {
+		if _, present := spec.Programs[name]; !present {
+			t.Errorf("stripAllLSM: cgroup program %q must remain", name)
+		}
+	}
+	for _, name := range []string{"deny_events", "deny_reserve_failures", "defend_cfg", "allowed_ipv4"} {
+		if _, present := spec.Maps[name]; !present {
+			t.Errorf("stripAllLSM: shared/cgroup map %q must remain", name)
+		}
+	}
+}
+
+// TestLoadResultZeroValueSafe pins the public contract that callers can
+// read a zero-value LoadResult without panicking — the caller branch in
+// agent_linux.go relies on LSMFellBack defaulting to false and FallbackErr
+// being a nil error on the happy path.
+func TestLoadResultZeroValueSafe(t *testing.T) {
+	var r LoadResult
+	if r.LSMFellBack {
+		t.Errorf("zero LoadResult.LSMFellBack = true; want false")
+	}
+	if r.LSMFallbackErr != nil {
+		t.Errorf("zero LoadResult.LSMFallbackErr != nil; want nil")
+	}
+	// errors.Is on a nil error must be safe.
+	if errors.Is(r.LSMFallbackErr, errors.New("any")) {
+		t.Errorf("errors.Is(nil, _) returned true unexpectedly")
 	}
 }
 


### PR DESCRIPTION
## Summary

- When `prog_load` rejects the LSM section of the defend collection for any reason **other than** the kernel-6.5+ `lsm_socket_sendpage` removal (which is already handled), `LoadDefendObjectsForKernel` now strips every LSM program + LSM-only map and reloads the cgroup-only collection — instead of bubbling the error up and disabling defend entirely.
- Surface the degradation via a new `defend.LoadResult{LSMFellBack, LSMFallbackErr}` return value. The agent caller in `internal/agent/agent_linux.go` consumes it, flips local `haveLSM` to false so the LSM attach block is skipped, and emits a `lsm_load_failed_fallback_cgroup` `BPFStatus` row carrying the original `prog_load` error in `Detail`.
- Factor the LSM strip into a shared `stripAllLSM(*ebpf.CollectionSpec)` helper used by both the initial `wantLSM=false` path and the new fallback retry, so the two stay in sync.
- Update the function's caller-contract comment with the new return shape and what the caller MUST do on `LSMFellBack=true`.
- Pin behaviour with two unit tests in `internal/bpf/defend/loader_test.go`: `TestStripAllLSM` (every LSM section gone, cgroup/shared sections intact) and `TestLoadResultZeroValueSafe` (caller-visible zero-value invariants).

## Why

Bug #2 from the post-v0.4.0 bug hunt. The pre-existing code only retried after a sendpage-specific `prog_load` rejection. Any other LSM-related failure — `CONFIG_BPF_LSM` absent despite `features.HaveProgramType(ebpf.LSM)` returning ok, kernel `lsm=` boot chain without `bpf`, BTF mismatch on `socket_connect` / `socket_sendmsg`, etc. — propagated to the caller and aborted defend mode. The cgroup `connect4` / `sendmsg4` hooks are independent of LSM, so losing LSM should degrade the backend to `defend+cgroup`, not the whole agent.

Pairs with bug #3 (downgrade the backend label when LSM attaches but never fires) — together they make the LSM path opportunistic rather than load-bearing for defend mode.

## Test plan

- [ ] `go test ./internal/bpf/defend/... -count=1` on Linux — including the new `TestStripAllLSM` and `TestLoadResultZeroValueSafe`
- [ ] `go test ./internal/agent/... -count=1` — caller-side compilation + non-defend tests stay green
- [ ] `go build ./...` — caller in `agent_linux.go` consumes the new return signature
- [ ] `bash scripts/check-gofmt.sh`
- [ ] CI sweep on Linux (gofmt, encoding, vet, staticcheck, unit, unit-arm64, integration, action_bundle, detect-mode, defend-mode) — the defend-mode job is the one that actually exercises `prog_load` against the running kernel
