### PR TITLE
fix(defend): gate IPv4-mapped IPv6 against the IPv4 allowlist

### DIFF
--- a/bpf/trace_defend_cgroup.inc
+++ b/bpf/trace_defend_cgroup.inc
@@ -184,6 +184,21 @@ static __always_inline int cg_ipv6_is_link_local(struct bpf_sock_addr *ctx)
 	return (ctx->user_ip6[0] & bpf_htonl(0xffc00000)) == bpf_htonl(0xfe800000);
 }
 
+/*
+ * IPv4-mapped IPv6 (::ffff:0:0/96): the high 80 bits are zero and bytes
+ * 10-11 are 0xffff, so user_ip6[0]==0, user_ip6[1]==0, user_ip6[2]==
+ * htonl(0x0000ffff). The embedded IPv4 (user_ip6[3], already network byte
+ * order) is the real wire destination — a dual-stack socket connecting to
+ * an allowlisted IPv4 via ::ffff:a.b.c.d must be gated by the IPv4 allowlist,
+ * not the AAAA-only allowed_ipv6 trie (which would falsely deny it).
+ */
+static __always_inline int cg_ipv6_is_v4mapped(struct bpf_sock_addr *ctx)
+{
+	return ctx->user_ip6[0] == 0 &&
+	       ctx->user_ip6[1] == 0 &&
+	       ctx->user_ip6[2] == bpf_htonl(0x0000ffff);
+}
+
 static __always_inline void cg_bump_percpu_u32(void *map)
 {
 	__u32 key = 0;
@@ -288,6 +303,30 @@ static __always_inline int defend_cgroup_sock_addr_ipv6(struct bpf_sock_addr *ct
 		return 1;
 	if (cg_ipv6_is_link_local(ctx))
 		return 1;
+
+	/*
+	 * IPv4-mapped IPv6: gate the embedded IPv4 against the IPv4 allowlist /
+	 * ignored trie and emit an IPv4-family deny on miss. The wire traffic is
+	 * IPv4, so this keeps a dual-stack socket to an allowlisted IPv4 from
+	 * being falsely blocked while still denying non-allowlisted destinations.
+	 * Mirrors defend_cgroup_sock_addr_ipv4; does not bump the IPv6 observe
+	 * counter (the destination is not genuine IPv6 egress).
+	 */
+	if (cg_ipv6_is_v4mapped(ctx)) {
+		__be32 v4 = ctx->user_ip6[3]; /* network byte order */
+		__u8 addr4[4];
+
+		if (!cg_defense_enabled())
+			return 1;
+		if (cg_dst_in_ignored(v4))
+			return 1;
+		if (cg_dst_is_allowlisted(v4))
+			return 1;
+		__builtin_memcpy(addr4, &v4, sizeof(addr4));
+		cg_emit_deny_event_ipv4(protocol, addr4, dport, COLDSTEP_DENY_REASON_DST_NOT_ALLOWLISTED);
+		return 0;
+	}
+
 	cg_bump_percpu_u32(observe_map);
 
 	if (!cg_defense_enabled())

--- a/internal/agent/agent_linux_policy_maps.go
+++ b/internal/agent/agent_linux_policy_maps.go
@@ -270,9 +270,16 @@ type defendMapSet struct {
 // next agent restart. Operators relying on DNS-backed domain rules should treat
 // the agent's lifetime as the freshness window for the allowlist and add literal
 // CIDRs / IPs for any destinations that need to survive DNS rotation. The
-// dns_cache map (populated by trace_dns.bpf.c at runtime) is consulted as a
-// fallback for reverse lookups in defend_policy.inc:dst_is_allowlisted, but the
-// primary LPM map is snapshot-only.
+// defend dns_cache map is consulted as an owner-fallback in
+// defend_policy.inc:dst_is_allowlisted, but the primary LPM map is
+// snapshot-only. SECURITY (dns-cache-trust): that defend dns_cache is seeded
+// ONLY from the agent's own resolver (seedDefendOwners / policy.ResolveOwners)
+// and refreshed by the DNS drift watcher — it is deliberately NOT fed by
+// trace_dns.bpf.c sniffed traffic (which writes the separate detection-side
+// dnsObjs.DnsCache). Feeding sniffed replies into enforcement would let a
+// hostile build step forge an allowlisted-FQDN→attacker-IP mapping and bypass
+// the allowlist; see the wiring note in agent_linux.go where SetBPFMaps
+// registers only the detection map.
 func loadDefendMapsForBackend(maps defendMapSet, compiled policy.CompileResult, pol *policy.Policy) (int, int, error) {
 	keyMode := uint32(0)
 	modeDefend := uint32(1)

--- a/internal/policy/ipv6_bypass.go
+++ b/internal/policy/ipv6_bypass.go
@@ -30,9 +30,11 @@ import "net"
 // Any other class (including ::, unique-local fc00::/7, multicast ff00::/8,
 // and globally routable 2000::/3) is NOT bypassed: those addresses go
 // through the LPM trie and are denied if absent. IPv4-mapped IPv6 inputs
-// (::ffff:0:0/96) are not considered bypass either — they should never
-// reach the IPv6 cgroup hook in practice (the kernel routes them through
-// the IPv4 path) but defensive coding treats them as ordinary IPv6.
+// (::ffff:0:0/96) are NOT bypass and NOT ordinary IPv6 — a dual-stack socket
+// can connect to ::ffff:a.b.c.d and reach the IPv6 cgroup hook, so the BPF
+// program routes the embedded IPv4 to the IPv4 allowlist instead (see
+// cg_ipv6_is_v4mapped + IPv4MappedEmbeddedIPv4). This function returns false
+// for them; IPv4MappedEmbeddedIPv4 is the classifier that matters there.
 func IPv6BypassesDefend(ip net.IP) bool {
 	if ip == nil {
 		return false
@@ -52,4 +54,33 @@ func IPv6BypassesDefend(ip net.IP) bool {
 	// == 0x80). Matches the BPF check `(user_ip6[0] & htonl(0xffc00000))
 	// == htonl(0xfe800000)`.
 	return ip16[0] == 0xfe && (ip16[1]&0xc0) == 0x80
+}
+
+// IPv4MappedEmbeddedIPv4 reports whether ip is an IPv4-mapped IPv6 address
+// (::ffff:0:0/96) and, if so, returns the embedded 4-byte IPv4. This is the
+// userspace mirror of cg_ipv6_is_v4mapped in bpf/trace_defend_cgroup.inc: a
+// dual-stack socket connecting to ::ffff:a.b.c.d reaches the cgroup/connect6 +
+// sendmsg6 hooks, which must gate the embedded IPv4 against the IPv4 allowlist
+// (allowed_ipv4 / ignored trie) rather than the AAAA-only allowed_ipv6 trie —
+// otherwise a v4-mapped connection to an allowlisted IPv4 is falsely denied.
+//
+// The prefix test (bytes 0-9 zero, bytes 10-11 == 0xff) mirrors the BPF check
+// `user_ip6[0]==0 && user_ip6[1]==0 && user_ip6[2]==htonl(0x0000ffff)`. Keep
+// the two in lockstep.
+func IPv4MappedEmbeddedIPv4(ip net.IP) (net.IP, bool) {
+	ip16 := ip.To16()
+	if ip16 == nil {
+		return nil, false
+	}
+	for i := 0; i < 10; i++ {
+		if ip16[i] != 0 {
+			return nil, false
+		}
+	}
+	if ip16[10] != 0xff || ip16[11] != 0xff {
+		return nil, false
+	}
+	out := make(net.IP, net.IPv4len)
+	copy(out, ip16[12:16])
+	return out, true
 }

--- a/internal/policy/ipv6_bypass_test.go
+++ b/internal/policy/ipv6_bypass_test.go
@@ -67,3 +67,45 @@ func TestIPv6BypassesDefend_NilSafe(t *testing.T) {
 		t.Fatal("IPv6BypassesDefend(nil) returned true, want false")
 	}
 }
+
+// TestIPv4MappedEmbeddedIPv4 pins the userspace mirror of cg_ipv6_is_v4mapped.
+// A v4-mapped destination on a dual-stack socket reaches the IPv6 cgroup hook;
+// the embedded IPv4 must be extracted so defend gates it against the IPv4
+// allowlist instead of the AAAA-only allowed_ipv6 trie.
+func TestIPv4MappedEmbeddedIPv4(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		ip     string
+		wantOK bool
+		wantV4 string
+	}{
+		{"v4-mapped allowlisted", "::ffff:93.184.216.34", true, "93.184.216.34"},
+		{"v4-mapped zero", "::ffff:0.0.0.0", true, "0.0.0.0"},
+		{"v4-mapped 1.1.1.1", "::ffff:1.1.1.1", true, "1.1.1.1"},
+		{"native ipv4 not mapped via To16", "8.8.8.8", true, "8.8.8.8"}, // To16 of v4 yields ::ffff:8.8.8.8
+		{"real ipv6 global", "2606:4700:4700::1111", false, ""},
+		{"loopback v6", "::1", false, ""},
+		{"link-local", "fe80::1", false, ""},
+		{"ipv4-compatible (deprecated, not mapped)", "::1.2.3.4", false, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			v4, ok := IPv4MappedEmbeddedIPv4(net.ParseIP(c.ip))
+			if ok != c.wantOK {
+				t.Fatalf("%s: ok=%v want %v", c.ip, ok, c.wantOK)
+			}
+			if ok && v4.String() != c.wantV4 {
+				t.Fatalf("%s: embedded=%s want %s", c.ip, v4, c.wantV4)
+			}
+		})
+	}
+}
+
+func TestIPv4MappedEmbeddedIPv4_NilSafe(t *testing.T) {
+	t.Parallel()
+	if _, ok := IPv4MappedEmbeddedIPv4(nil); ok {
+		t.Fatal("nil must return ok=false")
+	}
+}


### PR DESCRIPTION
Confirmed defend-mode correctness bug found in the BPF deep-dive review.

**Bug:** a dual-stack socket connecting to `::ffff:<allowlisted-IPv4>` reaches `cgroup/connect6`/`sendmsg6`, which only checked the AAAA-only `allowed_ipv6` LPM trie → the embedded allowlisted IPv4 was **falsely denied**. Fail-closed (over-block, not a bypass), but breaks dual-stack clients that prefer v4-mapped (Go default dialer on some hosts, JVM `preferIPv4Stack=false`).

**Fix:** `defend_cgroup_sock_addr_ipv6` detects `::ffff:0:0/96` (new `cg_ipv6_is_v4mapped`) and routes the embedded IPv4 through the IPv4 allowlist / ignored trie / deny path, emitting an AF_INET deny on miss. IPv6 observe counter not bumped (not genuine IPv6 egress). LSM path unaffected (it only enforces AF_INET sockaddr; cgroup6 is the gate).

Userspace mirror `policy.IPv4MappedEmbeddedIPv4` added as regression anchor (same pattern as `IPv6BypassesDefend`); stale comment corrected. 9 mirror test cases pass.

CI regenerates the defend BPF objects and runs the verifier + defend-mode integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)