### PR TITLE
fix(action): reject wildcard allow-list entries in defend mode

### DIFF
--- a/.github/pr-bodies/fix-defend-wildcard-reject.md
+++ b/.github/pr-bodies/fix-defend-wildcard-reject.md
@@ -1,0 +1,15 @@
+## Summary
+
+- Reject wildcard allow-list entries (`*.example.com`) at action parse time when `mode: defend`. Adds `rejectDefendWildcards` in `cmd/coldstep-action/allowlist_files.go` and wires it into `runStart` after inline + file + bootstrap merge.
+- Add `TestRejectDefendWildcards` covering the clean, single-wildcard, and multi-wildcard (dedup) paths.
+- Update `action.yml`, `README.md`, and `QUICK_START.md` to document that wildcards are detect-only in lockstep with the input behaviour change.
+
+## Why
+
+Bug #4 from the post-v0.4.0 bug hunt. The BPF `allowed_domains` map uses exact-string lookup, so wildcard entries cannot match in defend mode. Previously the agent emitted a `slog.Warn` from `loadAllowedDomainsMap` and continued; if any other entry resolved, the defend-mode check passed and the agent attached — but the wildcard intent was silently ignored, so subdomains the user expected to be allowed got blocked with no error. Failing loud at action parse time matches the same posture used for rejecting `mode: enforce`.
+
+## Test plan
+
+- [ ] `go test ./cmd/coldstep-action/... -count=1` — including the new `TestRejectDefendWildcards` case
+- [ ] `bash scripts/check-gofmt.sh`
+- [ ] CI sweep on Linux (gofmt, encoding, vet, staticcheck, unit, unit-arm64, integration, action_bundle, detect-mode, defend-mode)

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -102,7 +102,7 @@ Every `with:` key the action accepts (defaults are what you get if you omit the 
 | Input | Default | Summary |
 | :---- | :------ | :------ |
 | **`mode`** | `detect` | **`detect`** — observe only. **`defend`** — block non-allowlisted egress (**`enforce`** is rejected). |
-| **`allow`** | *(empty)* | Comma/newline-separated egress allowlist. Accepts plain domains (`example.com`), wildcard domains (`*.example.com`), IPv4 literals (`1.2.3.4`), and CIDRs (`10.0.0.0/8`). Prefix a CIDR with `!` to ignore that net (e.g. `!192.168.0.0/16`). Entries are auto-classified. |
+| **`allow`** | *(empty)* | Comma/newline-separated egress allowlist. Accepts plain domains (`example.com`), wildcard domains (`*.example.com` — **detect only**, rejected at parse time when `mode: defend`), IPv4 literals (`1.2.3.4`), and CIDRs (`10.0.0.0/8`). Prefix a CIDR with `!` to ignore that net (e.g. `!192.168.0.0/16`). Entries are auto-classified. |
 | **`allow-file`** | *(empty)* | Comma-separated workspace paths to UTF-8 files; same format as `allow`. Merged after inline `allow`. |
 | **`ignored-nets`** | *(empty)* | Extra IPv4 CIDRs to treat as ignored (plus implicit RFC1918 unless disabled below). Also accepts `!CIDR` entries via `allow`. Max **128** merged CIDRs total. |
 | **`ignored-nets-file`** | *(empty)* | File paths for more ignored CIDRs. |

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Full list and defaults: **[`action.yml`](action.yml)**. Frequently used:
 | Input | Purpose |
 | :---- | :------ |
 | `mode` | **`detect`** or **`defend`** (blocking). **`enforce`** is rejected. |
-| `allow` / `allow-file` | Unified egress allowlist (**required** for **defend** / blocking). Accepts plain domains, `*.example.com` wildcards, IPv4 literals/CIDRs, and `!CIDR` ignore entries. |
+| `allow` / `allow-file` | Unified egress allowlist (**required** for **defend** / blocking). Accepts plain domains, `*.example.com` wildcards (**detect only** — rejected at parse time in `defend`), IPv4 literals/CIDRs, and `!CIDR` ignore entries. |
 | `fail-on-error` | Fail if the agent never reaches **operational** readiness (BPF/load), not for policy "violations" alone. Defaults to **`true`** in defend mode. |
 | `detect-profile` | **`detect` only:** `standard` (default) or **`enhanced`** — enhanced enables `proc_tree` / `tls_sni` / `fs_events` and sets `COLDSTEP_DETECT_PROFILE` for stricter **report-model** integrity (set the same `COLDSTEP_DETECT_PROFILE` on `coldstep-report build-model`). |
 | `report` | `job-summary` (default), `pr-comment`, `both`, or `none` — where to post the detect digest. |

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,9 @@ inputs:
       Merged with allow-file and the legacy per-type inputs. In defend mode each
       domain is resolved for both A and AAAA records; matching IPv4 and IPv6
       addresses populate the BPF allowlists. IPv6 literals are not accepted as
-      input today — use AAAA-bearing hostnames instead.
+      input today — use AAAA-bearing hostnames instead. Wildcard entries
+      (*.example.com) are detect-only — they are rejected at parse time when
+      mode=defend, because the BPF allowed_domains map uses exact-string lookup.
     required: false
     default: ''
 

--- a/cmd/coldstep-action/allowlist_files.go
+++ b/cmd/coldstep-action/allowlist_files.go
@@ -17,6 +17,31 @@ type classifiedAllow struct {
 	ignoredNets []string
 }
 
+// rejectDefendWildcards returns an error if any allow-list host entry uses the
+// `*.suffix` wildcard form. Defend mode loads exact hostnames into the BPF
+// allowed_domains map (which has no wildcard matching), so a wildcard would be
+// silently dropped — subdomains the user expected to be allowed would get
+// blocked with no error. Same posture as rejecting `enforce` mode at parse time.
+func rejectDefendWildcards(c classifiedAllow) error {
+	var bad []string
+	seen := make(map[string]struct{})
+	for _, list := range [][]string{c.hosts, c.domains} {
+		for _, h := range list {
+			if strings.HasPrefix(h, "*.") {
+				if _, ok := seen[h]; ok {
+					continue
+				}
+				seen[h] = struct{}{}
+				bad = append(bad, h)
+			}
+		}
+	}
+	if len(bad) == 0 {
+		return nil
+	}
+	return fmt.Errorf("defend mode does not support wildcard allow-list entries (BPF allowed_domains map uses exact-string lookup); replace with exact hostnames or IPv4 literals/CIDRs: %s", strings.Join(bad, ", "))
+}
+
 // classifyAllowTokens splits unified allow-list tokens into per-type buckets.
 // Plain or wildcard domains go to both hosts and domains; IPv4 literals/CIDRs
 // go to ips; a leading `!` on an IPv4 CIDR routes it to ignoredNets.

--- a/cmd/coldstep-action/allowlist_files_test.go
+++ b/cmd/coldstep-action/allowlist_files_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -89,6 +90,44 @@ func TestReadBootstrapTokens(t *testing.T) {
 	got2, err := readBootstrapTokens(filepath.Join(dir, "missing.txt"))
 	if err != nil || got2 != nil {
 		t.Errorf("missing file: got %v err %v", got2, err)
+	}
+}
+
+func TestRejectDefendWildcards(t *testing.T) {
+	t.Parallel()
+
+	// No wildcards — accepted in defend mode.
+	clean := classifyAllowTokens([]string{"example.com", "api.example.com", "1.2.3.4"})
+	if err := rejectDefendWildcards(clean); err != nil {
+		t.Fatalf("clean allowlist: unexpected error %v", err)
+	}
+
+	// Wildcard entry — must be rejected with a message that names the entry.
+	withWild := classifyAllowTokens([]string{"example.com", "*.example.com"})
+	err := rejectDefendWildcards(withWild)
+	if err == nil {
+		t.Fatal("expected error for wildcard entry")
+	}
+	if !strings.Contains(err.Error(), "*.example.com") {
+		t.Errorf("error %q does not name the offending entry", err)
+	}
+	if !strings.Contains(err.Error(), "defend") {
+		t.Errorf("error %q does not mention defend mode", err)
+	}
+
+	// Multiple wildcards — each surfaced, no duplicates.
+	multi := classifyAllowTokens([]string{"*.a.com", "*.b.com", "*.a.com"})
+	err = rejectDefendWildcards(multi)
+	if err == nil {
+		t.Fatal("expected error for multiple wildcards")
+	}
+	for _, want := range []string{"*.a.com", "*.b.com"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err, want)
+		}
+	}
+	if strings.Count(err.Error(), "*.a.com") != 1 {
+		t.Errorf("expected each wildcard listed once, got %q", err)
 	}
 }
 

--- a/cmd/coldstep-action/main.go
+++ b/cmd/coldstep-action/main.go
@@ -278,6 +278,12 @@ func runStart(cfg startConfig) error {
 		allow.ips = append(allow.ips, bsIPs...)
 	}
 
+	if mode == "defend" {
+		if err := rejectDefendWildcards(allow); err != nil {
+			return err
+		}
+	}
+
 	detectProfile := strings.ToLower(strings.TrimSpace(cfg.DetectProfile))
 	featureGates := ""
 	if detectProfile == "enhanced" {


### PR DESCRIPTION
## Summary

- Reject wildcard allow-list entries (`*.example.com`) at action parse time when `mode: defend`. Adds `rejectDefendWildcards` in `cmd/coldstep-action/allowlist_files.go` and wires it into `runStart` after inline + file + bootstrap merge.
- Add `TestRejectDefendWildcards` covering the clean, single-wildcard, and multi-wildcard (dedup) paths.
- Update `action.yml`, `README.md`, and `QUICK_START.md` to document that wildcards are detect-only in lockstep with the input behaviour change.

## Why

Bug #4 from the post-v0.4.0 bug hunt. The BPF `allowed_domains` map uses exact-string lookup, so wildcard entries cannot match in defend mode. Previously the agent emitted a `slog.Warn` from `loadAllowedDomainsMap` and continued; if any other entry resolved, the defend-mode check passed and the agent attached — but the wildcard intent was silently ignored, so subdomains the user expected to be allowed got blocked with no error. Failing loud at action parse time matches the same posture used for rejecting `mode: enforce`.

## Test plan

- [ ] `go test ./cmd/coldstep-action/... -count=1` — including the new `TestRejectDefendWildcards` case
- [ ] `bash scripts/check-gofmt.sh`
- [ ] CI sweep on Linux (gofmt, encoding, vet, staticcheck, unit, unit-arm64, integration, action_bundle, detect-mode, defend-mode)
