### PR TITLE
fix(policy,reputation): DNS retry timeout & enrich goroutine leak

### DIFF
--- a/.github/pr-bodies/fix-dns-retry-and-reputation-leak.md
+++ b/.github/pr-bodies/fix-dns-retry-and-reputation-leak.md
@@ -1,0 +1,20 @@
+## Summary
+
+- **Bug #7 (`internal/policy/allowlist.go`)**: distinguish parent-cancel from per-attempt timeout in the DNS retry loop. The per-attempt 25s context's `DeadlineExceeded` was indistinguishable from a parent-cancel `Canceled`, so the loop `break`ed and `maxAttempts > 1` was dead code on transient timeouts. Now: after `errors.Is(err, Canceled|DeadlineExceeded)`, check `gctx.Err()` — break only when the parent context fired; otherwise fall through to the next attempt.
+- **Bug #12 (`internal/reputation/registry.go`)**: drain `resCh` in a dedicated goroutine so the caller returns immediately on ctx cancellation without holding the closer hostage to a slow enricher. Partial results are preserved via a shared mutex + snapshot pattern (keeps `TestEnrichAll_HungEnricherDoesNotBlockOthers` passing). Enricher ctx contract is now documented in the godoc.
+- Add `TestCompileDomainAllowlist_PerAttemptTimeoutRetries` — resolver returns `context.DeadlineExceeded` on attempt 1 and the IP on attempt 2; asserts the second attempt's IP lands in `AllowedIPv4`.
+- Add `TestEnrichAll_DoesNotBlockOnCtxIgnoringEnricher` — enricher blocks on a test-controlled channel ignoring ctx; asserts `EnrichAll` returns within 2s of the 50ms ctx deadline.
+
+## Why
+
+Both bugs are silent reliability failures that compound on hosted runners:
+
+- Bug #7 caused defend-mode allowlists to silently shrink on flaky DNS, masking the recoverable case as `UnresolvedDomains`. Workflow authors saw "this domain didn't resolve" when the truth was "this domain timed out once and the retry was dead code."
+- Bug #12 pinned memory (goroutines + waitgroup + buffered channel) for the lifetime of any ctx-ignoring enricher backend. The HTTP enrichers we ship today respect ctx, but the contract was undocumented and the registry itself relied on that good behaviour to avoid the leak.
+
+## Test plan
+
+- [ ] `go test ./internal/policy/... ./internal/reputation/... -count=1` (Linux + Windows)
+- [ ] `bash scripts/check-gofmt.sh`
+- [ ] `staticcheck ./internal/policy/... ./internal/reputation/...`
+- [ ] CI sweep: gofmt, encoding, vet, staticcheck, unit, unit-arm64, integration, action_bundle, detect-mode, defend-mode

--- a/internal/policy/allowlist.go
+++ b/internal/policy/allowlist.go
@@ -246,10 +246,16 @@ func CompileDomainAllowlist(ctx context.Context, domains []string, resolver Look
 					lookupCtx, cancel := context.WithTimeout(gctx, coldstepDomainLookupAttemptTimeout)
 					ips4, err4 := resolver(lookupCtx, "ip4", d)
 					cancel()
+					// Bug #7: distinguish parent-cancel from per-attempt timeout.
+					// Both surface as context.Canceled / context.DeadlineExceeded on err4,
+					// but only parent-cancel means "stop retrying"; an attempt-context
+					// timeout is exactly the case retries exist for.
 					if err4 != nil && (errors.Is(err4, context.Canceled) || errors.Is(err4, context.DeadlineExceeded)) {
-						break
-					}
-					if err4 == nil {
+						if gctx.Err() != nil {
+							break
+						}
+						// per-attempt deadline fired: fall through to next attempt
+					} else if err4 == nil {
 						for _, ip := range ips4 {
 							if ip.To4() != nil {
 								res.ips4 = append(res.ips4, ip)
@@ -263,9 +269,11 @@ func CompileDomainAllowlist(ctx context.Context, domains []string, resolver Look
 					ips6, err6 := resolver(lookupCtx6, "ip6", d)
 					cancel6()
 					if err6 != nil && (errors.Is(err6, context.Canceled) || errors.Is(err6, context.DeadlineExceeded)) {
-						break
-					}
-					if err6 == nil {
+						if gctx.Err() != nil {
+							break
+						}
+						// per-attempt deadline fired: fall through to next attempt
+					} else if err6 == nil {
 						for _, ip := range ips6 {
 							if ip.To4() == nil && ip.To16() != nil {
 								res.ips6 = append(res.ips6, ip)

--- a/internal/policy/allowlist_test.go
+++ b/internal/policy/allowlist_test.go
@@ -161,6 +161,40 @@ func TestCompileDomainAllowlist_ContextCanceledStopsRetries(t *testing.T) {
 	}
 }
 
+// Bug #7: per-attempt DeadlineExceeded must not abort the retry loop.
+// When a resolver returns context.DeadlineExceeded on attempt 1 (the
+// per-attempt context fired) and succeeds on attempt 2, the result must
+// land the IP in AllowedIPv4 — proving the retry loop did not break.
+func TestCompileDomainAllowlist_PerAttemptTimeoutRetries(t *testing.T) {
+	ctx := context.Background()
+	var ip4Calls atomic.Int32
+	resolver := func(_ context.Context, network, _ string) ([]net.IP, error) {
+		switch network {
+		case "ip4":
+			n := ip4Calls.Add(1)
+			if n == 1 {
+				return nil, context.DeadlineExceeded
+			}
+			return []net.IP{net.ParseIP("10.0.0.1")}, nil
+		case "ip6":
+			return nil, nil
+		default:
+			return nil, errors.New("unexpected network")
+		}
+	}
+
+	got := CompileDomainAllowlist(ctx, []string{"retry.example.com"}, resolver, 3)
+	if len(got.UnresolvedDomains) != 0 {
+		t.Fatalf("UnresolvedDomains: got %v want empty (retry should have succeeded)", got.UnresolvedDomains)
+	}
+	if !got.AllowedIPv4.Contains(net.ParseIP("10.0.0.1")) {
+		t.Fatalf("AllowedIPv4 missing 10.0.0.1; second attempt should have populated it")
+	}
+	if n := ip4Calls.Load(); n < 2 {
+		t.Fatalf("ip4 resolver calls: got %d want >=2 (must have retried after per-attempt timeout)", n)
+	}
+}
+
 func TestCompileDomainAllowlist_MaxAttemptsFloor(t *testing.T) {
 	ctx := context.Background()
 	calls := 0

--- a/internal/reputation/registry.go
+++ b/internal/reputation/registry.go
@@ -60,6 +60,13 @@ func Registered() []Enricher {
 //   - If one or more enrichers return an error, the errors are joined
 //     and returned alongside any successful results. Callers should not
 //     treat a partial error as fatal.
+//
+// Enricher ctx contract: implementations must observe ctx and return
+// promptly when it fires. Bug #12 — if an enricher ignores ctx, its
+// goroutine plus the drainer/closer goroutines stay alive until the
+// enricher eventually returns; EnrichAll itself still returns on ctx
+// cancellation without blocking the caller, but the background state
+// cannot be GC'd until the slow enricher exits.
 func EnrichAll(ctx context.Context, ip string) ([]*Result, error) {
 	enrichers := Registered()
 	if len(enrichers) == 0 {
@@ -93,43 +100,49 @@ func EnrichAll(ctx context.Context, ip string) ([]*Result, error) {
 		close(resCh)
 	}()
 
-	var results []*Result
-	var errs []error
-	for {
-		select {
-		case <-ctx.Done():
-			// Drain whatever already arrived before the deadline; do not
-			// wait on the still-running enrichers. Their goroutines exit
-			// when they observe ctx (or, worst case, run to completion in
-			// the background and their sends are dropped because nobody is
-			// reading).
-			for {
-				select {
-				case o, ok := <-resCh:
-					if !ok {
-						return finalize(results, errs, ctx.Err())
-					}
-					if o.res != nil {
-						results = append(results, o.res)
-					}
-					if o.err != nil {
-						errs = append(errs, o.err)
-					}
-				default:
-					return finalize(results, errs, ctx.Err())
-				}
-			}
-		case o, ok := <-resCh:
-			if !ok {
-				return finalize(results, errs, nil)
-			}
+	// Bug #12: drain resCh in a dedicated goroutine. If the caller returns
+	// early on ctx cancellation, the drainer keeps running until the closer
+	// fires close(resCh) — guaranteeing in-flight enricher sends never block
+	// and that the wg+channel+goroutine state becomes eligible for GC once
+	// the slow enricher eventually exits, even if the caller has long since
+	// moved on. The shared mutex + snapshot pattern lets ctx.Done() return
+	// partial results (preserves TestEnrichAll_HungEnricherDoesNotBlockOthers)
+	// while the drainer continues to consume in the background.
+	var (
+		mu        sync.Mutex
+		results   []*Result
+		errs      []error
+		drainDone = make(chan struct{})
+	)
+	go func() {
+		for o := range resCh {
+			mu.Lock()
 			if o.res != nil {
 				results = append(results, o.res)
 			}
 			if o.err != nil {
 				errs = append(errs, o.err)
 			}
+			mu.Unlock()
 		}
+		close(drainDone)
+	}()
+
+	snapshot := func(ctxErr error) ([]*Result, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		// Copy slices so the background drainer can keep appending after
+		// the caller returns without racing on the returned data.
+		snapResults := append([]*Result(nil), results...)
+		snapErrs := append([]error(nil), errs...)
+		return finalize(snapResults, snapErrs, ctxErr)
+	}
+
+	select {
+	case <-drainDone:
+		return snapshot(nil)
+	case <-ctx.Done():
+		return snapshot(ctx.Err())
 	}
 }
 

--- a/internal/reputation/reputation_test.go
+++ b/internal/reputation/reputation_test.go
@@ -203,6 +203,54 @@ func TestEnrichAll_HungEnricherDoesNotBlockOthers(t *testing.T) {
 	}
 }
 
+// ignoringHangEnricher blocks on a test-controlled channel and intentionally
+// ignores ctx. Used to verify Bug #12 — EnrichAll must not block the caller
+// when an enricher ignores ctx cancellation.
+type ignoringHangEnricher struct {
+	name    string
+	release <-chan struct{}
+}
+
+func (h *ignoringHangEnricher) Name() string { return h.name }
+func (h *ignoringHangEnricher) Enrich(_ context.Context, _ string) (*reputation.Result, error) {
+	<-h.release
+	return nil, nil
+}
+
+// Bug #12: EnrichAll must return promptly on ctx cancellation even when an
+// enricher ignores ctx. The slow goroutine is allowed to linger (memory will
+// be reclaimed once it exits); the caller must not be held hostage.
+func TestEnrichAll_DoesNotBlockOnCtxIgnoringEnricher(t *testing.T) {
+	reputation.Reset()
+	t.Cleanup(reputation.Reset)
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	reputation.Register(&ignoringHangEnricher{name: "ignoring", release: release})
+	reputation.Register(&fakeEnricher{name: "fast", result: &reputation.Result{Score: 1}})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	var err error
+	go func() {
+		_, err = reputation.EnrichAll(ctx, "1.1.1.1")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// EnrichAll returned promptly — fix is working.
+	case <-time.After(2 * time.Second):
+		t.Fatalf("EnrichAll did not return within 2s of ctx deadline (50ms) — caller blocked on ctx-ignoring enricher")
+	}
+	if err == nil {
+		t.Fatalf("expected ctx error from EnrichAll, got nil")
+	}
+}
+
 func TestEnrichAll_PartialErrorsReturned(t *testing.T) {
 	reputation.Reset()
 	t.Cleanup(reputation.Reset)


### PR DESCRIPTION
## Summary

- **Bug #7 (`internal/policy/allowlist.go`)**: distinguish parent-cancel from per-attempt timeout in the DNS retry loop. The per-attempt 25s context's `DeadlineExceeded` was indistinguishable from a parent-cancel `Canceled`, so the loop `break`ed and `maxAttempts > 1` was dead code on transient timeouts. Now: after `errors.Is(err, Canceled|DeadlineExceeded)`, check `gctx.Err()` — break only when the parent context fired; otherwise fall through to the next attempt.
- **Bug #12 (`internal/reputation/registry.go`)**: drain `resCh` in a dedicated goroutine so the caller returns immediately on ctx cancellation without holding the closer hostage to a slow enricher. Partial results are preserved via a shared mutex + snapshot pattern (keeps `TestEnrichAll_HungEnricherDoesNotBlockOthers` passing). Enricher ctx contract is now documented in the godoc.
- Add `TestCompileDomainAllowlist_PerAttemptTimeoutRetries` — resolver returns `context.DeadlineExceeded` on attempt 1 and the IP on attempt 2; asserts the second attempt's IP lands in `AllowedIPv4`.
- Add `TestEnrichAll_DoesNotBlockOnCtxIgnoringEnricher` — enricher blocks on a test-controlled channel ignoring ctx; asserts `EnrichAll` returns within 2s of the 50ms ctx deadline.

## Why

Both bugs are silent reliability failures that compound on hosted runners:

- Bug #7 caused defend-mode allowlists to silently shrink on flaky DNS, masking the recoverable case as `UnresolvedDomains`. Workflow authors saw "this domain didn't resolve" when the truth was "this domain timed out once and the retry was dead code."
- Bug #12 pinned memory (goroutines + waitgroup + buffered channel) for the lifetime of any ctx-ignoring enricher backend. The HTTP enrichers we ship today respect ctx, but the contract was undocumented and the registry itself relied on that good behaviour to avoid the leak.

## Test plan

- [ ] `go test ./internal/policy/... ./internal/reputation/... -count=1` (Linux + Windows)
- [ ] `bash scripts/check-gofmt.sh`
- [ ] `staticcheck ./internal/policy/... ./internal/reputation/...`
- [ ] CI sweep: gofmt, encoding, vet, staticcheck, unit, unit-arm64, integration, action_bundle, detect-mode, defend-mode
