### PR TITLE
chore: gitignore scripts/scratch local scan artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,8 @@ AGENTS.md
 /design/
 /knowledge/
 /.worktrees/
+# Local scratch: scan artifacts + WSL repro scripts (near-missed git add -A once).
+/scripts/scratch/
 # Soft alias junction (mklink /J elon knowledge) — same vault, local-only.
 /elon/
 # Ignore stray copies under .github only.


### PR DESCRIPTION
Ignore the local-only `scripts/scratch/` tree (semgrep/cover scan output + WSL repro scripts). It was untracked and once nearly swept into a merge by `git add -A`; this guard makes that impossible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)