### PR TITLE
test(action)+refactor(agent): lift action coverage; dedup per-CPU sum

### DIFF
--- a/cmd/coldstep-action/runstop_linux_test.go
+++ b/cmd/coldstep-action/runstop_linux_test.go
@@ -1,0 +1,31 @@
+//go:build linux
+
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestWaitForReady_ChildExit: when the agent pid is already dead and no
+// healthy status file exists, waitForReady must return "child_exit" rather
+// than spinning until the timeout. Uses a real process run to completion so
+// its reaped pid is reliably not-alive.
+func TestWaitForReady_ChildExit(t *testing.T) {
+	cmd := exec.Command("true")
+	if err := cmd.Run(); err != nil {
+		t.Skipf("cannot run /usr/bin/true: %v", err)
+	}
+	deadPid := cmd.Process.Pid // reaped by Run -> Signal(0) yields ESRCH
+
+	if pidAlive(deadPid) {
+		t.Skipf("reaped pid %d still reported alive; environment cannot exercise child_exit", deadPid)
+	}
+
+	missing := filepath.Join(t.TempDir(), "never-written.json")
+	if got := waitForReady(missing, 5*time.Second, deadPid); got != "child_exit" {
+		t.Fatalf("waitForReady with dead pid = %q, want child_exit", got)
+	}
+}

--- a/cmd/coldstep-action/runstop_test.go
+++ b/cmd/coldstep-action/runstop_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestWaitForReady_Ready: a status file with ok:true returns "ready".
+func TestWaitForReady_Ready(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "ready.json")
+	if err := os.WriteFile(p, []byte(`{"ok":true}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := waitForReady(p, 2*time.Second, os.Getpid()); got != "ready" {
+		t.Fatalf("waitForReady = %q, want ready", got)
+	}
+}
+
+// TestWaitForReady_ExplicitNotReady: ok:false returns "explicit_not_ready".
+func TestWaitForReady_ExplicitNotReady(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "ready.json")
+	if err := os.WriteFile(p, []byte(`{"ok":false}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := waitForReady(p, 2*time.Second, os.Getpid()); got != "explicit_not_ready" {
+		t.Fatalf("waitForReady = %q, want explicit_not_ready", got)
+	}
+}
+
+// TestWaitForReady_Timeout: no status file + live pid + short budget -> "timeout".
+func TestWaitForReady_Timeout(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "never-written.json")
+	if got := waitForReady(p, 250*time.Millisecond, os.Getpid()); got != "timeout" {
+		t.Fatalf("waitForReady = %q, want timeout", got)
+	}
+}
+
+// TestRunStop_JobSummaryMergeAndMarker exercises the default report path:
+// the on-disk digest is appended to GITHUB_STEP_SUMMARY behind the section
+// heading, and the H11 integrity marker is appended to the detect log.
+func TestRunStop_JobSummaryMergeAndMarker(t *testing.T) {
+	ws := t.TempDir()
+	action := t.TempDir()
+	detect := filepath.Join(ws, ".coldstep-detect.md")
+	const body = "## digest\n\nsome egress rows\n"
+	if err := os.WriteFile(detect, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	summary := filepath.Join(ws, "step-summary.md")
+	if err := os.WriteFile(summary, []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GITHUB_WORKSPACE", ws)
+	t.Setenv("GITHUB_ACTION_PATH", action)
+	t.Setenv("GITHUB_STEP_SUMMARY", summary)
+
+	// No pid file present -> runStop skips SIGTERM/drain and proceeds to report.
+	if err := runStop(stopConfig{Report: "job-summary"}); err != nil {
+		t.Fatalf("runStop: %v", err)
+	}
+
+	got, err := os.ReadFile(summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(got)
+	if !strings.Contains(s, "Coldstep - digest") {
+		t.Errorf("step summary missing section heading:\n%s", s)
+	}
+	if !strings.Contains(s, "some egress rows") {
+		t.Errorf("step summary missing digest body:\n%s", s)
+	}
+
+	// Integrity marker appended to the on-disk detect log.
+	d, err := os.ReadFile(detect)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(d), "coldstep-digest-sha256:") {
+		t.Errorf("detect log missing integrity marker:\n%s", d)
+	}
+}
+
+// TestRunStop_ReportNoneSkipsSummary: report=none must not touch
+// GITHUB_STEP_SUMMARY even when a digest exists.
+func TestRunStop_ReportNoneSkipsSummary(t *testing.T) {
+	ws := t.TempDir()
+	action := t.TempDir()
+	if err := os.WriteFile(filepath.Join(ws, ".coldstep-detect.md"), []byte("## d\n\nrows\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	summary := filepath.Join(ws, "step-summary.md")
+	if err := os.WriteFile(summary, []byte("PRE-EXISTING\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GITHUB_WORKSPACE", ws)
+	t.Setenv("GITHUB_ACTION_PATH", action)
+	t.Setenv("GITHUB_STEP_SUMMARY", summary)
+
+	if err := runStop(stopConfig{Report: "none"}); err != nil {
+		t.Fatalf("runStop: %v", err)
+	}
+
+	got, err := os.ReadFile(summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(got), "Coldstep") {
+		t.Errorf("report=none must not write the digest to the step summary:\n%s", got)
+	}
+}
+
+// TestRunStop_FailOnErrorWithoutReady: fail-on-error with no ready marker and
+// no healthy status returns the operational error.
+func TestRunStop_FailOnErrorWithoutReady(t *testing.T) {
+	ws := t.TempDir()
+	action := t.TempDir()
+	t.Setenv("GITHUB_WORKSPACE", ws)
+	t.Setenv("GITHUB_ACTION_PATH", action)
+	t.Setenv("GITHUB_STEP_SUMMARY", "")
+
+	err := runStop(stopConfig{FailOnError: true, Report: "none"})
+	if err == nil {
+		t.Fatal("runStop with fail-on-error and no ready signal: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "did not report ready") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/agent/agent_linux_policy_maps.go
+++ b/internal/agent/agent_linux_policy_maps.go
@@ -112,13 +112,18 @@ func loadIgnoredLPMMap(m *ebpf.Map, nets []*net.IPNet) (int, error) {
 // program unloaded) is logged at WARN and surfaced as zero so digest rendering
 // keeps progressing — losing the distinction between "counter is genuinely
 // zero" and "map is unreadable" was the M-07 anti-pattern.
-func readUint32PerCPUArraySum(m *ebpf.Map, helperName string) int {
+// readUint32PerCPUKeySum sums every CPU slot for a single key of a
+// BPF_MAP_TYPE_PERCPU_ARRAY with uint32 values. Failure semantics (M-07):
+// "key not found" is the legitimate zero state and is returned silently; any
+// other Lookup error is logged at WARN and surfaced as zero so callers keep
+// progressing. Shared core for readUint32PerCPUArraySum (key 0) and the
+// per-syscall partial-observe counters.
+func readUint32PerCPUKeySum(m *ebpf.Map, key uint32, helperName string) int {
 	if m == nil {
 		return 0
 	}
-	var k uint32
 	var vals []uint32
-	if err := m.Lookup(&k, &vals); err != nil {
+	if err := m.Lookup(&key, &vals); err != nil {
 		if errors.Is(err, ebpf.ErrKeyNotExist) {
 			return 0
 		}
@@ -132,6 +137,10 @@ func readUint32PerCPUArraySum(m *ebpf.Map, helperName string) int {
 	return n
 }
 
+func readUint32PerCPUArraySum(m *ebpf.Map, helperName string) int {
+	return readUint32PerCPUKeySum(m, 0, helperName)
+}
+
 // readPartialEgressCounts returns the BG-01 per-syscall partial-observe
 // counters (sendfile, splice, sendmmsg) summed across CPUs. Slots:
 //
@@ -141,28 +150,9 @@ func readUint32PerCPUArraySum(m *ebpf.Map, helperName string) int {
 //
 // Reads each slot independently because PERCPU_ARRAY Lookup is per-key.
 func readPartialEgressCounts(m *ebpf.Map) (sendfile, splice, sendmmsg int) {
-	if m == nil {
-		return 0, 0, 0
-	}
-	read := func(key uint32, label string) int {
-		var vals []uint32
-		if err := m.Lookup(&key, &vals); err != nil {
-			if errors.Is(err, ebpf.ErrKeyNotExist) {
-				return 0
-			}
-			slog.Warn("percpu uint32 map lookup failed", "helper", label, "err", err)
-			return 0
-		}
-		n := 0
-		for _, v := range vals {
-			n += int(v)
-		}
-		return n
-	}
-	sendfile = read(0, "readPartialEgressCounts(sendfile)")
-	splice = read(1, "readPartialEgressCounts(splice)")
-	sendmmsg = read(2, "readPartialEgressCounts(sendmmsg)")
-	return
+	return readUint32PerCPUKeySum(m, 0, "readPartialEgressCounts(sendfile)"),
+		readUint32PerCPUKeySum(m, 1, "readPartialEgressCounts(splice)"),
+		readUint32PerCPUKeySum(m, 2, "readPartialEgressCounts(sendmmsg)")
 }
 
 // readIPv6ConnectObservedCount returns the per-CPU sum of the


### PR DESCRIPTION
## Summary

Two independent hygiene changes surfaced during a coverage + simplification pass. No production behavior change.

## 1. `test(action)` — lift `cmd/coldstep-action` coverage 54.7% → 64.2%

It was the lowest-covered package despite owning security-relevant post-step logic. Adds unit tests for the two 0%-covered entry points:

- **`waitForReady`** — `ready` / `explicit_not_ready` / `timeout` / `child_exit` branches (the dead-pid path via a reaped real process so it is exercised deterministically; Linux-tagged).
- **`runStop`** — `GITHUB_STEP_SUMMARY` merge + H11 integrity-marker append on the default job-summary path, `report=none` suppression, and the `fail-on-error` "did not report ready" operational gate.

## 2. `refactor(agent)` — one shared per-CPU sum core

`readUint32PerCPUArraySum` and `readPartialEgressCounts` each hand-rolled the same `Lookup` + `ErrKeyNotExist`-tolerant handling + cross-CPU sum loop. Extract `readUint32PerCPUKeySum(m, key, helper)`: the array sum is now key 0, the partial-egress counters call it for keys 0/1/2. Behavior identical (M-07 zero-on-error preserved); −10 net lines.

gofmt / vet / staticcheck clean; agent + action tests green (WSL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
