### PR TITLE
fix(config,action): trim signing key; hoist per-call markdown regexes

### DIFF
--- a/cmd/coldstep-action/main.go
+++ b/cmd/coldstep-action/main.go
@@ -52,6 +52,14 @@ var httpNotifyClient = &http.Client{Timeout: 60 * time.Second}
 // GitHub allows alphanumeric, hyphens, dots, and underscores in org/repo names.
 var githubRepoPartRE = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 
+// Markdown fence runs escaped per-line by sanitizeDigestForMarkdown. Compiled
+// once at package scope — the function runs over every digest line, so a
+// per-call MustCompile was needless work on the post-step hot path.
+var (
+	markdownBacktickRunRE = regexp.MustCompile("`{3,}")
+	markdownTildeRunRE    = regexp.MustCompile("~{3,}")
+)
+
 const (
 	maxReadyStatusJSONBytes = 512 << 10 // agent status should be tiny; bound disk/memory abuse
 	maxGitHubEventJSONBytes = 8 << 20   // $GITHUB_EVENT_PATH payload cap before full json.Unmarshal
@@ -656,8 +664,6 @@ func sanitizeDigestForMarkdown(body string) string {
 	body = strings.TrimPrefix(body, "\uFEFF")
 	body = strings.ReplaceAll(strings.ReplaceAll(body, "\r\n", "\n"), "\r", "\n")
 	lines := strings.Split(body, "\n")
-	backticks := regexp.MustCompile("`{3,}")
-	tildes := regexp.MustCompile("~{3,}")
 	for i := range lines {
 		line := lines[i]
 		if len(line) > 4096 {
@@ -670,10 +676,10 @@ func sanitizeDigestForMarkdown(body string) string {
 		}
 		line = strings.ReplaceAll(line, "\\", "\\\\")
 		line = strings.ReplaceAll(line, "<", "&lt;")
-		line = backticks.ReplaceAllStringFunc(line, func(m string) string {
+		line = markdownBacktickRunRE.ReplaceAllStringFunc(line, func(m string) string {
 			return strings.Repeat("\\`", len(m))
 		})
-		line = tildes.ReplaceAllStringFunc(line, func(m string) string {
+		line = markdownTildeRunRE.ReplaceAllStringFunc(line, func(m string) string {
 			return strings.Repeat("\\~", len(m))
 		})
 		lines[i] = line

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -141,7 +141,7 @@ func LoadFromEnv() (Config, error) {
 		FeatureGates:         gates,
 		DetectProfile:        profile,
 		CgroupAttachPath:     cgPath,
-		SigningKey:           os.Getenv("COLDSTEP_SIGNING_KEY"),
+		SigningKey:           strings.TrimSpace(os.Getenv("COLDSTEP_SIGNING_KEY")),
 		RunnerHasIPv6:        envBoolTrue("COLDSTEP_RUNNER_HAS_IPV6"),
 	}, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -295,6 +295,37 @@ func TestLoadFromEnv_AllowlistNormalization(t *testing.T) {
 	}
 }
 
+func TestLoadFromEnv_SigningKeyTrimmed(t *testing.T) {
+	clearColdstepPolicyEnv(t)
+	t.Setenv("CI_GUARD_MODE", "detect")
+	t.Setenv("GITHUB_STEP_SUMMARY", "")
+	t.Setenv("COLDSTEP_SIGNING_KEY", "  AAAA==\n")
+	c, err := LoadFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// NewSigner treats a bad-base64 key as fatal; surrounding whitespace from a
+	// CI secret injection must be trimmed or an otherwise-valid key crashes the
+	// agent at startup.
+	if c.SigningKey != "AAAA==" {
+		t.Fatalf("SigningKey = %q, want trimmed %q", c.SigningKey, "AAAA==")
+	}
+}
+
+func TestLoadFromEnv_SigningKeyBlankStaysEmpty(t *testing.T) {
+	clearColdstepPolicyEnv(t)
+	t.Setenv("CI_GUARD_MODE", "detect")
+	t.Setenv("GITHUB_STEP_SUMMARY", "")
+	t.Setenv("COLDSTEP_SIGNING_KEY", "   \n")
+	c, err := LoadFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.SigningKey != "" {
+		t.Fatalf("SigningKey = %q, want empty (signing disabled)", c.SigningKey)
+	}
+}
+
 func TestParseFeatureGates(t *testing.T) {
 	t.Parallel()
 	m := ParseFeatureGates(" proc_tree=1 , FS_EVENTS=false ")


### PR DESCRIPTION
Three deep-dive audit passes (optimizations + confirmed security/robustness, code only).

**Pass 1 — telemetry/signing:** audited clean. JSONL record-boundary injection is structurally prevented (json.Marshal escaping + SanitizeField). One latent note (signed-JSONL float64 round-trip on uint64 > 2^53; not hit on fresh runners) — left as-is.

**Pass 2 — config (confirmed bug, fixed):** `COLDSTEP_SIGNING_KEY` was the only env var in `LoadFromEnv` not `TrimSpace`'d. `NewSigner` treats bad base64 as fatal → a CI-injected trailing newline crashed agent startup on an otherwise-valid key. Trimmed + 2 regression tests.

**Pass 3 — action (optimization, fixed):** `sanitizeDigestForMarkdown` recompiled two regexes per call while iterating digest lines → hoisted to package scope.

Verified: gofmt, `GOOS=linux` vet + staticcheck + test-compile clean; `cmd/coldstep-action` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)