### PR TITLE
fix(defend): trust-seed dns_cache owner map + cross-layer deny dedup

### DIFF
--- a/bpf/dns_cache.h
+++ b/bpf/dns_cache.h
@@ -17,7 +17,8 @@ struct {
 } dns_cache SEC(".maps");
 
 /*
- * allowed_domains map: FQDN (64 bytes) -> __u8.
+ * allowed_domains map: FQDN (char[256], matches dns_cache value width so a
+ * dns_cache value pointer can be used directly as an allowed_domains key) -> __u8.
  * Populated by userspace agent based on policy.
  */
 struct {

--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -413,6 +413,18 @@ func Run(ctx context.Context, cfg config.Config) error {
 		}
 		defendState.setModeAndAllowlist(defendModeForBackend(backend.backend), allowlistSize, ignoredSize)
 		defendState.setIPv6AllowlistSize(ipv6AllowlistSize)
+
+		// SECURITY (dns-cache-trust): seed the defend dns_cache owner-fallback map
+		// from the agent's own resolver so dst_is_allowlisted's late-binding path
+		// is trusted, never fed by poisonable sniffed traffic (see SetBPFMaps note
+		// below). At startup these IPs already overlap the allowed_ipv4 LPM
+		// snapshot; the fallback's real value is the trusted refresh performed by
+		// the DNS drift watcher when a domain's A-record set rotates mid-job.
+		if defendObjs.DnsCache != nil && len(cfg.AllowedDomains) > 0 {
+			owners := policy.ResolveOwners(compileCtx, cfg.AllowedDomains, nil, 2)
+			seeded := seedDefendOwners(defendObjs.DnsCache, owners, stats.addDNSCacheUpdateFailure)
+			slog.Info("defend dns_cache owner map seeded from trusted resolver", "entries", seeded)
+		}
 		rd, err := ringbuf.NewReader(defendObjs.DenyEvents)
 		if err != nil {
 			return fmt.Errorf("ringbuf reader deny: %w", err)
@@ -699,11 +711,17 @@ func Run(ctx context.Context, cfg config.Config) error {
 		// late-binding IP -> FQDN attribution. Defend's cgroup + LSM sections
 		// share one dns_cache map (Phase 2.3 merge), so a single defend
 		// entry covers both hook families (M-14, paired with H-03's deletes).
-		dnsCacheMaps := []*ebpf.Map{dnsObjs.DnsCache}
-		if hasDefend && defendObjs.DnsCache != nil {
-			dnsCacheMaps = append(dnsCacheMaps, defendObjs.DnsCache)
-		}
-		dnsCache.SetBPFMaps(dnsCacheMaps)
+		// SECURITY (dns-cache-trust): the sniffed DNS cache feeds ONLY the
+		// detection-side enrichment map (dnsObjs.DnsCache), used for late-binding
+		// IP -> FQDN attribution in JSONL/digest. The defend ENFORCEMENT map
+		// (defendObjs.DnsCache), consulted by dst_is_allowlisted's owner fallback,
+		// is deliberately NOT registered here: a hostile build step can forge a DNS
+		// reply mapping an allowlisted FQDN to an attacker IP, and feeding that into
+		// the enforcement map would let the forged IP pass the allowlist (defend
+		// bypass). The defend map is seeded instead from the agent's own resolver
+		// via seedDefendOwners (policy.ResolveOwners) at startup and refreshed by
+		// the DNS drift watcher below.
+		dnsCache.SetBPFMaps([]*ebpf.Map{dnsObjs.DnsCache})
 		bpfSt[2] = telemetry.BPFStatus{Name: "dns recvfrom sniff", OK: true}
 		slog.Info("tracing DNS replies (recvfrom)")
 		defer dnsObjs.Close()
@@ -1144,8 +1162,25 @@ func Run(ctx context.Context, cfg config.Config) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			// SECURITY (dns-cache-trust): refresh the defend dns_cache owner
+			// fallback from the trusted resolver on every re-resolution tick so a
+			// domain whose A-records rotate mid-job stays reachable via the
+			// trusted late-binding path — without ever trusting sniffed traffic.
+			// Runs on both drift and no-drift ticks (the IPv4 LPM stays frozen;
+			// only the owner fallback, which was already a live path, is updated).
+			reseedDefendOwners := func() {
+				if defendObjs.DnsCache == nil || len(cfg.AllowedDomains) == 0 {
+					return
+				}
+				rctx, rcancel := context.WithTimeout(runCtx, 60*time.Second)
+				owners := policy.ResolveOwners(rctx, cfg.AllowedDomains, nil, allowlistReCheckMaxAttempts)
+				rcancel()
+				seeded := seedDefendOwners(defendObjs.DnsCache, owners, stats.addDNSCacheUpdateFailure)
+				slog.Debug("defend dns_cache owner map refreshed from trusted resolver", "entries", seeded)
+			}
 			onDrift := func(dr policy.DriftReport) {
 				stats.addDNSDrift()
+				reseedDefendOwners()
 				if cfg.EventsLogPath == "" {
 					return
 				}
@@ -1165,6 +1200,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 				}
 			}
 			onClean := func() {
+				reseedDefendOwners()
 				slog.Debug("allowlist DNS re-resolution: no drift", "domains", len(defendCompiled.Domains))
 			}
 			runDNSDriftWatch(runCtx, defendCompiled, nil, allowlistReCheckMaxAttempts, allowlistReCheckInterval, onDrift, onClean)

--- a/internal/agent/agent_linux_digest.go
+++ b/internal/agent/agent_linux_digest.go
@@ -201,6 +201,7 @@ func buildDigestInput(
 		DefendAllowlistSize:            defendState.allowlistSize,
 		DefendIPv6AllowlistSize:        defendState.allowlistIPv6Size,
 		DefendDenyCount:                defendState.denyCount,
+		DefendDenyCorroborated:         defendState.denyCorroborated,
 		DefendDenyReserveFailures:      defendState.denyReserveFailures,
 		DefendFirstDeny:                defendState.firstDeny,
 		Connect4TupleUpdateFailures:    stats.connect4TupleUpdateFailures(),

--- a/internal/agent/agent_linux_policy_maps.go
+++ b/internal/agent/agent_linux_policy_maps.go
@@ -519,7 +519,8 @@ func appendDenyFromRaw(cfg config.Config, raw []byte, seq *telemetry.SeqGen, jso
 	// blocked process whose argv[0] embeds newline / control bytes must not
 	// be able to forge an extra record in the event log.
 	comm := telemetry.SanitizeField(string(bytes.TrimRight(commb[:], "\x00")), 16)
-	ts := time.Now().UTC().Format(time.RFC3339Nano)
+	now := time.Now()
+	ts := now.UTC().Format(time.RFC3339Nano)
 	matchKind := "unknown"
 	if dns != nil && dns.Lookup(dstIP) != "" {
 		matchKind = "dns_cache"
@@ -545,6 +546,22 @@ func appendDenyFromRaw(cfg config.Config, raw []byte, seq *telemetry.SeqGen, jso
 		deny.HookFamily = hookFamily
 	}
 	deny.MatchKind = matchKind
+	// Cross-layer dedup: on LSM-enabled kernels one blocked syscall fires both
+	// the cgroup hook (connect4/sendmsg4) and the LSM hook (socket_connect/
+	// socket_sendmsg), producing two deny ringbuf records for the same logical
+	// event. Suppress the second (other-family) report within denyDedupWindow so
+	// JSONL and the digest deny count are not doubled; the suppressed event is
+	// tallied in denyCorroboratedN instead. Same-family repeats always emit.
+	dedupKey := denyDedupKey{
+		tgid:     deny.TGID,
+		tid:      deny.ThreadID,
+		dst:      deny.Dst,
+		dport:    deny.Dport,
+		protocol: deny.Protocol,
+	}
+	if !state.shouldEmitDeny(dedupKey, hookFamily, now.UnixNano()) {
+		return deny, nil
+	}
 	if cfg.EventsLogPath != "" {
 		jsonlMu.Lock()
 		deny.Seq = seq.Next()

--- a/internal/agent/agent_linux_state_defend.go
+++ b/internal/agent/agent_linux_state_defend.go
@@ -6,10 +6,38 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/coldstep-io/coldstep/internal/report"
 	"github.com/coldstep-io/coldstep/internal/telemetry"
 )
+
+// denyDedupWindow bounds how long after an emitted deny a second deny with the
+// SAME {tgid,tid,dst,dport,proto} key but a DIFFERENT hook family is treated as
+// the cross-layer twin of the same syscall (cgroup/connect4 + lsm/socket_connect
+// both fire on one connect() on LSM-enabled kernels). Cross-layer ringbuf
+// delivery is near-simultaneous; 1s is generous. Same-family repeats always emit
+// regardless of the window, so genuine retries are never collapsed.
+const denyDedupWindow = time.Second
+
+// denyDedupMaxEntries caps the dedup map so a long defend run with many distinct
+// blocked destinations cannot grow it without bound. Stale entries (older than
+// the window) are pruned opportunistically when the cap is exceeded.
+const denyDedupMaxEntries = 4096
+
+// denyDedupKey identifies one logical deny across hook families.
+type denyDedupKey struct {
+	tgid     uint32
+	tid      uint32
+	dst      string
+	dport    uint16
+	protocol string
+}
+
+type denyDedupEntry struct {
+	family string
+	nano   int64
+}
 
 type defendState struct {
 	mu                     sync.Mutex
@@ -17,11 +45,13 @@ type defendState struct {
 	allowlistSize          int
 	allowlistIPv6Size      int
 	denyCountN             int
+	denyCorroboratedN      int
 	denyReserveFailuresN   int
 	mapIntegrityFailures   int
 	expectedEntries        int
 	expectedIgnoredEntries int
 	firstDenyRowV          *report.DenyDigestRow
+	denyDedup              map[denyDedupKey]denyDedupEntry
 }
 
 type defendSnapshot struct {
@@ -29,6 +59,7 @@ type defendSnapshot struct {
 	allowlistSize        int
 	allowlistIPv6Size    int
 	denyCount            int
+	denyCorroborated     int
 	denyReserveFailures  int
 	mapIntegrityFailures int
 	firstDeny            *report.DenyDigestRow
@@ -139,6 +170,57 @@ func (s *defendState) mapIntegrityFailureCount() int {
 	return s.mapIntegrityFailures
 }
 
+// shouldEmitDeny reports whether a decoded deny should be emitted (JSONL +
+// counted) or treated as the cross-layer twin of a deny already emitted by the
+// other hook family within denyDedupWindow. Returns true to emit, false to
+// corroborate (the corroboration counter is bumped internally).
+//
+// A duplicate is recognized only across DIFFERENT hook families: cgroup/connect4
+// and lsm/socket_connect both fire on the same connect() syscall. Two denies
+// from the SAME family are genuine separate attempts (e.g. a retry loop) and
+// always emit, so no traffic is hidden. A nil receiver always emits.
+func (s *defendState) shouldEmitDeny(key denyDedupKey, family string, nowNano int64) bool {
+	if s == nil {
+		return true
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.denyDedup == nil {
+		s.denyDedup = make(map[denyDedupKey]denyDedupEntry)
+	}
+	prev, ok := s.denyDedup[key]
+	fresh := ok && nowNano-prev.nano <= int64(denyDedupWindow)
+	if fresh && prev.family != "" && family != "" && prev.family != family {
+		// Cross-layer twin of a recently emitted deny: corroborate, don't
+		// re-emit. Keep the original emitting family; refresh the timestamp so
+		// a third hook family (e.g. sendpage) within the window also folds in.
+		s.denyCorroboratedN++
+		s.denyDedup[key] = denyDedupEntry{family: prev.family, nano: nowNano}
+		return false
+	}
+	s.denyDedup[key] = denyDedupEntry{family: family, nano: nowNano}
+	if len(s.denyDedup) > denyDedupMaxEntries {
+		s.pruneDenyDedupLocked(nowNano)
+	}
+	return true
+}
+
+// pruneDenyDedupLocked drops dedup entries older than the window. Caller holds mu.
+func (s *defendState) pruneDenyDedupLocked(nowNano int64) {
+	for k, e := range s.denyDedup {
+		if nowNano-e.nano > int64(denyDedupWindow) {
+			delete(s.denyDedup, k)
+		}
+	}
+}
+
+// denyCorroborated returns the number of denies suppressed as cross-layer twins.
+func (s *defendState) denyCorroborated() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.denyCorroboratedN
+}
+
 func (s *defendState) noteDeny(row report.DenyDigestRow) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -173,6 +255,7 @@ func (s *defendState) snapshot() defendSnapshot {
 		allowlistSize:        s.allowlistSize,
 		allowlistIPv6Size:    s.allowlistIPv6Size,
 		denyCount:            s.denyCountN,
+		denyCorroborated:     s.denyCorroboratedN,
 		denyReserveFailures:  s.denyReserveFailuresN,
 		mapIntegrityFailures: s.mapIntegrityFailures,
 	}

--- a/internal/agent/agent_linux_test.go
+++ b/internal/agent/agent_linux_test.go
@@ -483,6 +483,98 @@ func TestAppendDenyFromRaw_TwoSamples(t *testing.T) {
 	}
 }
 
+// TestAppendDenyFromRaw_CrossLayerDedup verifies the cgroup+LSM dedup: one
+// blocked syscall reported by both hook families within the window emits a
+// single JSONL line and counts once, with the twin tallied as corroborated.
+func TestAppendDenyFromRaw_CrossLayerDedup(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	events := filepath.Join(dir, "events.jsonl")
+	cfg := config.Config{Mode: config.ModeDefend, EventsLogPath: events}
+	var seq telemetry.SeqGen
+	var jsonlMu sync.Mutex
+	state := newDefendState()
+
+	raw := fillTestDenyRawV4(4321, 5001, "curl", denyProtoTCP, denyReasonDstNotAllowlisted, net.ParseIP("1.2.3.4"), 443)
+
+	// Same logical deny, both hook families.
+	if _, err := appendDenyFromRaw(cfg, raw, &seq, &jsonlMu, state, nil, "cgroup", nil); err != nil {
+		t.Fatalf("cgroup deny: %v", err)
+	}
+	if _, err := appendDenyFromRaw(cfg, raw, &seq, &jsonlMu, state, nil, "lsm", nil); err != nil {
+		t.Fatalf("lsm deny: %v", err)
+	}
+
+	if got := state.denyCount(); got != 1 {
+		t.Fatalf("denyCount=%d want 1 (cross-layer twin must not double-count)", got)
+	}
+	if got := state.denyCorroborated(); got != 1 {
+		t.Fatalf("denyCorroborated=%d want 1", got)
+	}
+	b, err := os.ReadFile(events)
+	if err != nil {
+		t.Fatalf("read events: %v", err)
+	}
+	if n := strings.Count(string(b), `"type":"deny"`); n != 1 {
+		t.Fatalf("expected exactly 1 deny JSONL line, got %d:\n%s", n, string(b))
+	}
+}
+
+// TestAppendDenyFromRaw_SameFamilyNotDeduped verifies genuine repeats on the
+// same hook family (e.g. a retry loop) are never collapsed — only cross-family
+// twins are.
+func TestAppendDenyFromRaw_SameFamilyNotDeduped(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	events := filepath.Join(dir, "events.jsonl")
+	cfg := config.Config{Mode: config.ModeDefend, EventsLogPath: events}
+	var seq telemetry.SeqGen
+	var jsonlMu sync.Mutex
+	state := newDefendState()
+
+	raw := fillTestDenyRawV4(7, 8, "curl", denyProtoTCP, denyReasonDstNotAllowlisted, net.ParseIP("5.6.7.8"), 443)
+
+	for i := 0; i < 3; i++ {
+		if _, err := appendDenyFromRaw(cfg, raw, &seq, &jsonlMu, state, nil, "cgroup", nil); err != nil {
+			t.Fatalf("cgroup deny %d: %v", i, err)
+		}
+	}
+	if got := state.denyCount(); got != 3 {
+		t.Fatalf("denyCount=%d want 3 (same-family repeats must all emit)", got)
+	}
+	if got := state.denyCorroborated(); got != 0 {
+		t.Fatalf("denyCorroborated=%d want 0", got)
+	}
+}
+
+// TestAppendDenyFromRaw_DistinctDstCrossFamily verifies cross-family denies to
+// DIFFERENT destinations are both real and both emit.
+func TestAppendDenyFromRaw_DistinctDstCrossFamily(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	events := filepath.Join(dir, "events.jsonl")
+	cfg := config.Config{Mode: config.ModeDefend, EventsLogPath: events}
+	var seq telemetry.SeqGen
+	var jsonlMu sync.Mutex
+	state := newDefendState()
+
+	rawA := fillTestDenyRawV4(1, 1, "curl", denyProtoTCP, denyReasonDstNotAllowlisted, net.ParseIP("1.1.1.1"), 443)
+	rawB := fillTestDenyRawV4(1, 1, "curl", denyProtoTCP, denyReasonDstNotAllowlisted, net.ParseIP("2.2.2.2"), 443)
+
+	if _, err := appendDenyFromRaw(cfg, rawA, &seq, &jsonlMu, state, nil, "cgroup", nil); err != nil {
+		t.Fatalf("deny A: %v", err)
+	}
+	if _, err := appendDenyFromRaw(cfg, rawB, &seq, &jsonlMu, state, nil, "lsm", nil); err != nil {
+		t.Fatalf("deny B: %v", err)
+	}
+	if got := state.denyCount(); got != 2 {
+		t.Fatalf("denyCount=%d want 2 (distinct dst must not dedup)", got)
+	}
+	if got := state.denyCorroborated(); got != 0 {
+		t.Fatalf("denyCorroborated=%d want 0", got)
+	}
+}
+
 func TestAppendDenyFromRaw_InvalidPayload(t *testing.T) {
 	t.Parallel()
 	cfg := config.Config{Mode: config.ModeDefend}

--- a/internal/agent/defend_dns_seed.go
+++ b/internal/agent/defend_dns_seed.go
@@ -1,0 +1,74 @@
+package agent
+
+import (
+	"log/slog"
+	"net"
+
+	"github.com/cilium/ebpf"
+)
+
+// ownerBPFValue renders a trusted owner name into the 256-byte dns_cache value
+// buffer consulted by defend_policy.inc:dst_is_allowlisted. The owner string is
+// looked up verbatim as an allowed_domains key, so it must byte-match the
+// normalized domain programmed into allowed_domains. Returns the buffer and
+// whether the name was truncated (names longer than dnsBPFNameMax bytes), which
+// mirrors dnsNameForBPF's contract on the sniffed path.
+func ownerBPFValue(name string) ([256]byte, bool) {
+	var buf [256]byte
+	truncated := false
+	if len(name) > dnsBPFNameMax {
+		name = name[:dnsBPFNameMax]
+		truncated = true
+	}
+	copy(buf[:], name)
+	return buf, truncated
+}
+
+// ownerMapWriter is the subset of *ebpf.Map that seedDefendOwners needs. An
+// interface keeps the seeding logic unit-testable on non-Linux hosts where a
+// real BPF map cannot be created. *ebpf.Map satisfies it.
+type ownerMapWriter interface {
+	Update(key, value interface{}, flags ebpf.MapUpdateFlags) error
+}
+
+// seedDefendOwners writes trusted ip->owner entries into the defend dns_cache
+// BPF map consulted by dst_is_allowlisted's late-binding fallback.
+//
+// SECURITY (dns-cache-trust): owners MUST come from policy.ResolveOwners — the
+// agent's own resolver — never from sniffed DNS replies. The sniffed DNSCache
+// (DNSCache.AddFromPacket) feeds only the detection-side enrichment map; routing
+// it into the enforcement map would let a hostile build step forge a DNS reply
+// mapping an allowlisted FQDN to an attacker IP and egress to that IP. Seeding
+// from the trusted resolver raises the runtime fallback trust to match the
+// startup allowlist-compile trust.
+//
+// Returns the number of entries programmed. onFailure (nil-ok) is invoked once
+// per failed Update so partial userspace<->kernel sync is observable in the
+// digest, matching DNSCache's onBPFFailure semantics.
+func seedDefendOwners(m ownerMapWriter, owners map[[4]byte]string, onFailure func()) int {
+	if m == nil || len(owners) == 0 {
+		return 0
+	}
+	programmed := 0
+	for ip, name := range owners {
+		if name == "" {
+			continue
+		}
+		key := ip
+		val, truncated := ownerBPFValue(name)
+		if truncated {
+			slog.Warn("defend owner seed: owner truncated for BPF map value",
+				"ip", net.IP(ip[:]).String(), "name_len", len(name), "max_len", dnsBPFNameMax)
+		}
+		if err := m.Update(&key, &val, ebpf.UpdateAny); err != nil {
+			slog.Warn("defend owner seed: BPF map update failed",
+				"ip", net.IP(ip[:]).String(), "err", err)
+			if onFailure != nil {
+				onFailure()
+			}
+			continue
+		}
+		programmed++
+	}
+	return programmed
+}

--- a/internal/agent/defend_dns_seed_test.go
+++ b/internal/agent/defend_dns_seed_test.go
@@ -1,0 +1,116 @@
+package agent
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/cilium/ebpf"
+)
+
+// fakeOwnerMap is an in-memory ownerMapWriter so seedDefendOwners is testable
+// without a real BPF map (cross-platform: runs on the Windows dev host too).
+type fakeOwnerMap struct {
+	entries map[[4]byte][256]byte
+	failOn  map[[4]byte]bool
+	updates int
+}
+
+func (f *fakeOwnerMap) Update(key, value interface{}, _ ebpf.MapUpdateFlags) error {
+	f.updates++
+	k := *(key.(*[4]byte))
+	if f.failOn[k] {
+		return errors.New("simulated map update failure")
+	}
+	v := *(value.(*[256]byte))
+	if f.entries == nil {
+		f.entries = make(map[[4]byte][256]byte)
+	}
+	f.entries[k] = v
+	return nil
+}
+
+func ownerFromVal(v [256]byte) string {
+	return string(bytes.TrimRight(v[:], "\x00"))
+}
+
+func TestOwnerBPFValue(t *testing.T) {
+	v, truncated := ownerBPFValue("example.com")
+	if truncated {
+		t.Fatalf("short name reported truncated")
+	}
+	if got := ownerFromVal(v); got != "example.com" {
+		t.Fatalf("owner round-trip = %q, want example.com", got)
+	}
+	// Trailing bytes must be NUL so the BPF char* lookup terminates.
+	if v[len("example.com")] != 0 {
+		t.Fatalf("value not NUL-terminated after name")
+	}
+
+	long := make([]byte, dnsBPFNameMax+10)
+	for i := range long {
+		long[i] = 'a'
+	}
+	v2, truncated2 := ownerBPFValue(string(long))
+	if !truncated2 {
+		t.Fatalf("over-length name not reported truncated")
+	}
+	if got := len(ownerFromVal(v2)); got != dnsBPFNameMax {
+		t.Fatalf("truncated owner len = %d, want %d", got, dnsBPFNameMax)
+	}
+}
+
+func TestSeedDefendOwners_NilAndEmpty(t *testing.T) {
+	if n := seedDefendOwners(nil, map[[4]byte]string{{1, 2, 3, 4}: "a.com"}, nil); n != 0 {
+		t.Fatalf("nil map programmed %d entries, want 0", n)
+	}
+	m := &fakeOwnerMap{}
+	if n := seedDefendOwners(m, nil, nil); n != 0 {
+		t.Fatalf("empty owners programmed %d entries, want 0", n)
+	}
+	if m.updates != 0 {
+		t.Fatalf("empty owners triggered %d Update calls, want 0", m.updates)
+	}
+}
+
+func TestSeedDefendOwners_HappyPath(t *testing.T) {
+	m := &fakeOwnerMap{}
+	owners := map[[4]byte]string{
+		{93, 184, 216, 34}: "example.com",
+		{1, 1, 1, 1}:       "one.one.one.one",
+		{10, 0, 0, 9}:      "", // empty owner: skipped, never written
+	}
+	n := seedDefendOwners(m, owners, nil)
+	if n != 2 {
+		t.Fatalf("programmed %d entries, want 2", n)
+	}
+	if got := ownerFromVal(m.entries[[4]byte{93, 184, 216, 34}]); got != "example.com" {
+		t.Fatalf("example.com owner = %q", got)
+	}
+	if got := ownerFromVal(m.entries[[4]byte{1, 1, 1, 1}]); got != "one.one.one.one" {
+		t.Fatalf("cloudflare owner = %q", got)
+	}
+	if _, ok := m.entries[[4]byte{10, 0, 0, 9}]; ok {
+		t.Fatalf("empty-owner entry was written; must be skipped")
+	}
+}
+
+func TestSeedDefendOwners_FailureCounted(t *testing.T) {
+	failKey := [4]byte{198, 51, 100, 7}
+	m := &fakeOwnerMap{failOn: map[[4]byte]bool{failKey: true}}
+	owners := map[[4]byte]string{
+		failKey:          "bad.example",
+		{203, 0, 113, 5}: "good.example",
+	}
+	failures := 0
+	n := seedDefendOwners(m, owners, func() { failures++ })
+	if n != 1 {
+		t.Fatalf("programmed %d entries, want 1 (one failed)", n)
+	}
+	if failures != 1 {
+		t.Fatalf("onFailure called %d times, want 1", failures)
+	}
+	if _, ok := m.entries[failKey]; ok {
+		t.Fatalf("failed key must not be recorded as written")
+	}
+}

--- a/internal/bpf/defend/loader.go
+++ b/internal/bpf/defend/loader.go
@@ -3,6 +3,7 @@
 package defend
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -345,14 +346,35 @@ func kernelHasLSMHook(name string) bool {
 	return spec.TypeByName("bpf_lsm_"+name, &fn) == nil
 }
 
-// isSendpageLoadFailure pattern-matches an ebpf.NewCollection error to
-// detect prog_load rejection of lsm_socket_sendpage specifically. Used
-// as a defensive fallback when the BTF pre-check missed the kernel's
-// removal of the hook.
+// isSendpageLoadFailure detects an ebpf.NewCollection error that represents
+// prog_load rejection of lsm_socket_sendpage specifically. Used as a
+// defensive fallback when the BTF pre-check missed the kernel's removal of
+// the hook.
+//
+// Two signals are required, not one:
+//
+//  1. The error chain names the sendpage program/hook. The failing program
+//     name ("lsm_socket_sendpage") only appears in cilium/ebpf's
+//     "program <name>: ..." wrap, so a substring check is the only way to
+//     attribute the failure to this program rather than another LSM hook.
+//
+//  2. The error is a recognized structured load failure. On kernel 6.5+ the
+//     missing bpf_lsm_socket_sendpage BTF target surfaces as btf.ErrNotFound
+//     (prog_load fails at attach-target resolution before the verifier runs,
+//     so it is NOT an *ebpf.VerifierError); a genuine verifier rejection
+//     surfaces as *ebpf.VerifierError. Accept either.
+//
+// Requiring both guards against stripping sendpage on an unrelated error that
+// merely happens to contain the substring, while still firing for the real
+// 6.5+ removal case that pure VerifierError matching would miss.
 func isSendpageLoadFailure(err error) bool {
 	if err == nil {
 		return false
 	}
 	s := err.Error()
-	return strings.Contains(s, "lsm_socket_sendpage") || strings.Contains(s, "socket_sendpage")
+	if !strings.Contains(s, "lsm_socket_sendpage") && !strings.Contains(s, "socket_sendpage") {
+		return false
+	}
+	var ve *ebpf.VerifierError
+	return errors.Is(err, btf.ErrNotFound) || errors.As(err, &ve)
 }

--- a/internal/bpf/defend/loader_test.go
+++ b/internal/bpf/defend/loader_test.go
@@ -4,8 +4,52 @@ package defend
 
 import (
 	"errors"
+	"fmt"
 	"testing"
+
+	"github.com/cilium/ebpf/btf"
 )
+
+// TestIsSendpageLoadFailure pins the two-signal contract: the error must name
+// the sendpage program AND be a recognized structured load failure (btf
+// not-found or verifier error). An unrelated error containing the substring,
+// or a sendpage btf.ErrNotFound without the name, must not trigger the strip.
+func TestIsSendpageLoadFailure(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{
+			"sendpage btf not found (kernel 6.5+ removal)",
+			fmt.Errorf("program lsm_socket_sendpage: %w", btf.ErrNotFound),
+			true,
+		},
+		{
+			"unrelated btf not found without sendpage name",
+			fmt.Errorf("program lsm_socket_connect: %w", btf.ErrNotFound),
+			false,
+		},
+		{
+			"sendpage substring but not a structured load failure",
+			errors.New("write deny event for socket_sendpage: disk full"),
+			false,
+		},
+		{
+			"sendpage name plus btf not found in a deeper wrap",
+			fmt.Errorf("load defend: %w", fmt.Errorf("program lsm_socket_sendpage: %w", btf.ErrNotFound)),
+			true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSendpageLoadFailure(tc.err); got != tc.want {
+				t.Fatalf("isSendpageLoadFailure(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
 
 // TestDefendSpecExposesIOUringLSMProgram asserts the compiled BPF object
 // contains the H15 lsm/io_uring_cmd program. This is a pure spec parse —

--- a/internal/policy/allowlist.go
+++ b/internal/policy/allowlist.go
@@ -386,6 +386,99 @@ func NormalizeDomainsFromRaw(raw string) []string {
 	return normalizeAllowlistDomains(splitFields(raw))
 }
 
+// ResolveOwners resolves the given domains (A records / IPv4 only) via resolver
+// and returns a map of resolved IPv4 address -> owning domain. The owner string
+// is the normalized (lowercased, trimmed) domain so it byte-matches the
+// allowed_domains BPF map keys; the BPF dns_cache allow-path can then resolve
+// dns_cache[ip] -> owner -> allowed_domains[owner].
+//
+// This is the TRUSTED late-binding source for defend mode: it uses the agent's
+// own resolver, NOT DNS responses sniffed from runner traffic. Feeding the BPF
+// dns_cache enforcement map from sniffed traffic let a hostile build step poison
+// it (craft a fake response mapping an allowlisted FQDN to an attacker IP, then
+// egress to that IP). ResolveOwners raises the runtime trust to match the
+// startup allowlist-compile trust (same resolver path).
+//
+// Wildcard entries (`*.suffix`) are skipped — they are not in allowed_domains
+// (exact-string map) and are not resolvable. When two domains resolve to the
+// same IPv4, the lexicographically smallest owner wins so the result is stable
+// across runs. resolver may be nil (defaults to net.DefaultResolver.LookupIP);
+// maxAttempts is clamped to >= 1.
+func ResolveOwners(ctx context.Context, domains []string, resolver LookupIPFunc, maxAttempts int) map[[4]byte]string {
+	if resolver == nil {
+		resolver = net.DefaultResolver.LookupIP
+	}
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	normalized := normalizeAllowlistDomains(domains)
+
+	type ownerResult struct {
+		domain string
+		ips4   []net.IP
+	}
+	results := make([]ownerResult, len(normalized))
+
+	eg, gctx := errgroup.WithContext(ctx)
+	eg.SetLimit(coldstepDomainLookupConcurrencyLimit)
+	for i, domain := range normalized {
+		idx, d := i, domain
+		if strings.HasPrefix(d, "*.") {
+			continue
+		}
+		eg.Go(func() error {
+			res := ownerResult{domain: d}
+			for attempt := 0; attempt < maxAttempts; attempt++ {
+				if gctx.Err() != nil {
+					break
+				}
+				lookupCtx, cancel := context.WithTimeout(gctx, coldstepDomainLookupAttemptTimeout)
+				ips4, err := resolver(lookupCtx, "ip4", d)
+				cancel()
+				if err == nil {
+					for _, ip := range ips4 {
+						if ip.To4() != nil {
+							res.ips4 = append(res.ips4, ip)
+						}
+					}
+					break
+				}
+				if errors.Is(err, context.Canceled) && gctx.Err() != nil {
+					break
+				}
+				// per-attempt timeout or transient failure: retry
+			}
+			results[idx] = res
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		slog.Warn("resolve owners: errgroup wait returned error", "err", err)
+	}
+
+	out := make(map[[4]byte]string)
+	for _, res := range results {
+		if res.domain == "" {
+			continue
+		}
+		for _, ip := range res.ips4 {
+			ip4 := ip.To4()
+			if ip4 == nil {
+				continue
+			}
+			var k [4]byte
+			copy(k[:], ip4)
+			if existing, ok := out[k]; !ok || res.domain < existing {
+				out[k] = res.domain
+			}
+		}
+	}
+	return out
+}
+
 // DriftReport summarizes the difference between two CompileResult snapshots
 // of the same domain allowlist. AddedIPs / RemovedIPs are deterministic
 // (sorted ascending) so the caller can emit them in a stable JSONL payload.

--- a/internal/policy/resolve_owners_test.go
+++ b/internal/policy/resolve_owners_test.go
@@ -1,0 +1,84 @@
+package policy
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+)
+
+func ownerKey(a, b, c, d byte) [4]byte { return [4]byte{a, b, c, d} }
+
+func TestResolveOwners_MapsIPv4ToNormalizedOwner(t *testing.T) {
+	resolver := func(_ context.Context, network, host string) ([]net.IP, error) {
+		if network != "ip4" {
+			t.Fatalf("ResolveOwners must query ip4 only, got %q", network)
+		}
+		switch host {
+		case "example.com":
+			return []net.IP{net.ParseIP("93.184.216.34")}, nil
+		case "api.example.com":
+			return []net.IP{net.ParseIP("203.0.113.7"), net.ParseIP("203.0.113.8")}, nil
+		default:
+			return nil, errors.New("unexpected host")
+		}
+	}
+
+	got := ResolveOwners(context.Background(), []string{" Example.COM ", "API.example.com"}, resolver, 2)
+
+	want := map[[4]byte]string{
+		ownerKey(93, 184, 216, 34): "example.com",
+		ownerKey(203, 0, 113, 7):   "api.example.com",
+		ownerKey(203, 0, 113, 8):   "api.example.com",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d entries, want %d (%v)", len(got), len(want), got)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Fatalf("owner for %v = %q, want %q", net.IP(k[:]), got[k], v)
+		}
+	}
+}
+
+func TestResolveOwners_SkipsWildcards(t *testing.T) {
+	var calls sync.Map
+	resolver := func(_ context.Context, _, host string) ([]net.IP, error) {
+		calls.Store(host, true)
+		return []net.IP{net.ParseIP("10.0.0.1")}, nil
+	}
+	got := ResolveOwners(context.Background(), []string{"*.cdn.example.com"}, resolver, 1)
+	if len(got) != 0 {
+		t.Fatalf("wildcard produced %d entries, want 0", len(got))
+	}
+	if _, ok := calls.Load("*.cdn.example.com"); ok {
+		t.Fatalf("wildcard domain must not be resolved")
+	}
+}
+
+func TestResolveOwners_CollisionPrefersSmallestOwner(t *testing.T) {
+	// Two domains resolve to the same IP; the lexicographically smallest owner
+	// must win so the seeded map is stable across runs regardless of resolution
+	// order.
+	resolver := func(_ context.Context, _, host string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("198.51.100.5")}, nil
+	}
+	got := ResolveOwners(context.Background(), []string{"zebra.example.com", "alpha.example.com"}, resolver, 1)
+	if got[ownerKey(198, 51, 100, 5)] != "alpha.example.com" {
+		t.Fatalf("collision owner = %q, want alpha.example.com", got[ownerKey(198, 51, 100, 5)])
+	}
+}
+
+func TestResolveOwners_DropsNonIPv4Results(t *testing.T) {
+	resolver := func(_ context.Context, _, _ string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("2606:4700:4700::1111"), net.ParseIP("1.0.0.1")}, nil
+	}
+	got := ResolveOwners(context.Background(), []string{"one.example.com"}, resolver, 1)
+	if len(got) != 1 {
+		t.Fatalf("got %d entries, want 1 (IPv6 dropped)", len(got))
+	}
+	if got[ownerKey(1, 0, 0, 1)] != "one.example.com" {
+		t.Fatalf("IPv4 owner = %q", got[ownerKey(1, 0, 0, 1)])
+	}
+}

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -352,6 +352,9 @@ func buildTriageRows(in DigestInput) [][2]string {
 	modeCell := fmt.Sprintf("`%s`", mode)
 	if isBlockingDigestMode(in.DefendMode) {
 		modeCell += fmt.Sprintf(" — **deny events:** %d", in.DefendDenyCount)
+		if in.DefendDenyCorroborated > 0 {
+			modeCell += fmt.Sprintf(" (**+%d** corroborated by 2nd hook layer)", in.DefendDenyCorroborated)
+		}
 		if in.DefendDenyReserveFailures > 0 {
 			modeCell += fmt.Sprintf(" (**+%d** deny reserve failures)", in.DefendDenyReserveFailures)
 		}
@@ -776,6 +779,9 @@ func writeDefendDetails(b *strings.Builder, in DigestInput) {
 	fmt.Fprintf(b, "| Mode | `%s` |\n", sanitizeCell(mode))
 	fmt.Fprintf(b, "| Allowlist size | %d |\n", in.DefendAllowlistSize)
 	fmt.Fprintf(b, "| Deny count | %d |\n", in.DefendDenyCount)
+	if in.DefendDenyCorroborated > 0 {
+		fmt.Fprintf(b, "| Deny corroborated (2nd hook layer, deduped) | %d |\n", in.DefendDenyCorroborated)
+	}
 	if in.DefendDenyReserveFailures > 0 {
 		fmt.Fprintf(b, "| Deny ringbuf reserve failures (blocked, no JSONL) | %d |\n", in.DefendDenyReserveFailures)
 	}

--- a/internal/report/digest_types.go
+++ b/internal/report/digest_types.go
@@ -192,6 +192,7 @@ type DigestInput struct {
 	DefendMode                string
 	DefendAllowlistSize       int
 	DefendDenyCount           int
+	DefendDenyCorroborated    int
 	DefendDenyReserveFailures int
 	DefendFirstDeny           *DenyDigestRow
 


### PR DESCRIPTION
## Summary

Two defend-mode hardening fixes on one branch.

### 1. DNS cache trust (`f78155c`)

`defend_policy.inc:dst_is_allowlisted` has an owner fallback:
`dns_cache[ip] -> owner -> allowed_domains[owner]`. The defend enforcement
`dns_cache` map was registered into the same userspace slice that
`DNSCache.AddFromPacket` writes from **sniffed DNS replies**. A hostile build
step could forge a reply mapping an allowlisted FQDN to an attacker IP,
poison the enforcement map, and egress to that IP past the allowlist.

- Stop feeding `defendObjs.DnsCache` from sniffed traffic; sniffed data now
  feeds detection enrichment (`dnsObjs.DnsCache`) only.
- Seed the defend map from `policy.ResolveOwners` (the agent's own resolver)
  at startup, and refresh it on each DNS drift tick. Runtime fallback trust
  now matches the startup allowlist-compile trust.
- Owner strings normalize identically to `allowed_domains` keys
  (`ToLower`+`TrimSpace`), so the BPF exact-match lookup holds.
- Fix stale `dns_cache.h` comment (key is `char[256]`, not 64 bytes) and
  document why a `dns_cache` value pointer is a valid `allowed_domains` key.

New unit tests: `ResolveOwners` (policy) and `seedDefendOwners` (agent).

### 2. Cross-layer deny dedup (`30f11ec`, already on branch)

Dedup cross-layer deny events (cgroup + LSM fire on one syscall); harden
sendpage load detection. See commit for detail.

## Test

- `go test ./internal/policy/ ./internal/agent/` — pass
- `GOOS=linux` vet + staticcheck + test-binary compile — clean
- gofmt / encoding — clean

BPF integration (root + verifier) runs in CI.

## Out of scope (follow-up)

Deep BPF audit surfaced an IPv4-mapped IPv6 false-deny in defend mode
(`::ffff:<allowlisted-IPv4>` via an AF_INET6 socket misses `allowed_ipv6`
and is denied). Fail-closed, not a bypass; needs a BPF change + verifier
run, tracked separately.
