### PR TITLE
chore(agent): use errors.Is for context.Canceled comparisons in tests

### DIFF
--- a/internal/agent/agent_integration_test.go
+++ b/internal/agent/agent_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -93,7 +94,7 @@ func TestRun_DetectWritesSummary(t *testing.T) {
 
 	cancel()
 	err = <-errCh
-	if err != nil && err != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatalf("Run: %v", err)
 	}
 
@@ -145,7 +146,7 @@ func TestRun_TCPConnectLogged(t *testing.T) {
 
 	cancel()
 	err = <-errCh
-	if err != nil && err != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatalf("Run: %v", err)
 	}
 
@@ -234,7 +235,7 @@ func TestRun_DefendModeBlockedConnectEmitsDenyJSONL(t *testing.T) {
 	}
 
 	cancel()
-	if rerr := <-errCh; rerr != nil && rerr != context.Canceled {
+	if rerr := <-errCh; rerr != nil && !errors.Is(rerr, context.Canceled) {
 		t.Fatalf("Run: %v", rerr)
 	}
 
@@ -288,7 +289,7 @@ func TestRun_ExecJSONLIncludesExePath(t *testing.T) {
 
 	cancel()
 	err = <-errCh
-	if err != nil && err != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatalf("Run: %v", err)
 	}
 
@@ -351,7 +352,7 @@ func TestRun_ProcForkJSONLWhenFeatureGate(t *testing.T) {
 
 	cancel()
 	err = <-errCh
-	if err != nil && err != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatalf("Run: %v", err)
 	}
 
@@ -408,7 +409,7 @@ func TestRun_UDPSendtoLoggedJSONL(t *testing.T) {
 
 	cancel()
 	err = <-errCh
-	if err != nil && err != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatalf("Run: %v", err)
 	}
 
@@ -480,7 +481,7 @@ s.close()
 
 	cancel()
 	err = <-errCh
-	if err != nil && err != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatalf("Run: %v", err)
 	}
 
@@ -564,7 +565,7 @@ s.close()
 
 	cancel()
 	err = <-errCh
-	if err != nil && err != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatalf("Run: %v", err)
 	}
 
@@ -631,7 +632,7 @@ func TestRun_TLSClientHelloSNIJSONL(t *testing.T) {
 
 	cancel()
 	err = <-errCh
-	if err != nil && err != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatalf("Run: %v", err)
 	}
 
@@ -741,7 +742,7 @@ s.close()
 
 	cancel()
 	err = <-errCh
-	if err != nil && err != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatalf("Run: %v", err)
 	}
 
@@ -851,7 +852,7 @@ s.close()
 
 	cancel()
 	err = <-errCh
-	if err != nil && err != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatalf("Run: %v", err)
 	}
 
@@ -920,7 +921,7 @@ func TestRun_FSEventJSONLWhenFeatureGate(t *testing.T) {
 
 	time.Sleep(300 * time.Millisecond)
 	cancel()
-	if err := <-errCh; err != nil && err != context.Canceled {
+	if err := <-errCh; err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatalf("Run: %v", err)
 	}
 
@@ -1072,7 +1073,7 @@ func TestRun_BPFAuditLoggedJSONL(t *testing.T) {
 
 	cancel()
 	err = <-errCh
-	if err != nil && err != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatalf("Run: %v", err)
 	}
 


### PR DESCRIPTION
## Problem

`internal/agent/agent_integration_test.go` compared cancellation errors directly:

```go
if err != nil && err != context.Canceled { ... }
```

Production wraps the cancel error. A direct `==`/`!=` comparison bypasses unwrapping, so if the wrapping ever changes these tests would silently mis-pass.

## Fix

- Replaced all **13** comparison sites with `!errors.Is(err, context.Canceled)` (and the `rerr` variant on the channel-receive site).
- Added `"errors"` to the import block.

The task listed 10 line numbers from an earlier snapshot; current `main` has 13 such sites. All were converted for consistency — leaving any direct comparison would defeat the purpose.

## Verification

- `gofmt -l` clean.
- `GOOS=linux go vet -tags=integration ./internal/agent/` passes (compile-verified).
- Full integration run requires linux + root + BPF (CI `integration` job); not runnable on the Windows dev host. Change is mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
