### PR TITLE
fix(agent): io_uring_tls reader errCh undersizing (shutdown hang) + lost egress-backstop reserve counter

### DIFF
--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -1094,6 +1094,9 @@ func Run(ctx context.Context, cfg config.Config) error {
 	if ioUringRd.R != nil {
 		readerCount++
 	}
+	if ioUringTLSRd.R != nil {
+		readerCount++
+	}
 	if denyRd.R != nil {
 		readerCount++
 	}

--- a/internal/agent/agent_linux_digest.go
+++ b/internal/agent/agent_linux_digest.go
@@ -39,6 +39,7 @@ func buildDroppedEventsMap(stats *runStats, defendState *defendState) map[string
 	add("tcp_state", stats.tcpStateRingbufReserveFailures())
 	add("io_uring", stats.ioUringRingbufReserveFailures())
 	add("io_uring_tls", stats.ioUringTLSRingbufReserveFailures())
+	add("egress_backstop", stats.egressBackstopReserveFailures())
 	if defendState != nil {
 		add("deny", defendState.snapshot().denyReserveFailures)
 	}


### PR DESCRIPTION
## Two bugs from a deep scan (concurrency + dead-code)

### 1. Shutdown hang — HIGH (concurrency)
`readIoUringTLSRing` launches a reader goroutine but had **no matching `readerCount++`**, so `errCh` (buffered to `readerCount`) is undersized by one whenever `ioUringTLSRd.R` is set.

- **Defend mode:** masked by the spurious `hasDefend`/`hasLSM` slack counts.
- **Detect mode + `detect-profile: enhanced`** (io_uring TLS active, no slack): at shutdown the last reader blocks forever on `errCh <- err`, never reaches `wg.Done()`, and `wg.Wait()` **hangs the agent** — deferred digest/telemetry writers never run. Reincarnates the P3-bug-audit Bug 5 the surrounding comment warns about.

**Fix:** add `if ioUringTLSRd.R != nil { readerCount++ }`.

### 2. Lost telemetry — MEDIUM (dead getter)
`egressBackstopReserveFailures()` was collected from the BPF `skb_backstop_reserve_failures` map at startup but **never surfaced** — the getter was dead. A ring-full backstop loss was invisible (same class as the io_uring_tls BG-3 fix, missed for the backstop). Wired into `buildDroppedEventsMap` (`MetaEvent.DroppedEvents`).

Found via `deadcode` + a concurrency scan. Build/vet/tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
