### PR TITLE
fix(reputation): log virustotal-disabled warning once, drop IP from log

### DIFF
--- a/internal/reputation/loader/loader.go
+++ b/internal/reputation/loader/loader.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/coldstep-io/coldstep/internal/reputation"
 	"github.com/coldstep-io/coldstep/internal/reputation/otx"
@@ -76,11 +77,18 @@ type virusTotalEnricher struct {
 	apiKey string
 }
 
+// virusTotalStubWarnOnce guards the not-implemented warning so it fires
+// at most once per process regardless of how many IPs are enriched. The
+// warning carries no IP — egress IPs must not leak into logs.
+var virusTotalStubWarnOnce sync.Once
+
 func (v *virusTotalEnricher) Name() string { return "virustotal" }
 
-func (v *virusTotalEnricher) Enrich(_ context.Context, ip string) (*reputation.Result, error) {
+func (v *virusTotalEnricher) Enrich(_ context.Context, _ string) (*reputation.Result, error) {
 	// Stub: keys are accepted (so LoadFromEnv can report the backend as
 	// "configured") but no HTTP call is made yet. Treat as no-data.
-	slog.Warn("virustotal enricher: not yet implemented; COLDSTEP_VIRUSTOTAL_API_KEY is set but no enrichment is performed", "ip", ip)
+	virusTotalStubWarnOnce.Do(func() {
+		slog.Warn("virustotal reputation backend not yet implemented; COLDSTEP_VIRUSTOTAL_API_KEY is set but no enrichment is performed")
+	})
 	return nil, nil
 }

--- a/internal/reputation/loader/loader_test.go
+++ b/internal/reputation/loader/loader_test.go
@@ -1,0 +1,45 @@
+package loader
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestVirusTotalStub_WarnsOnceWithoutIP verifies the not-implemented
+// stub warning fires at most once per process and never carries an IP,
+// even when Enrich is called for multiple distinct IPs.
+func TestVirusTotalStub_WarnsOnceWithoutIP(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	v := &virusTotalEnricher{apiKey: "test-key"}
+	for _, ip := range []string{"203.0.113.1", "203.0.113.2"} {
+		if _, err := v.Enrich(context.Background(), ip); err != nil {
+			t.Fatalf("Enrich(%s) returned error: %v", ip, err)
+		}
+	}
+
+	lines := 0
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		lines++
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("log line is not valid JSON: %q: %v", line, err)
+		}
+		if _, ok := entry["ip"]; ok {
+			t.Errorf("warning log leaked an ip field: %q", line)
+		}
+	}
+	if lines != 1 {
+		t.Errorf("expected exactly 1 warning log entry, got %d:\n%s", lines, buf.String())
+	}
+}


### PR DESCRIPTION
## Problem

The virustotal stub enricher in `internal/reputation/loader/loader.go` logged a `slog.Warn` **per IP** enriched, embedding the raw egress IP via an `"ip"` field. With N IPs that produced N warnings and leaked egress addresses into logs.

## Fix

- Wrap the not-implemented warning in a package-level `sync.Once` so it fires at most once per process.
- Drop the `"ip"` field entirely (it leaked).
- Add `loader_test.go`: `TestVirusTotalStub_WarnsOnceWithoutIP` calls `Enrich` for two distinct IPs and asserts exactly one JSON log entry with no `ip` field (captured via `slog.NewJSONHandler`).

## Note

The warning actually fires when `COLDSTEP_VIRUSTOTAL_API_KEY` **is set** (the stub backend is constructed but not implemented), not when unset. The core fix — fire once, no IP — is unchanged; message wording reflects the accurate semantics.

## Test

`go test ./internal/reputation/...` → all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
