### PR TITLE
fix(report): canonicalize legacy enforce mode in digest details cell

### DIFF
--- a/internal/report/digest_aggregation.go
+++ b/internal/report/digest_aggregation.go
@@ -128,8 +128,28 @@ func isBlockingDigestMode(m string) bool {
 	return strings.HasPrefix(m, "defend+") || strings.HasPrefix(m, "enforce+")
 }
 
+// canonicalizeDigestMode maps a legacy "enforce" mode label (written into JSONL
+// artifacts by pre-rename agents) onto its current "defend" equivalent so the
+// triage ribbon and the Defend details table agree on a single label. The
+// ribbon canonicalizes via isBlockingDigestMode (always rendering "defend"),
+// so without this the details cell would leak the raw "enforce" string and the
+// same digest would carry two different mode labels. Backend suffixes are
+// preserved ("enforce+lsm" -> "defend+lsm"); non-enforce values pass through
+// trimmed but otherwise unchanged.
+func canonicalizeDigestMode(m string) string {
+	trimmed := strings.TrimSpace(m)
+	lower := strings.ToLower(trimmed)
+	if lower == "enforce" {
+		return "defend"
+	}
+	if strings.HasPrefix(lower, "enforce+") {
+		return "defend" + trimmed[len("enforce"):]
+	}
+	return trimmed
+}
+
 func digestModeCell(m string) string {
-	m = strings.TrimSpace(m)
+	m = canonicalizeDigestMode(m)
 	if m == "" {
 		return "detect"
 	}

--- a/internal/report/digest_test.go
+++ b/internal/report/digest_test.go
@@ -104,6 +104,52 @@ func TestBuildDetectMarkdown_LegacyEnforceModeTreatedAsDefend(t *testing.T) {
 	}
 }
 
+// Bug #2: the triage ribbon canonicalizes a legacy mode:"enforce" artifact to
+// `defend`, but the Defend details table used to render the raw mode string —
+// so one digest carried two different labels (ribbon `defend`, details
+// `enforce`). Both sites must now render `defend` for every enforce variant.
+func TestBuildDetectMarkdown_DefendDetailsCanonicalizesLegacyEnforce(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		mode string
+		want string
+	}{
+		{"enforce", "defend"},
+		{"Enforce", "defend"},
+		{"enforce+cgroup", "defend+cgroup"},
+		{"ENFORCE+lsm", "defend+lsm"},
+	} {
+		tc := tc
+		t.Run(tc.mode, func(t *testing.T) {
+			md := BuildDetectMarkdown(DigestInput{
+				DefendMode:          tc.mode,
+				DefendDenyCount:     2,
+				DefendAllowlistSize: 1,
+				BPF:                 []telemetry.BPFStatus{{Name: "connect", OK: true}},
+				MaxRowsPerSection:   50,
+			})
+			// Ribbon: Mode row canonicalizes to `defend`.
+			if !strings.Contains(md, "**Mode** | `defend`") {
+				t.Errorf("ribbon mode not canonicalized for %q; output:\n%s", tc.mode, md)
+			}
+			// Details: Defend section Mode cell renders the canonical label.
+			detailsCell := "| Mode | `" + tc.want + "` |"
+			if !strings.Contains(md, detailsCell) {
+				t.Errorf("missing details cell %q for %q; output:\n%s", detailsCell, tc.mode, md)
+			}
+			// The raw enforce label must not leak through either the ribbon
+			// or the details cell (digest body otherwise uses the word
+			// "enforcement" descriptively, so check the rendered cells only).
+			if strings.Contains(md, "**Mode** | `enforce") {
+				t.Errorf("ribbon leaked raw enforce label for %q; output:\n%s", tc.mode, md)
+			}
+			if strings.Contains(md, "| Mode | `enforce") {
+				t.Errorf("details leaked raw enforce label for %q; output:\n%s", tc.mode, md)
+			}
+		})
+	}
+}
+
 // Bug #6: also exercise the predicate directly so failures point at the source
 // of truth instead of routing through BuildDetectMarkdown.
 func TestIsBlockingDigestMode_LegacyEnforceAlias(t *testing.T) {


### PR DESCRIPTION
## Problem

The digest's triage ribbon canonicalizes a blocking run's mode to `defend` (via `isBlockingDigestMode`, which already treats legacy `enforce` artifacts as defend), but `writeDefendDetails` (`internal/report/digest.go:778`) rendered the **raw** `DefendMode` string through `digestModeCell`.

Result: a pre-rename JSONL artifact carrying `mode:"enforce"` produced a ribbon labeled `defend` **and** a Defend details cell labeled `enforce` — two different mode labels in the same digest. No test covered it.

## Fix

Add `canonicalizeDigestMode(s string)` in `internal/report/digest_aggregation.go` mapping `enforce` → `defend` (preserving any `+<backend>` suffix, e.g. `enforce+lsm` → `defend+lsm`) and route `digestModeCell` through it, so both render sites agree.

## Test

`TestBuildDetectMarkdown_DefendDetailsCanonicalizesLegacyEnforce` feeds `mode:"enforce"` (and `Enforce`, `enforce+cgroup`, `ENFORCE+lsm`) and asserts the triage ribbon and the Defend details cell both render the canonical `defend` label, and that the raw `enforce` string leaks through neither cell.

`go test ./internal/report/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)