### PR TITLE
fix(report): write enrichment model with canonical JSON encoder

### DIFF
--- a/.github/pr-bodies/fix-enrich-canonical-json.md
+++ b/.github/pr-bodies/fix-enrich-canonical-json.md
@@ -1,0 +1,15 @@
+## Summary
+
+- Add `model.MarshalCanonicalValue(any)` in `internal/report/model/canon.go` — the shape-agnostic form of the existing `MarshalCanonical(*Report)`, applying the same encoder settings (2-space indent, `SetEscapeHTML(false)`, no trailing newline).
+- Route `writeModelMap` in `cmd/coldstep-report/model_json.go` through `MarshalCanonicalValue`, replacing the plain `json.Marshal` path used by `rdns-enrich` and `otx-enrich`.
+- Add `TestWriteModelMap_CanonicalRoundTrip` and `TestWriteModelMap_RoundTripReadsBack` in a new `cmd/coldstep-report/model_json_test.go`: verify enrichment writes byte-match the canonical encoder, that PTR/domain strings with `<` / `>` / `&` survive without HTML escaping, and that the file roundtrips through `readModelMap`.
+
+## Why
+
+Bug #5 from the post-v0.4.0 bug hunt. `build-model` writes the report through `MarshalCanonical` (2-space indent, no HTML escaping, no trailing newline). The enrichment subcommands then re-read and re-write the same file through `writeModelMap`, which used plain `json.Marshal` — HTML escaping on, compact, no newline. After `rdns-enrich` or `otx-enrich` ran, the on-disk model diverged from the canonical form: downstream attestation hashes no longer matched the post-build-model snapshot, and PTR records or suspicious domain names containing `<` / `>` / `&` were silently rewritten to their `<` / `>` / `&` escapes.
+
+## Test plan
+
+- [ ] `go test ./cmd/coldstep-report/... ./internal/report/... -count=1` — including the new `TestWriteModelMap_*` cases
+- [ ] `bash scripts/check-gofmt.sh`
+- [ ] CI sweep on Linux (gofmt, encoding, vet, staticcheck, unit, unit-arm64, integration, action_bundle, detect-mode, defend-mode)

--- a/cmd/coldstep-report/model_json.go
+++ b/cmd/coldstep-report/model_json.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/coldstep-io/coldstep/internal/atomicwrite"
+	"github.com/coldstep-io/coldstep/internal/report/model"
 )
 
 // Loose upper bound so a hostile or corrupted artifact cannot exhaust memory in-process.
@@ -35,8 +36,14 @@ func readModelMap(path string) (map[string]any, error) {
 	return m, nil
 }
 
+// writeModelMap persists an enrichment-modified report model using the same
+// canonical encoder as `build-model`: 2-space indent, no HTML escaping, no
+// trailing newline. Plain json.Marshal would re-introduce HTML escaping on
+// `<`/`>`/`&` (silently rewriting PTR records or suspicious domain names) and
+// drop the indentation, diverging from the post-build-model snapshot so
+// downstream attestation hashes stop matching.
 func writeModelMap(path string, m map[string]any) error {
-	raw, err := json.Marshal(m)
+	raw, err := model.MarshalCanonicalValue(m)
 	if err != nil {
 		return err
 	}

--- a/cmd/coldstep-report/model_json_test.go
+++ b/cmd/coldstep-report/model_json_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/coldstep-io/coldstep/internal/report/model"
+)
+
+// Bug #5: writeModelMap (used by rdns-enrich / otx-enrich) must use the same
+// canonical encoder as build-model: 2-space indent, no HTML escaping, no
+// trailing newline. The previous json.Marshal path silently rewrote `<`/`>`/`&`
+// to their Unicode escapes (corrupting PTR records and suspicious domain
+// names) and dropped the indentation, so post-enrichment hashes diverged from
+// the post-build-model snapshot.
+func TestWriteModelMap_CanonicalRoundTrip(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "model.json")
+
+	payload := map[string]any{
+		"schema_version": "v1",
+		"dns_lookups": map[string]any{
+			// Characters json.Marshal HTML-escapes by default.
+			"1.2.3.4":  "evil<script>.example.com",
+			"5.6.7.8":  "a&b.example.com",
+			"9.10.0.1": "x>y.example.com",
+		},
+	}
+	if err := writeModelMap(p, payload); err != nil {
+		t.Fatalf("writeModelMap: %v", err)
+	}
+
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	got := string(raw)
+
+	// 1. No HTML escaping — the original characters must survive verbatim.
+	for _, want := range []string{
+		`evil<script>.example.com`,
+		`a&b.example.com`,
+		`x>y.example.com`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected literal %q in output; got:\n%s", want, got)
+		}
+	}
+	// The default encoding/json behaviour (HTML escaping on) would rewrite
+	// these characters as the unicode escape sequences below. None should
+	// appear when SetEscapeHTML(false) is in effect.
+	for _, banned := range []string{"\\u003c", "\\u003e", "\\u0026"} {
+		if strings.Contains(got, banned) {
+			t.Errorf("unexpected JSON HTML-escape sequence %q in output:\n%s", banned, got)
+		}
+	}
+
+	// 2. Indentation must match build-model (`MarshalCanonical`).
+	if !strings.Contains(got, "\n  \"") {
+		t.Errorf("expected 2-space indented JSON; got:\n%s", got)
+	}
+
+	// 3. No trailing newline.
+	if len(raw) > 0 && raw[len(raw)-1] == '\n' {
+		t.Errorf("expected no trailing newline; final byte is %q", raw[len(raw)-1])
+	}
+
+	// 4. Byte-identical to MarshalCanonicalValue on the same input — proves
+	//    enrichment writes stay in the same hash space as build-model output.
+	want, err := model.MarshalCanonicalValue(payload)
+	if err != nil {
+		t.Fatalf("MarshalCanonicalValue: %v", err)
+	}
+	if string(raw) != string(want) {
+		t.Errorf("writeModelMap output diverges from canonical encoder:\n--- got ---\n%s\n--- want ---\n%s", raw, want)
+	}
+}
+
+func TestWriteModelMap_RoundTripReadsBack(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "model.json")
+
+	payload := map[string]any{"dns_lookups": map[string]any{"1.2.3.4": "a<b&c>d.example.com"}}
+	if err := writeModelMap(p, payload); err != nil {
+		t.Fatalf("writeModelMap: %v", err)
+	}
+	round, err := readModelMap(p)
+	if err != nil {
+		t.Fatalf("readModelMap: %v", err)
+	}
+	lookups, ok := round["dns_lookups"].(map[string]any)
+	if !ok {
+		t.Fatalf("dns_lookups missing or wrong type: %#v", round["dns_lookups"])
+	}
+	if got := lookups["1.2.3.4"]; got != "a<b&c>d.example.com" {
+		t.Errorf("roundtrip lost characters: got %q", got)
+	}
+}

--- a/internal/report/model/canon.go
+++ b/internal/report/model/canon.go
@@ -8,11 +8,20 @@ import (
 // MarshalCanonical produces stable, 2-space indented JSON. Map keys are
 // sorted by the encoding/json default; struct field order follows declaration.
 func MarshalCanonical(r *Report) ([]byte, error) {
+	return MarshalCanonicalValue(r)
+}
+
+// MarshalCanonicalValue is the shape-agnostic form of MarshalCanonical: it
+// applies the same encoder settings (2-space indent, no HTML escaping, no
+// trailing newline) to any JSON-encodable value, so map[string]any payloads
+// written by post-build enrichment subcommands stay byte-identical to the
+// build-model output for hashing / attestation.
+func MarshalCanonicalValue(v any) ([]byte, error) {
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
 	enc.SetIndent("", "  ")
 	enc.SetEscapeHTML(false)
-	if err := enc.Encode(r); err != nil {
+	if err := enc.Encode(v); err != nil {
 		return nil, err
 	}
 	out := buf.Bytes()


### PR DESCRIPTION
## Summary

- Add `model.MarshalCanonicalValue(any)` in `internal/report/model/canon.go` — the shape-agnostic form of the existing `MarshalCanonical(*Report)`, applying the same encoder settings (2-space indent, `SetEscapeHTML(false)`, no trailing newline).
- Route `writeModelMap` in `cmd/coldstep-report/model_json.go` through `MarshalCanonicalValue`, replacing the plain `json.Marshal` path used by `rdns-enrich` and `otx-enrich`.
- Add `TestWriteModelMap_CanonicalRoundTrip` and `TestWriteModelMap_RoundTripReadsBack` in a new `cmd/coldstep-report/model_json_test.go`: verify enrichment writes byte-match the canonical encoder, that PTR/domain strings with `<` / `>` / `&` survive without HTML escaping, and that the file roundtrips through `readModelMap`.

## Why

Bug #5 from the post-v0.4.0 bug hunt. `build-model` writes the report through `MarshalCanonical` (2-space indent, no HTML escaping, no trailing newline). The enrichment subcommands then re-read and re-write the same file through `writeModelMap`, which used plain `json.Marshal` — HTML escaping on, compact, no newline. After `rdns-enrich` or `otx-enrich` ran, the on-disk model diverged from the canonical form: downstream attestation hashes no longer matched the post-build-model snapshot, and PTR records or suspicious domain names containing `<` / `>` / `&` were silently rewritten to their `<` / `>` / `&` escapes.

## Test plan

- [ ] `go test ./cmd/coldstep-report/... ./internal/report/... -count=1` — including the new `TestWriteModelMap_*` cases
- [ ] `bash scripts/check-gofmt.sh`
- [ ] CI sweep on Linux (gofmt, encoding, vet, staticcheck, unit, unit-arm64, integration, action_bundle, detect-mode, defend-mode)
