### PR TITLE
fix(action): reset malformedSince on read error in waitForReady

### DIFF
--- a/cmd/coldstep-action/main.go
+++ b/cmd/coldstep-action/main.go
@@ -594,6 +594,12 @@ func waitForReady(statusPath string, timeout time.Duration, pid int) string {
 			case incomplete:
 				malformedSince = nil
 			}
+		} else {
+			// Read errors are transient I/O (status file mid-write,
+			// briefly missing); they are not a parseable-but-malformed
+			// status, so they must not advance the malformed budget.
+			// Reset the window and fall through to the liveness check.
+			malformedSince = nil
 		}
 
 		if !pidAlive(pid) {


### PR DESCRIPTION
## Problem

`waitForReady` (`cmd/coldstep-action/main.go`) returns `"malformed_status"` once the agent emits a parseable-but-malformed ready status continuously for longer than a 45s budget. The budget is wall-clock since the first malformed status (`time.Since(*malformedSince)`).

The read-error path skipped the whole `if err == nil { ... }` block, leaving `malformedSince` untouched. A transient read error (status file mid-write, briefly missing) between two malformed statuses therefore let the read-error gap accumulate toward the malformed budget — despite no continuous malformed run. Read errors are transient I/O and should be independent of the malformed budget.

## Fix

Added an `else` branch that resets `malformedSince = nil` on read error, then falls through to the existing `pidAlive` liveness check and sleep. No `continue` is introduced, so child-exit detection still runs on every iteration. (`malformedSince` is a `*time.Time`, so the reset is `nil`, the pointer-typed equivalent of the `time.Time{}` mentioned in the issue.)

## Why no unit test

`waitForReady` reads the status file via `os.ReadFile` directly (no injectable reader), uses a hardcoded 45s `malformedBudget`, and sleeps 150ms per iteration on the real clock. Deterministically exercising the reset would require either a continuous 45s malformed run or precise file-state interleaving across sleep ticks — neither is achievable in a fast, non-flaky unit test without refactoring the function signature to inject a clock and reader. That refactor exceeds the minimal-fix scope (single named file, preserve control flow), so the change is documented here instead.

## Verification

- `gofmt -l` clean.
- `go vet ./cmd/coldstep-action/` clean (host + `GOOS=linux`).
- `go test ./cmd/coldstep-action/...` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
