### PR TITLE
test(redteam): fix egress-backstop no-false-positive flake on live runners (ambient egress)

### DIFF
--- a/internal/agent/redteam_test.go
+++ b/internal/agent/redteam_test.go
@@ -614,8 +614,9 @@ for _ in range(8):
 
 // TestRedTeam_EgressBackstop_NoFalsePositiveOnAllowlisted verifies that a
 // normal TCP connect to an allowlisted loopback address does NOT produce an
-// "egress_backstop" JSONL row. The cgroup_skb/egress backstop should remain
-// silent for traffic that passes through the connect4 hook's allow path.
+// "egress_backstop" JSONL row for that destination. The tc/clsact egress
+// backstop must remain silent for the loopback dst (it observes all interface
+// egress, so ambient non-allowlisted traffic to other IPs is expected).
 //
 // Note: 127.0.0.0/8 is excluded from egress_backstop observation by the BPF
 // program itself (skb_v4_is_loopback short-circuit in trace_defend_skb.inc),
@@ -666,10 +667,20 @@ func TestRedTeam_EgressBackstop_NoFalsePositiveOnAllowlisted(t *testing.T) {
 	// Wait a window long enough for any spurious backstop event to surface.
 	time.Sleep(1500 * time.Millisecond)
 
+	// The backstop is a tc/clsact egress program, so it observes ALL interface
+	// egress — including the runner's own ambient background traffic to
+	// non-allowlisted (e.g. cloud) IPs, which it legitimately flags. The
+	// no-false-positive property under test is specifically that it must NOT
+	// fire for the allowlisted LOOPBACK destination this test generates
+	// (127.0.0.0/8 is short-circuited in skb_v4_is_loopback). Ambient events to
+	// other IPs are expected and correct; fail only on a loopback-dst event.
 	data, _ := os.ReadFile(h.events)
 	for _, line := range bytes.Split(data, []byte("\n")) {
-		if bytes.Contains(line, []byte(`"type":"egress_backstop"`)) {
-			t.Fatalf("unexpected egress_backstop event for allowlisted loopback traffic:\n%s", line)
+		if !bytes.Contains(line, []byte(`"type":"egress_backstop"`)) {
+			continue
+		}
+		if bytes.Contains(line, []byte(`"dst":"127.`)) {
+			t.Fatalf("unexpected egress_backstop event for allowlisted loopback dst:\n%s", line)
 		}
 	}
 }


### PR DESCRIPTION
## Fixes a failing integration test on `main`

`TestRedTeam_EgressBackstop_NoFalsePositiveOnAllowlisted` fails on the real CI runner — **the backstop is working correctly**, the test was wrong.

The tc/clsact egress backstop (#253) observes **all** interface egress. On a live Azure runner there is constant ambient background egress to non-allowlisted cloud IPs (observed: `20.75.202.224:443`), which the backstop legitimately flags. The test asserted **zero** `egress_backstop` events — unachievable on a real runner.

**Root cause of the miss:** #253 was merged on local (WSL) validation, where the short test window had no ambient cloud egress, so the assertion passed locally but fails on Azure.

**Fix:** scope the assertion to the property actually under test — no `egress_backstop` event for the **allowlisted loopback destination** the test generates (`127.0.0.0/8`, short-circuited in `skb_v4_is_loopback`). Ambient events to other IPs are expected and correct. Verified locally (both `TestRedTeam_EgressBackstop_*` pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
