### PR TITLE
fix(agent): keep KTLS wildcard live until the last offload's TTL, not the first

### DIFF
--- a/internal/agent/agent_linux_ktls_tracker.go
+++ b/internal/agent/agent_linux_ktls_tracker.go
@@ -75,11 +75,22 @@ type ktlsEntry struct {
 //     ktlsTrackerTTL. There is no background goroutine — the tracker lives
 //     as long as a single agent run and the entry count is bounded by the
 //     per-run KTLS setsockopt rate (single-digit to low-thousands).
+//
+//   - The wildcard (fd==0) answer is derived on demand from `by` rather than
+//     cached in a parallel per-pid map. An earlier design kept a `latest[pid]`
+//     entry holding the earliest Mark, but that conflated two clocks: the
+//     ordering reference (earliest markedAt) and TTL liveness (the wall-clock
+//     `at` of *some* offload). It stored the earliest mark's `at`, so the
+//     wildcard expired when the FIRST offload's TTL lapsed even while later
+//     offloads on the same pid were still active — and was never rebuilt from
+//     surviving `by` entries, silently dropping the override and over-stating
+//     SNI confidence on a still-encrypted socket. Deriving from `by` (bounded,
+//     under lock) keeps liveness = "any surviving offload" and ordering =
+//     "earliest surviving markedAt" without a desync-prone cache.
 type ktlsTracker struct {
-	mu     sync.Mutex
-	now    func() time.Time
-	by     map[ktlsKey]ktlsEntry
-	latest map[uint32]ktlsEntry // pid -> most recent offload (wildcard path)
+	mu  sync.Mutex
+	now func() time.Time
+	by  map[ktlsKey]ktlsEntry
 }
 
 // newKTLSTracker constructs a tracker with the wall-clock time source. Tests
@@ -91,9 +102,8 @@ func newKTLSTracker() *ktlsTracker {
 
 func newKTLSTrackerClock(now func() time.Time) *ktlsTracker {
 	return &ktlsTracker{
-		now:    now,
-		by:     make(map[ktlsKey]ktlsEntry),
-		latest: make(map[uint32]ktlsEntry),
+		now: now,
+		by:  make(map[ktlsKey]ktlsEntry),
 	}
 }
 
@@ -106,14 +116,9 @@ func newKTLSTrackerClock(now func() time.Time) *ktlsTracker {
 //
 // For the per-(pid, fd) entry the most recent Mark wins — that record is
 // keyed by fd, so the second offload genuinely supersedes the first. The
-// per-pid `latest` map is the wildcard fallback (for TLS events whose wire
-// format does not carry fd) and tracks the *earliest* surviving Mark for
-// the pid: when two fds on the same pid both offload, a pre-offload TLS
-// write captured between the two Marks must still gate against the
-// earlier offload's markedAt, not the later one — otherwise the
-// arrival-order ordering check (`tlsTimestampNs >= markedAt`) would be
-// evaluated against the wrong reference and the TLS event could be
-// misclassified as pre-offload plaintext.
+// wildcard (fd==0) fallback used by the TLS ring reader is derived from `by`
+// at query time (see IsKTLS), not cached here, so it stays correct across
+// eviction without a parallel per-pid map.
 func (t *ktlsTracker) Mark(pid, fd uint32, markedAtNs int64) {
 	if t == nil {
 		return
@@ -122,11 +127,7 @@ func (t *ktlsTracker) Mark(pid, fd uint32, markedAtNs int64) {
 	defer t.mu.Unlock()
 	now := t.now()
 	t.evictLocked(now)
-	entry := ktlsEntry{at: now, markedAt: markedAtNs}
-	t.by[ktlsKey{PID: pid, FD: fd}] = entry
-	if existing, ok := t.latest[pid]; !ok || markedAtNs < existing.markedAt {
-		t.latest[pid] = entry
-	}
+	t.by[ktlsKey{PID: pid, FD: fd}] = ktlsEntry{at: now, markedAt: markedAtNs}
 }
 
 // IsKTLS reports whether (pid, fd) has been Marked within ktlsTrackerTTL AND
@@ -151,10 +152,29 @@ func (t *ktlsTracker) IsKTLS(pid, fd uint32, tlsTimestampNs int64) bool {
 		}
 		return false
 	}
-	if e, ok := t.latest[pid]; ok && e.at.After(cutoff) {
-		return tlsTimestampNs >= e.markedAt
+	// Wildcard: liveness = any non-expired offload for this pid; ordering =
+	// the EARLIEST surviving markedAt so a plaintext write captured between
+	// two offloads on the same pid still gates against the earlier reference.
+	// Derived from `by` (bounded, lock held) so a later offload keeps the
+	// wildcard live after an earlier one's TTL lapses (the eviction-gap bug
+	// the old cached `latest[pid]` had).
+	var (
+		found    bool
+		earliest int64
+	)
+	for k, e := range t.by {
+		if k.PID != pid || !e.at.After(cutoff) {
+			continue
+		}
+		if !found || e.markedAt < earliest {
+			earliest = e.markedAt
+			found = true
+		}
 	}
-	return false
+	if !found {
+		return false
+	}
+	return tlsTimestampNs >= earliest
 }
 
 func (t *ktlsTracker) evictLocked(now time.Time) {
@@ -162,11 +182,6 @@ func (t *ktlsTracker) evictLocked(now time.Time) {
 	for k, e := range t.by {
 		if !e.at.After(cutoff) {
 			delete(t.by, k)
-		}
-	}
-	for pid, e := range t.latest {
-		if !e.at.After(cutoff) {
-			delete(t.latest, pid)
 		}
 	}
 }

--- a/internal/agent/agent_linux_ktls_tracker_test.go
+++ b/internal/agent/agent_linux_ktls_tracker_test.go
@@ -169,6 +169,60 @@ func TestKTLSTracker_MultiFDPerPidEarliestMarkWins(t *testing.T) {
 	}
 }
 
+// TestKTLSTracker_WildcardSurvivesEarlierOffloadEviction is the regression
+// for the eviction-gap bug: when a pid has two offloads whose Marks straddle
+// the TTL boundary, the wildcard (fd==0) path must stay live as long as ANY
+// offload for that pid is within the window. The old cached latest[pid] held
+// the EARLIEST mark's wall-clock `at`, so the wildcard went blind when the
+// first offload expired — even though the second was still active — silently
+// dropping the KTLS override and over-stating SNI confidence on a still-
+// encrypted socket. Deriving the wildcard from `by` fixes it.
+func TestKTLSTracker_WildcardSurvivesEarlierOffloadEviction(t *testing.T) {
+	var now = time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	tr := newKTLSTrackerClock(clock)
+
+	const pid uint32 = 5150
+	const fd1 uint32 = 3
+	const fd2 uint32 = 5
+	const firstMarkNs int64 = 1_000_000_000
+	const secondMarkNs int64 = 2_000_000_000
+	const tlsAfterNs int64 = 3_000_000_000 // after both Marks
+
+	// Offload A at t=0.
+	tr.Mark(pid, fd1, firstMarkNs)
+	// Offload B 10s later — still well inside the 60s TTL.
+	now = now.Add(10 * time.Second)
+	tr.Mark(pid, fd2, secondMarkNs)
+
+	// Advance past A's TTL but not B's: A expires at t0+60s, B at t0+70s.
+	// Land at t0+65s so only B survives.
+	now = now.Add(ktlsTrackerTTL - 5*time.Second) // 10s + 55s = 65s since t0
+
+	// A's per-(pid,fd) record must be gone; B's must remain.
+	if tr.IsKTLS(pid, fd1, tlsAfterNs) {
+		t.Fatalf("IsKTLS(%d, %d) exact = true after A's TTL lapsed; want false", pid, fd1)
+	}
+	if !tr.IsKTLS(pid, fd2, tlsAfterNs) {
+		t.Fatalf("IsKTLS(%d, %d) exact = false while B still in TTL; want true", pid, fd2)
+	}
+
+	// The wildcard must still flip — B keeps the pid live. The old code
+	// returned false here because latest[pid] was evicted with A.
+	if !tr.IsKTLS(pid, 0, tlsAfterNs) {
+		t.Fatalf("IsKTLS(%d, 0, %d) wildcard = false while a later offload (fd=%d) "+
+			"is still within TTL; want true (eviction-gap regression)",
+			pid, tlsAfterNs, fd2)
+	}
+
+	// Past B's TTL too: now the wildcard genuinely goes false.
+	now = now.Add(10 * time.Second) // t0+75s — both expired
+	if tr.IsKTLS(pid, 0, tlsAfterNs) {
+		t.Fatalf("IsKTLS(%d, 0, %d) wildcard = true after both offloads expired; want false",
+			pid, tlsAfterNs)
+	}
+}
+
 // TestKTLSTracker_WildcardIsolation guards the per-pid wildcard against
 // cross-pid bleed: marking pid=A must not make IsKTLS(pid=B, 0) return true.
 // Without this property the digest would falsely tag unrelated TLS events as


### PR DESCRIPTION
## Summary

Fixes a KTLS-tracker logic bug found during a deep Go audit: the per-pid wildcard (`fd==0`) path — used by the TLS ring reader because `tls_sniff_event` carries no fd — went blind once the **first** of several offloads on a pid expired, even while later offloads were still active.

## The bug

`Mark` cached the wildcard answer in a parallel `latest[pid]` map holding the earliest offload's `ktlsEntry`. That entry stores the earliest offload's wall-clock `at`, conflating two distinct clocks:

- the **ordering reference** (earliest `markedAt`, correct), and
- **TTL liveness** (which should track the *latest* surviving offload).

`evictLocked` therefore dropped `latest[pid]` when the **first** offload's TTL lapsed and never rebuilt it from the still-live entries in `by`.

### Failure scenario
- pid P offloads fd3 @ t=0 (`markedAt=100`) and fd5 @ t=10s (`markedAt=200`); `latest[P] = {at:0, markedAt:100}`.
- At t=65s a wildcard TLS event (`fd=0`) arrives. `by[{P,5}]` is still valid (`at=10s` > cutoff `5s`) but `latest[P]` was evicted at t=60s.
- `IsKTLS(P,0,…)` returns **false** → the TLS row keeps its original `full`/`partial` SNI confidence instead of being downgraded to `unknown`/reason `ktls`.

**Impact:** over-states SNI visibility on a still-kernel-encrypted socket — the exact honesty regression P4 exists to prevent. Reachable by any multi-connection TLS client (curl keepalive, a step hitting several HTTPS endpoints) whose offloads straddle the 60s TTL.

## Fix

Delete the desync-prone `latest` map and derive the wildcard answer on demand from `by` under the existing lock: liveness = any non-expired offload for the pid, ordering = earliest surviving `markedAt`. `by` is bounded (single-digit→low-thousands per run) so the scan is cheap. Net −1 map, simpler struct, single source of truth.

## Tests

Adds `TestKTLSTracker_WildcardSurvivesEarlierOffloadEviction` (two offloads straddling the TTL boundary → wildcard stays live on the survivor, goes false only after both expire). Existing earliest-mark / TTL / pre-offload-ordering / isolation tests unchanged and green.

gofmt / vet / staticcheck clean; full `internal/agent` unit suite passes (WSL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
