### PR TITLE
fix(report): BOM strip, fingerprint conflation, drop preamble HTML

### DIFF
--- a/.github/pr-bodies/fix-report-model-bugs.md
+++ b/.github/pr-bodies/fix-report-model-bugs.md
@@ -1,0 +1,21 @@
+## Summary
+
+- **Bug #10 (UTF-8 BOM drops first JSONL event)** — `internal/report/model/jsonl.go`. A leading `EF BB BF` on the first line of an event log (common when a Windows producer pre-pends the BOM) made `json.Unmarshal` fail silently, discarding the first event — typically `meta`. That skews `ObservationWindow` and can flip the integrity gate. Fix: strip the BOM with `strings.TrimPrefix(line, "\xef\xbb\xbf")` after `TrimSpace`. (BOM is U+FEFF, not classified as whitespace by Go's `unicode.IsSpace`, so the trim has to happen explicitly.)
+- **Bug #11 (BuildDiff fingerprint conflates name vs IP)** — `internal/report/model/builders.go`. The fingerprint was per-event (`type»firstNonEmpty(fqdn, host, sni, dst)`). Two consecutive identical runs where one event hit a DNS cache miss would produce two fingerprints — `tcp»example.com` and `tcp»1.2.3.4` — and surface a spurious `traffic_gone` + `traffic_new` pair. Fix: build a single `dst → name` map across the union of `current ∪ baseline` events, then resolve dst-only events through that map so they share the fingerprint with their name-bearing siblings.
+- **Bug #13 (Job Summary HTML rendered literal)** — `internal/report/detect.go`. The `detectReportPreamble` used `<p align="center">` and `<sub>` which fall outside GitHub's Job Summary HTML allowlist and rendered as literal HTML text. Replace with plain GFM (`**bold**` + em-dash subtitle).
+- Add three regression tests: BOM strip (`TestLoadEventsStripsLeadingUTF8BOM`), fingerprint conflation (`TestDiffFingerprintCollapsesDNSCacheMiss`), preamble HTML-tag guard (`TestDetectReportPreamble_NoForbiddenHTML`). Adjust `BenchmarkBuildDiff_*` for the new `fingerprintCounts` signature.
+
+## Why
+
+All three are visible failure modes in the post-v0.4.0 hunt:
+
+- **#10**: an external user reported the integrity gate failing intermittently on detect-mode artifacts they round-tripped through PowerShell pipelines. The PowerShell `Out-File` default encoding emits a BOM.
+- **#11**: noisy `traffic_new` / `traffic_gone` diffs across identical workflow runs where the only difference was whether the DNS resolver had warm cache. Reviewers wasted time triaging "new traffic" that was the same destination IP with a momentarily missing fqdn.
+- **#13**: the Job Summary card in detect-mode runs showed `<p align="center"><strong>eBPF runtime audit trail</strong></p>` as a literal HTML string, which looks broken. `internal/report/digest.go` already guards `BuildDetectMarkdown` against the same tags — the preamble in `detect.go` was the missing case.
+
+## Test plan
+
+- [ ] `go test ./internal/report/... ./internal/report/model/... -count=1` — including the three new regression cases
+- [ ] `bash scripts/check-gofmt.sh`
+- [ ] `staticcheck ./internal/report/... ./internal/report/model/...`
+- [ ] CI sweep: gofmt, encoding, vet, staticcheck, unit, unit-arm64, integration, action_bundle, detect-mode, defend-mode

--- a/cmd/coldstep-action/agent_pid_linux_test.go
+++ b/cmd/coldstep-action/agent_pid_linux_test.go
@@ -67,10 +67,7 @@ func TestWalkForAgentComm_FindsKnownChild(t *testing.T) {
 	// child's comm to become readable. On loaded CI machines the immediate
 	// post-Start window can race.
 	deadline := time.Now().Add(500 * time.Millisecond)
-	for {
-		if readComm(cmd.Process.Pid) == "sleep" {
-			break
-		}
+	for readComm(cmd.Process.Pid) != "sleep" {
 		if !time.Now().Before(deadline) {
 			t.Skipf("child comm did not stabilise to 'sleep' within 500ms")
 		}

--- a/internal/report/detect.go
+++ b/internal/report/detect.go
@@ -7,10 +7,11 @@ import (
 )
 
 // detectReportPreamble is written once when the detect log file is still empty.
-// Tuned for GitHub Actions job summaries (GFM + limited HTML). (Double-quoted so inline `…` renders in Markdown.)
+// Tuned for GitHub Actions job summaries: pure GFM only. Bug #13 — `<p align>`
+// and `<sub>` fall outside the GitHub Job Summary HTML allowlist and rendered
+// as literal HTML text rather than centered subtitled prose.
 const detectReportPreamble = "## Coldstep · detect\n\n" +
-	"<p align=\"center\"><strong>eBPF runtime audit trail</strong><br/>\n" +
-	"<sub>Process exec plus optional IPv4 TCP (and best-effort DNS names). Detect-only: observe, do not block.</sub></p>\n\n" +
+	"**eBPF runtime audit trail** — process exec plus optional IPv4 TCP (and best-effort DNS names). Detect-only: observe, do not block.\n\n" +
 	"> **Reading this table:** each row is one event from this job. **Comm** is the kernel task name (16-byte field), not full argv or binary path.\n\n" +
 	"<details>\n<summary><strong>Signal sources</strong></summary>\n\n" +
 	"| Kind | Origin |\n|:--|:--|\n" +

--- a/internal/report/detect_test.go
+++ b/internal/report/detect_test.go
@@ -35,6 +35,18 @@ func TestFormatDetectTCPRow(t *testing.T) {
 	}
 }
 
+// Bug #13: the detect preamble used <p align="center"> and <sub> which are
+// outside GitHub's Job Summary HTML allowlist and rendered as literal text.
+// Regression guard: the preamble must contain only pure GFM.
+func TestDetectReportPreamble_NoForbiddenHTML(t *testing.T) {
+	forbidden := []string{"<p align", "<sub>", "</sub>", "<center", "<font"}
+	for _, tag := range forbidden {
+		if strings.Contains(detectReportPreamble, tag) {
+			t.Fatalf("detect preamble contains forbidden GFM tag %q (renders as literal text in Job Summaries):\n%s", tag, detectReportPreamble)
+		}
+	}
+}
+
 func TestAppendDetectRecord_PreambleOnce(t *testing.T) {
 	dir := t.TempDir()
 	p := filepath.Join(dir, "detect.md")

--- a/internal/report/model/builders.go
+++ b/internal/report/model/builders.go
@@ -201,8 +201,16 @@ func BuildDiff(current []Event, baseline []Event) DiffPayload {
 	}
 	// Minimal diff: count events by (type,dst,sni,host,fqdn) tuple. Plan 4 may
 	// extend this to match the Python ci_coldstep_jsonl_traffic_diff fingerprint.
-	cur := fingerprintCounts(current)
-	base := fingerprintCounts(baseline)
+	//
+	// Bug #11: a destination observed once with fqdn populated and once
+	// without (DNS cache miss race) would yield two distinct fingerprints —
+	// `tcp»example.com` and `tcp»1.2.3.4` — and surface as a spurious
+	// traffic_gone + traffic_new pair across otherwise-identical runs.
+	// Build a single dst→name map across current + baseline so the dst-only
+	// events resolve to the same fingerprint as their name-bearing siblings.
+	nameByDst := buildDstNameMap(current, baseline)
+	cur := fingerprintCounts(current, nameByDst)
+	base := fingerprintCounts(baseline, nameByDst)
 	fpIndicators := map[string]map[string]struct{}{}
 	addFingerprintIndicators := func(events []Event) {
 		for _, e := range events {
@@ -210,8 +218,7 @@ func BuildDiff(current []Event, baseline []Event) DiffPayload {
 			if _, ok := egressTypes[typ]; !ok {
 				continue
 			}
-			host := firstNonEmpty(e.AsString("fqdn"), e.AsString("host"), e.AsString("sni"), e.AsString("dst"))
-			fp := typ + "»" + host
+			fp := typ + "»" + resolveFingerprintHost(e, nameByDst)
 			if fpIndicators[fp] == nil {
 				fpIndicators[fp] = map[string]struct{}{}
 			}
@@ -296,18 +303,60 @@ func sortedIndicators(set map[string]struct{}) []string {
 	return out
 }
 
-func fingerprintCounts(events []Event) map[string]int {
+func fingerprintCounts(events []Event, nameByDst map[string]string) map[string]int {
 	out := map[string]int{}
 	for _, e := range events {
 		typ := e.AsString("type")
 		if _, ok := egressTypes[typ]; !ok {
 			continue
 		}
-		host := firstNonEmpty(e.AsString("fqdn"), e.AsString("host"), e.AsString("sni"), e.AsString("dst"))
-		fp := typ + "»" + host
+		fp := typ + "»" + resolveFingerprintHost(e, nameByDst)
 		out[fp]++
 	}
 	return out
+}
+
+// buildDstNameMap collects dst → first-observed name (fqdn / sni / host)
+// across all events, so dst-only events resolve to the same fingerprint as
+// their name-bearing siblings. Repeated dst with different names keeps the
+// first encountered (input order). Empty dst entries are skipped.
+func buildDstNameMap(eventSlices ...[]Event) map[string]string {
+	out := map[string]string{}
+	for _, events := range eventSlices {
+		for _, e := range events {
+			dst := e.AsString("dst")
+			if dst == "" || dst == "0.0.0.0" {
+				continue
+			}
+			if _, ok := out[dst]; ok {
+				continue
+			}
+			name := firstNonEmpty(e.AsString("fqdn"), e.AsString("sni"), e.AsString("host"))
+			if name == "" {
+				continue
+			}
+			out[dst] = name
+		}
+	}
+	return out
+}
+
+// resolveFingerprintHost picks the host portion of the fingerprint for e.
+// Prefers a name on the event itself; falls back to nameByDst (resolved
+// across the union of current + baseline events) so dst-only events match
+// their name-bearing siblings; finally falls back to dst when no name is
+// available anywhere.
+func resolveFingerprintHost(e Event, nameByDst map[string]string) string {
+	if name := firstNonEmpty(e.AsString("fqdn"), e.AsString("sni"), e.AsString("host")); name != "" {
+		return name
+	}
+	if dst := e.AsString("dst"); dst != "" {
+		if name, ok := nameByDst[dst]; ok && name != "" {
+			return name
+		}
+		return dst
+	}
+	return ""
 }
 
 func firstNonEmpty(args ...string) string {

--- a/internal/report/model/builders_bench_test.go
+++ b/internal/report/model/builders_bench_test.go
@@ -14,7 +14,7 @@ func BenchmarkFingerprintCounts_tcpBaseline(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = fingerprintCounts(ev)
+		_ = fingerprintCounts(ev, nil)
 	}
 }
 

--- a/internal/report/model/builders_test.go
+++ b/internal/report/model/builders_test.go
@@ -118,6 +118,38 @@ func TestDiffWithEmptyNonNilBaselineReportsUnavailable(t *testing.T) {
 	}
 }
 
+// Bug #11: BuildDiff fingerprint must conflate dst-only and name-bearing
+// events for the same destination IP. Two consecutive identical runs where
+// one has fqdn populated and the other doesn't (DNS cache miss race) must
+// produce zero diff entries.
+func TestDiffFingerprintCollapsesDNSCacheMiss(t *testing.T) {
+	// Baseline: dst has fqdn populated.
+	baseline := []Event{
+		{"type": "tcp", "fqdn": "example.com", "dst": "1.2.3.4"},
+		{"type": "tls", "fqdn": "example.com", "sni": "example.com", "dst": "1.2.3.4"},
+	}
+	// Current: identical egress, but DNS cache missed on the tcp event so
+	// fqdn is empty. The tls event still has the name.
+	current := []Event{
+		{"type": "tcp", "dst": "1.2.3.4"},
+		{"type": "tls", "fqdn": "example.com", "sni": "example.com", "dst": "1.2.3.4"},
+	}
+
+	d := BuildDiff(current, baseline)
+	if d.Status != "ok" {
+		t.Fatalf("diff.status = %q; want ok", d.Status)
+	}
+	if len(d.TrafficNew) != 0 {
+		t.Errorf("traffic_new = %v; want empty (DNS cache miss must not flip fingerprint)", d.TrafficNew)
+	}
+	if len(d.TrafficGone) != 0 {
+		t.Errorf("traffic_gone = %v; want empty (DNS cache miss must not flip fingerprint)", d.TrafficGone)
+	}
+	if len(d.TrafficChanged) != 0 {
+		t.Errorf("traffic_changed = %v; want empty", d.TrafficChanged)
+	}
+}
+
 func TestDiffWithBaselineIncludesNewGoneChangedAndIndicators(t *testing.T) {
 	current := []Event{
 		{"type": "tcp", "fqdn": "new.example", "dst": "1.1.1.1"},

--- a/internal/report/model/jsonl.go
+++ b/internal/report/model/jsonl.go
@@ -57,7 +57,12 @@ func loadEvents(path string, lim loadEventsLimits) ([]Event, error) {
 		if scanLines > lim.maxScanLines {
 			return nil, fmt.Errorf("jsonl exceeds max scan line count (%d)", lim.maxScanLines)
 		}
-		line := strings.TrimSpace(s.Text())
+		// Bug #10: strip a leading UTF-8 BOM (EF BB BF). Windows producers
+		// (or copy-pasted artifacts edited in Notepad) prepend the BOM to
+		// the first line; without this strip, json.Unmarshal fails silently
+		// on that line, discarding the first event — typically `meta` —
+		// which skews ObservationWindow and can flip the integrity gate.
+		line := strings.TrimPrefix(strings.TrimSpace(s.Text()), "\xef\xbb\xbf")
 		if line == "" {
 			continue
 		}

--- a/internal/report/model/jsonl_test.go
+++ b/internal/report/model/jsonl_test.go
@@ -28,6 +28,33 @@ func TestLoadEventsReturnsErrOnMissingFile(t *testing.T) {
 	}
 }
 
+// Bug #10: a leading UTF-8 BOM (EF BB BF) on the first line must not
+// cause the first event (typically meta) to be dropped via silent
+// json.Unmarshal failure. Reproduce a Windows-edited JSONL with BOM and
+// assert the meta event is parsed correctly.
+func TestLoadEventsStripsLeadingUTF8BOM(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "bom.jsonl")
+	body := "\xef\xbb\xbf" + `{"type":"meta","schema":"v1"}` + "\n" +
+		`{"type":"tcp","dst":"10.0.0.1"}` + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	events, err := LoadEvents(path)
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	if got, want := len(events), 2; got != want {
+		t.Fatalf("event count = %d; want %d (BOM must not drop the meta line)", got, want)
+	}
+	if events[0]["type"] != "meta" {
+		t.Fatalf("first event type = %v; want meta (BOM must not corrupt parse)", events[0]["type"])
+	}
+	if events[0]["schema"] != "v1" {
+		t.Fatalf("first event schema = %v; want v1", events[0]["schema"])
+	}
+}
+
 func TestLoadEventsRejectsTooManyParsedEvents(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "e.jsonl")


### PR DESCRIPTION
## Summary

- **Bug #10 (UTF-8 BOM drops first JSONL event)** — `internal/report/model/jsonl.go`. A leading `EF BB BF` on the first line of an event log (common when a Windows producer pre-pends the BOM) made `json.Unmarshal` fail silently, discarding the first event — typically `meta`. That skews `ObservationWindow` and can flip the integrity gate. Fix: strip the BOM with `strings.TrimPrefix(line, "\xef\xbb\xbf")` after `TrimSpace`. (BOM is U+FEFF, not classified as whitespace by Go's `unicode.IsSpace`, so the trim has to happen explicitly.)
- **Bug #11 (BuildDiff fingerprint conflates name vs IP)** — `internal/report/model/builders.go`. The fingerprint was per-event (`type»firstNonEmpty(fqdn, host, sni, dst)`). Two consecutive identical runs where one event hit a DNS cache miss would produce two fingerprints — `tcp»example.com` and `tcp»1.2.3.4` — and surface a spurious `traffic_gone` + `traffic_new` pair. Fix: build a single `dst → name` map across the union of `current ∪ baseline` events, then resolve dst-only events through that map so they share the fingerprint with their name-bearing siblings.
- **Bug #13 (Job Summary HTML rendered literal)** — `internal/report/detect.go`. The `detectReportPreamble` used `<p align="center">` and `<sub>` which fall outside GitHub's Job Summary HTML allowlist and rendered as literal HTML text. Replace with plain GFM (`**bold**` + em-dash subtitle).
- Add three regression tests: BOM strip (`TestLoadEventsStripsLeadingUTF8BOM`), fingerprint conflation (`TestDiffFingerprintCollapsesDNSCacheMiss`), preamble HTML-tag guard (`TestDetectReportPreamble_NoForbiddenHTML`). Adjust `BenchmarkBuildDiff_*` for the new `fingerprintCounts` signature.

## Why

All three are visible failure modes in the post-v0.4.0 hunt:

- **#10**: an external user reported the integrity gate failing intermittently on detect-mode artifacts they round-tripped through PowerShell pipelines. The PowerShell `Out-File` default encoding emits a BOM.
- **#11**: noisy `traffic_new` / `traffic_gone` diffs across identical workflow runs where the only difference was whether the DNS resolver had warm cache. Reviewers wasted time triaging "new traffic" that was the same destination IP with a momentarily missing fqdn.
- **#13**: the Job Summary card in detect-mode runs showed `<p align="center"><strong>eBPF runtime audit trail</strong></p>` as a literal HTML string, which looks broken. `internal/report/digest.go` already guards `BuildDetectMarkdown` against the same tags — the preamble in `detect.go` was the missing case.

## Test plan

- [ ] `go test ./internal/report/... ./internal/report/model/... -count=1` — including the three new regression cases
- [ ] `bash scripts/check-gofmt.sh`
- [ ] `staticcheck ./internal/report/... ./internal/report/model/...`
- [ ] CI sweep: gofmt, encoding, vet, staticcheck, unit, unit-arm64, integration, action_bundle, detect-mode, defend-mode
