### PR TITLE
feat(agent): reassemble TLS SNI for IPv4-mapped IPv6 sockets

### DIFF
--- a/internal/agent/agent_linux_ring_read.go
+++ b/internal/agent/agent_linux_ring_read.go
@@ -493,16 +493,19 @@ func readTLSRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, pol
 			// split where the 5-byte record header lands in one write() and the
 			// handshake body lands in the next.
 			//
-			// P5: skip reassembly for IPv6 — tlsReassemblyKey keys on the v4
-			// daddr ([4]byte), which would collapse to {0,0,0,0} for every
-			// IPv6 stream and cause cross-connection collisions. Extending
-			// the key shape is out of scope for the SNI-only P5 increment;
-			// fragmented v6 handshakes fall through to tls_sni_parse drop.
-			if isIPv6 {
+			// tlsReassemblyKey keys on a v4 daddr ([4]byte). Native IPv6
+			// streams have no usable v4 key (they would all collapse to
+			// {0,0,0,0} and collide), so they fall through to the
+			// tls_sni_parse drop. IPv4-mapped IPv6 (::ffff:0:0/96) is the
+			// exception: dual-stack sockets carry real IPv4 wire traffic, and
+			// tlsReassemblyKeyForEvent extracts the embedded v4 to route those
+			// onto the same reassembly path as native IPv4 (H21 fix).
+			key, ok := tlsReassemblyKeyForEvent(tgid, daddr, daddr6, isIPv6, port)
+			if !ok {
 				stats.addDropped("tls_sni_parse")
 				continue
 			}
-			res := reasm.appendAndParse(tlsReassemblyKey{PID: tgid, Dst: daddr, Dport: port}, rawPay)
+			res := reasm.appendAndParse(key, rawPay)
 			if !res.parsed {
 				stats.addDropped("tls_sni_parse")
 				continue

--- a/internal/agent/agent_linux_tls_reassembler.go
+++ b/internal/agent/agent_linux_tls_reassembler.go
@@ -3,6 +3,7 @@
 package agent
 
 import (
+	"net"
 	"sync"
 	"time"
 
@@ -39,6 +40,34 @@ type tlsReassemblyKey struct {
 	PID   uint32
 	Dst   [4]byte
 	Dport uint16
+}
+
+// tlsReassemblyKeyForEvent derives the reassembly key for a tls_sniff_event.
+//
+// Native IPv4 events key on daddr directly. The key's Dst is a [4]byte, so
+// native IPv6 streams have no usable key — they would all collapse to
+// {0,0,0,0} and cross-pollute each other, so the caller drops their fragments.
+//
+// IPv4-mapped IPv6 (::ffff:0:0/96) is the exception: the wire traffic is real
+// IPv4 carried over a dual-stack socket, and the low 4 bytes of daddr6 hold the
+// genuine IPv4 destination. net.IP.To4() returns that embedded v4 for the
+// mapped prefix and nil for native IPv6, so it doubles as the discriminator.
+// Mapped events are keyed on the embedded v4 and share the native-IPv4
+// reassembly path, recovering fragmented ClientHello SNI that was previously
+// dropped on dual-stack systems (detect-only telemetry gap).
+//
+// ok=false signals "no shared v4 key; drop this fragment".
+func tlsReassemblyKeyForEvent(tgid uint32, daddr [4]byte, daddr6 [16]byte, isIPv6 bool, dport uint16) (tlsReassemblyKey, bool) {
+	if !isIPv6 {
+		return tlsReassemblyKey{PID: tgid, Dst: daddr, Dport: dport}, true
+	}
+	v4 := net.IP(daddr6[:]).To4()
+	if v4 == nil {
+		return tlsReassemblyKey{}, false
+	}
+	var dst [4]byte
+	copy(dst[:], v4)
+	return tlsReassemblyKey{PID: tgid, Dst: dst, Dport: dport}, true
 }
 
 type tlsReassemblyEntry struct {

--- a/internal/agent/agent_linux_tls_reassembler_test.go
+++ b/internal/agent/agent_linux_tls_reassembler_test.go
@@ -4,6 +4,7 @@ package agent
 
 import (
 	"encoding/binary"
+	"net"
 	"testing"
 	"time"
 )
@@ -202,5 +203,64 @@ func TestTLSReassembler_BufferCapBoundsMemory(t *testing.T) {
 		if res.bufferLen > 64 {
 			t.Fatalf("buffer grew past cap: %d", res.bufferLen)
 		}
+	}
+}
+
+// v4mapped6 builds the 16-byte ::ffff:a.b.c.d wire form for a dotted IPv4.
+func v4mapped6(a, b, c, d byte) [16]byte {
+	var out [16]byte
+	out[10] = 0xff
+	out[11] = 0xff
+	out[12], out[13], out[14], out[15] = a, b, c, d
+	return out
+}
+
+func TestTLSReassemblyKeyForEvent_NativeIPv4(t *testing.T) {
+	key, ok := tlsReassemblyKeyForEvent(42, [4]byte{1, 2, 3, 4}, [16]byte{}, false, 443)
+	if !ok {
+		t.Fatal("native IPv4 must produce a reassembly key")
+	}
+	if key != (tlsReassemblyKey{PID: 42, Dst: [4]byte{1, 2, 3, 4}, Dport: 443}) {
+		t.Fatalf("unexpected key %+v", key)
+	}
+}
+
+func TestTLSReassemblyKeyForEvent_V4MappedIPv6(t *testing.T) {
+	// ::ffff:10.1.2.3 — wire traffic is IPv4; key on the embedded v4 so it
+	// shares the reassembly path with native IPv4 (dual-stack SNI recovery).
+	key, ok := tlsReassemblyKeyForEvent(7, [4]byte{}, v4mapped6(10, 1, 2, 3), true, 443)
+	if !ok {
+		t.Fatal("IPv4-mapped IPv6 must produce a reassembly key")
+	}
+	if key != (tlsReassemblyKey{PID: 7, Dst: [4]byte{10, 1, 2, 3}, Dport: 443}) {
+		t.Fatalf("unexpected key %+v", key)
+	}
+}
+
+func TestTLSReassemblyKeyForEvent_NativeIPv6Skipped(t *testing.T) {
+	var d6 [16]byte
+	copy(d6[:], net.ParseIP("2606:4700:4700::1111"))
+	if _, ok := tlsReassemblyKeyForEvent(9, [4]byte{}, d6, true, 443); ok {
+		t.Fatal("native IPv6 has no shared v4 key; must be skipped")
+	}
+}
+
+// End-to-end: a fragmented ClientHello over a dual-stack (IPv4-mapped IPv6)
+// socket must recover SNI via the same reassembly path as native IPv4.
+func TestTLSReassembler_V4MappedFragmentedClientHello(t *testing.T) {
+	r := newTLSReassembler()
+	hello := buildSyntheticClientHello(t, "dualstack.example")
+
+	key, ok := tlsReassemblyKeyForEvent(123, [4]byte{}, v4mapped6(93, 184, 216, 34), true, 443)
+	if !ok {
+		t.Fatal("expected v4-mapped key")
+	}
+
+	if res := r.appendAndParse(key, hello[:5]); res.parsed {
+		t.Fatal("record header alone must not recover SNI")
+	}
+	res := r.appendAndParse(key, hello[5:])
+	if !res.parsed || !res.reassembly || res.sni != "dualstack.example" {
+		t.Fatalf("v4-mapped reassembly: parsed=%v reassembly=%v sni=%q", res.parsed, res.reassembly, res.sni)
 	}
 }


### PR DESCRIPTION
## Summary

Fragmented TLS ClientHellos over **dual-stack (IPv4-mapped IPv6) sockets** lost their SNI. The userspace inter-syscall reassembler in `agent_linux_ring_read.go` skipped reassembly for *every* `isIPv6` event:

```go
if isIPv6 {
    stats.addDropped("tls_sni_parse")
    continue
}
```

The original justification only holds for **native** IPv6: `tlsReassemblyKey.Dst` is a `[4]byte`, so native-v6 streams would all collapse to `{0,0,0,0}` and collide. But **IPv4-mapped IPv6** (`::ffff:0:0/96`) wire traffic is real IPv4 — the genuine destination lives in the low 4 bytes of `daddr6`. Those events have a perfectly good v4 key and were being dropped needlessly.

Result on dual-stack systems (very common on hosted runners): when a Go `crypto/tls` / rustls ClientHello split its 5-byte record header and handshake body across two `write()` syscalls, the SNI was dropped instead of reassembled.

## Fix

New `tlsReassemblyKeyForEvent` helper encapsulates the key derivation:

- Native IPv4 → key on `daddr` (unchanged).
- IPv4-mapped IPv6 → extract the embedded v4 (`net.IP(daddr6[:]).To4()` returns the embedded v4 for the mapped prefix, `nil` for native v6 — so it doubles as the discriminator) and route onto the **same** reassembly path as native IPv4.
- Native IPv6 → `ok=false`, caller drops the fragment (unchanged behavior).

The ring-read loop now calls the helper instead of hard-skipping all IPv6.

## Impact

**Detect-only telemetry gap.** Surfaced by the bug-hunt audit (finding H21). **No security impact** — defend mode gates IPv4-mapped IPv6 egress correctly against the IPv4 allowlist (#242); this change only restores **SNI observability** on dual-stack sockets in detect mode.

## Tests

`internal/agent/agent_linux_tls_reassembler_test.go`:

- `TestTLSReassemblyKeyForEvent_NativeIPv4` / `_V4MappedIPv6` / `_NativeIPv6Skipped` — key derivation + discriminator.
- `TestTLSReassembler_V4MappedFragmentedClientHello` — end-to-end: synthesizes a v4-mapped IPv6 connect + a header/body-split ClientHello and asserts SNI is recovered with `reassembly=true`.

`go test ./internal/agent/... -count=1` passes (run on Linux, kernel 6.6).

## Scope

- No BPF/C changes.
- Branch is `feat/h21-tls-sni-v4mapped` (the originally-requested `feat/h21-v4mapped-sni-reassembly` name was already taken in the shared checkout by an unrelated concurrent commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
