### PR TITLE
fix(defend): downgrade defend+lsm label when LSM hooks attach but stay silent

### DIFF
--- a/.github/pr-bodies/fix-defend-lsm-silent-downgrade.md
+++ b/.github/pr-bodies/fix-defend-lsm-silent-downgrade.md
@@ -1,0 +1,21 @@
+## Summary
+
+- After the cgroup `connect4` probe confirms the cgroup hook is enforcing, run the same dial-loop-and-drain pattern against the LSM deny ringbuf (`probeLSMSilent` in `internal/agent/agent_linux_probe.go`). If no matching deny event arrives within `lsmProbeTimeout` (1500ms), the LSM programs are attached but the kernel never invokes them.
+- When silent, downgrade `defendState.mode` from `defend+lsm` to `defend+cgroup` via a new `defendState.downgradeMode(mode)` accessor and emit an `lsm_attached_but_silent` `BPFStatus` row with the Ubuntu 24.04 `lsm=` boot chain hint in `Detail`.
+- The LSM ringbuf reader stays alive for any events that may still fire — we just stop *claiming* LSM defense in the digest when it's observably absent.
+- Document the Ubuntu 24.04 default `lsm=lockdown,yama,apparmor` situation (no `bpf` token in the boot chain) in code comments on both the probe helper and the call site.
+- Pin behaviour with two unit tests: `TestProbeLSMSilent_NilReaderReturnsSilent` (nil reader short-circuits to silent) and `TestDefendStateDowngradeModePreservesAllowlistCounters` (the downgrade must not clobber allowlist sizes captured by `setModeAndAllowlist`).
+
+## Why
+
+Bug #3 from the post-v0.4.0 bug hunt. Symptom: digests on Ubuntu 24.04 runners advertised `defend+lsm` even though `security_socket_connect` never dispatched to `lsm/socket_connect`, because the default boot chain (`lsm=lockdown,yama,apparmor`) omits the `bpf` token. AttachLSM returns success, the program loads, and BPFStatus shows OK — but enforcement is actually 100% cgroup. The digest was misleading users and CI gates into thinking LSM was contributing to defense.
+
+Pairs with bug #2 (fall back to cgroup-only on non-sendpage LSM load failure). Together they make the LSM path opportunistic rather than load-bearing: the agent advertises LSM defense only when it actually fires, and never refuses to start because LSM is missing or silent.
+
+## Test plan
+
+- [ ] `go test ./internal/agent/... -count=1` on Linux — including the new `TestProbeLSMSilent_NilReaderReturnsSilent` and `TestDefendStateDowngradeModePreservesAllowlistCounters`
+- [ ] `go build ./...` — clean cross-package compile
+- [ ] `bash scripts/check-gofmt.sh`
+- [ ] `bash scripts/check-encoding.sh`
+- [ ] CI sweep on Linux (gofmt, encoding, vet, staticcheck, unit, unit-arm64, integration, action_bundle, detect-mode, defend-mode) — the defend-mode job exercises the post-attach probe against a real kernel; on `ubuntu-latest` (24.04) we expect the new `lsm_attached_but_silent` row to surface in the telemetry artifact

--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -489,6 +489,28 @@ func Run(ctx context.Context, cfg config.Config) error {
 			_ = writeAgentStatus(cfg.AgentStatusPath, false)
 			return fmt.Errorf("defend mode requires confirmed cgroup BPF enforcement: %w", err)
 		}
+
+		// Bug #3: AttachLSM can succeed but the kernel may still never invoke
+		// our LSM programs — Ubuntu 24.04 ships with `lsm=lockdown,yama,apparmor`
+		// by default (no `bpf` token), in which case `security_socket_connect`
+		// loads + attaches without ever dispatching. Cgroup probe just confirmed
+		// cgroup is firing; run the same dial-loop-and-drain pattern against the
+		// LSM ringbuf, and downgrade the backend label from `defend+lsm` to
+		// `defend+cgroup` when no LSM events arrive. The LSM ringbuf reader stays
+		// alive for any events that may yet fire — we just stop *claiming* LSM
+		// defense in the digest when it's observably absent.
+		if hasLSM && lsmDenyRd.R != nil {
+			if probeLSMSilent(lsmDenyRd.R, lsmProbeTimeout) {
+				defendState.downgradeMode(defendModeForBackend(defendBackendCgroup))
+				bpfSt = append(bpfSt, telemetry.BPFStatus{
+					Name:   "lsm_attached_but_silent",
+					OK:     false,
+					Detail: "lsm hooks attached but no deny events observed during post-attach probe; downgraded backend label to cgroup. Common on Ubuntu 24.04 where the kernel `lsm=` boot chain omits bpf — boot with e.g. `lsm=lockdown,yama,bpf,apparmor` to restore LSM dispatch.",
+				})
+				slog.Warn("defend: lsm hooks attached but silent during post-attach probe; downgrading backend label to cgroup",
+					"hint", "kernel `lsm=` boot chain likely missing `bpf` (Ubuntu 24.04 default)")
+			}
+		}
 	}
 
 	var execObjs traceexec.TraceexecObjects

--- a/internal/agent/agent_linux_probe.go
+++ b/internal/agent/agent_linux_probe.go
@@ -24,6 +24,12 @@ const (
 	defaultProbeTimeout time.Duration = 5 * time.Second
 	probeDialTimeout    time.Duration = 50 * time.Millisecond
 	probeDialRetryEvery time.Duration = 50 * time.Millisecond
+	// lsmProbeTimeout bounds how long probeLSMSilent waits for an LSM deny
+	// event before declaring the LSM section attached-but-silent. Kept
+	// shorter than defaultProbeTimeout because the dial loop's connects
+	// also land in the cgroup ringbuf as background self-denies, and we do
+	// not want to pile up more than a couple of seconds of those.
+	lsmProbeTimeout time.Duration = 1500 * time.Millisecond
 )
 
 // probeDefendEnforcement verifies that the cgroup defend BPF program is actively
@@ -99,6 +105,64 @@ func runProbeDialLoop(stop <-chan struct{}, deadline time.Time) {
 			return
 		case <-time.After(probeDialRetryEvery):
 		}
+	}
+}
+
+// probeLSMSilent mirrors probeDefendEnforcement's dial-loop-and-drain pattern
+// against the LSM deny ringbuf. If no matching deny event arrives within
+// timeout, the LSM programs are attached but the kernel never invokes them —
+// returns true (silent).
+//
+// Ubuntu 24.04 ships with `lsm=lockdown,yama,apparmor` by default; `bpf` is
+// missing from the boot chain, so AttachLSM succeeds but
+// `security_socket_connect` / `security_socket_sendmsg` never dispatch to
+// our SEC("lsm/...") programs. The cgroup `connect4` / `sendmsg4` hooks are
+// unaffected — they remain the load-bearing enforcement path on these
+// kernels. This probe lets the digest report that posture honestly via a
+// `lsm_attached_but_silent` BPFStatus row and a `defend+cgroup` mode label
+// instead of advertising LSM defense that does not exist. To restore LSM
+// dispatch on these distros, the operator must boot with the `bpf` token
+// in the kernel `lsm=` parameter (e.g.
+// `lsm=lockdown,yama,bpf,apparmor`).
+//
+// The dial loop's connects that get denied by cgroup (because LSM is silent
+// and cgroup is the one firing) land in the cgroup ringbuf and are processed
+// by the main agent reader later as background self-denies; that noise is
+// bounded by lsmProbeTimeout (≤ ~30 connects at the 50ms retry tick).
+func probeLSMSilent(rd *ringbuf.Reader, timeout time.Duration) bool {
+	if rd == nil {
+		// No LSM ringbuf reader to observe — treat as silent so the caller
+		// downgrades the label rather than claiming LSM defense.
+		return true
+	}
+	if timeout <= 0 {
+		timeout = lsmProbeTimeout
+	}
+	deadline := time.Now().Add(timeout)
+
+	stop := make(chan struct{})
+	defer close(stop)
+	go runProbeDialLoop(stop, deadline)
+
+	rd.SetDeadline(deadline)
+	defer rd.SetDeadline(time.Time{})
+
+	for {
+		rec, err := rd.Read()
+		if err != nil {
+			if errors.Is(err, os.ErrDeadlineExceeded) {
+				return true
+			}
+			// Reader error other than deadline (e.g. closed) — treat as
+			// silent so the caller errs on the side of honesty about
+			// LSM's contribution to enforcement.
+			return true
+		}
+		if matchProbeDenyEvent(rec.RawSample) {
+			return false
+		}
+		// Non-probe deny event during startup — drain and keep waiting,
+		// matching probeDefendEnforcement's behaviour.
 	}
 }
 

--- a/internal/agent/agent_linux_probe_test.go
+++ b/internal/agent/agent_linux_probe_test.go
@@ -5,6 +5,7 @@ package agent
 import (
 	"net"
 	"testing"
+	"time"
 )
 
 func TestMatchProbeDenyEvent_Match(t *testing.T) {
@@ -43,5 +44,14 @@ func TestMatchProbeDenyEvent_ShortBuffer(t *testing.T) {
 	t.Parallel()
 	if matchProbeDenyEvent(make([]byte, denyEventWireSize-1)) {
 		t.Fatalf("expected no match: truncated payload must be rejected")
+	}
+}
+
+// Bug #3: a nil LSM ringbuf reader must short-circuit to silent=true so the
+// caller downgrades the backend label rather than claiming LSM defense.
+func TestProbeLSMSilent_NilReaderReturnsSilent(t *testing.T) {
+	t.Parallel()
+	if !probeLSMSilent(nil, 100*time.Millisecond) {
+		t.Fatalf("probeLSMSilent(nil) = false; want true (no reader → silent)")
 	}
 }

--- a/internal/agent/agent_linux_state_defend.go
+++ b/internal/agent/agent_linux_state_defend.go
@@ -107,6 +107,16 @@ func (s *defendState) setModeAndAllowlist(mode string, allowlistSize, ignoredSiz
 	s.expectedIgnoredEntries = ignoredSize
 }
 
+// downgradeMode replaces the mode label without disturbing allowlist
+// counters. Used by the LSM-silent probe to flip `defend+lsm` to
+// `defend+cgroup` after the fact when LSM attaches succeed but the kernel
+// never dispatches to the hooks (Ubuntu 24.04 default `lsm=` boot chain).
+func (s *defendState) downgradeMode(mode string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mode = mode
+}
+
 // setIPv6AllowlistSize records the number of /128 entries written into the
 // BPF allowed_ipv6 LPM trie at startup. Called from loadDefendMaps after
 // populateAllowedIPv6Map. Zero means defend is in pure block-all IPv6

--- a/internal/agent/defend_backend_fallback_linux_test.go
+++ b/internal/agent/defend_backend_fallback_linux_test.go
@@ -99,3 +99,26 @@ func TestDefendBackendUsesCgroupWhenLSMUnavailable(t *testing.T) {
 		t.Fatalf("expected cgroup backend without LSM, got %q", outcome.backend)
 	}
 }
+
+// Bug #3: downgradeMode flips the mode label after backend choice when the
+// post-attach LSM probe finds the hooks silent. It must NOT clobber the
+// allowlist counters captured by setModeAndAllowlist — those were populated
+// from the actual BPF maps and remain accurate even when LSM is silent.
+func TestDefendStateDowngradeModePreservesAllowlistCounters(t *testing.T) {
+	state := newDefendState()
+	state.setModeAndAllowlist(defendModeLSM, 7, 3)
+	state.setIPv6AllowlistSize(2)
+
+	state.downgradeMode(defendModeCgroup)
+
+	snap := state.snapshot()
+	if snap.mode != defendModeCgroup {
+		t.Errorf("mode = %q; want %q", snap.mode, defendModeCgroup)
+	}
+	if snap.allowlistSize != 7 {
+		t.Errorf("allowlistSize = %d; want 7 (must not be reset by downgrade)", snap.allowlistSize)
+	}
+	if snap.allowlistIPv6Size != 2 {
+		t.Errorf("allowlistIPv6Size = %d; want 2 (must not be reset by downgrade)", snap.allowlistIPv6Size)
+	}
+}


### PR DESCRIPTION
## Summary

- After the cgroup `connect4` probe confirms the cgroup hook is enforcing, run the same dial-loop-and-drain pattern against the LSM deny ringbuf (`probeLSMSilent` in `internal/agent/agent_linux_probe.go`). If no matching deny event arrives within `lsmProbeTimeout` (1500ms), the LSM programs are attached but the kernel never invokes them.
- When silent, downgrade `defendState.mode` from `defend+lsm` to `defend+cgroup` via a new `defendState.downgradeMode(mode)` accessor and emit an `lsm_attached_but_silent` `BPFStatus` row with the Ubuntu 24.04 `lsm=` boot chain hint in `Detail`.
- The LSM ringbuf reader stays alive for any events that may still fire — we just stop *claiming* LSM defense in the digest when it's observably absent.
- Document the Ubuntu 24.04 default `lsm=lockdown,yama,apparmor` situation (no `bpf` token in the boot chain) in code comments on both the probe helper and the call site.
- Pin behaviour with two unit tests: `TestProbeLSMSilent_NilReaderReturnsSilent` (nil reader short-circuits to silent) and `TestDefendStateDowngradeModePreservesAllowlistCounters` (the downgrade must not clobber allowlist sizes captured by `setModeAndAllowlist`).

## Why

Bug #3 from the post-v0.4.0 bug hunt. Symptom: digests on Ubuntu 24.04 runners advertised `defend+lsm` even though `security_socket_connect` never dispatched to `lsm/socket_connect`, because the default boot chain (`lsm=lockdown,yama,apparmor`) omits the `bpf` token. AttachLSM returns success, the program loads, and BPFStatus shows OK — but enforcement is actually 100% cgroup. The digest was misleading users and CI gates into thinking LSM was contributing to defense.

Pairs with bug #2 (fall back to cgroup-only on non-sendpage LSM load failure). Together they make the LSM path opportunistic rather than load-bearing: the agent advertises LSM defense only when it actually fires, and never refuses to start because LSM is missing or silent.

## Test plan

- [ ] `go test ./internal/agent/... -count=1` on Linux — including the new `TestProbeLSMSilent_NilReaderReturnsSilent` and `TestDefendStateDowngradeModePreservesAllowlistCounters`
- [ ] `go build ./...` — clean cross-package compile
- [ ] `bash scripts/check-gofmt.sh`
- [ ] `bash scripts/check-encoding.sh`
- [ ] CI sweep on Linux (gofmt, encoding, vet, staticcheck, unit, unit-arm64, integration, action_bundle, detect-mode, defend-mode) — the defend-mode job exercises the post-attach probe against a real kernel; on `ubuntu-latest` (24.04) we expect the new `lsm_attached_but_silent` row to surface in the telemetry artifact
