### PR TITLE
feat(bpf): lsm/bpf self-defense section + loader strip/wire (B1, inert)

### DIFF
--- a/bpf/bpf_self_defense_event.h
+++ b/bpf/bpf_self_defense_event.h
@@ -1,0 +1,37 @@
+#ifndef COLDSTEP_BPF_SELF_DEFENSE_EVENT_H
+#define COLDSTEP_BPF_SELF_DEFENSE_EVENT_H
+
+/*
+ * Wire struct for the lsm/bpf self-defense hook (sub-project B).
+ *
+ * Emitted once (deduped) when a non-agent task attempts to obtain a handle to
+ * one of coldstep's own BPF objects via BPF_PROG_GET_FD_BY_ID /
+ * BPF_MAP_GET_FD_BY_ID (by id) or BPF_OBJ_GET (by pin path), and the hook
+ * denies it with -EPERM. target_kind distinguishes prog / map / pin so the
+ * digest can attribute the attempt. The JSONL seq is NOT carried on the wire —
+ * userspace allocates it under jsonlMu on emit (BG-1 pattern).
+ *
+ * Fixed 40-byte layout — keep in sync with bpfSelfDefenseEventWireSize in
+ * internal/agent/agent_linux.go and the Go decoder:
+ *   ts u64 (8) + comm[16] (16) + tgid u32 (4) + target_id u32 (4)
+ *   + cmd s32 (4) + target_kind u8 (1) + _pad[3] (3) = 40, naturally aligned.
+ */
+
+#define COLDSTEP_SELFDEF_KIND_PROG 1
+#define COLDSTEP_SELFDEF_KIND_MAP 2
+#define COLDSTEP_SELFDEF_KIND_PIN 3
+
+struct bpf_self_defense_event {
+	__u64 ts;          /* bpf_ktime_get_ns() at deny */
+	char comm[16];     /* offending task comm (best-effort) */
+	__u32 tgid;        /* offending task tgid */
+	__u32 target_id;   /* prog_id / map_id; 0 for pin-path opens */
+	__s32 cmd;         /* the denied bpf() cmd */
+	__u8 target_kind;  /* COLDSTEP_SELFDEF_KIND_* */
+	__u8 _pad[3];
+};
+
+_Static_assert(sizeof(struct bpf_self_defense_event) == 40,
+	       "bpf_self_defense_event wire size mismatch");
+
+#endif /* COLDSTEP_BPF_SELF_DEFENSE_EVENT_H */

--- a/bpf/trace_defend_all.bpf.c
+++ b/bpf/trace_defend_all.bpf.c
@@ -31,6 +31,7 @@
 #include "dns_cache.h"
 #include "deny_event.h"
 #include "egress_backstop_event.h"
+#include "bpf_self_defense_event.h"
 
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
@@ -80,5 +81,6 @@ _Static_assert(sizeof(struct deny_event) == 46,
 
 #include "trace_defend_cgroup.inc"
 #include "trace_defend_skb.inc"
+#include "trace_lsm_bpf_self_defense.inc"
 #include "trace_lsm_defend_lsm.inc"
 #include "trace_lsm_defend_iouring.inc"

--- a/bpf/trace_lsm_bpf_self_defense.inc
+++ b/bpf/trace_lsm_bpf_self_defense.inc
@@ -1,0 +1,239 @@
+/*
+ * lsm/bpf self-defense section of bpf/trace_defend_all.bpf.c (sub-project B).
+ *
+ * Goal: stop a malicious build step holding CAP_BPF / CAP_SYS_ADMIN from
+ * obtaining a handle to coldstep's OWN bpf programs/maps and then detaching or
+ * unloading the monitor (the Doyensec/Datadog "unload the monitor" gap).
+ *
+ * Scope is "self objects only" — zero blast radius to any other BPF user on the
+ * runner. The hook denies exactly three control-plane operations, and ONLY when
+ * they target a coldstep object:
+ *
+ *   BPF_PROG_GET_FD_BY_ID  attr->prog_id ∈ self_prog_ids  → -EPERM
+ *   BPF_MAP_GET_FD_BY_ID   attr->map_id  ∈ self_map_ids   → -EPERM
+ *   BPF_OBJ_GET            attr->pathname prefix==pin dir  → -EPERM
+ *
+ * Realistic CAP_BPF attackers have no pre-existing fd to coldstep objects, so
+ * these "get a handle" paths are the chokepoint: deny the handle and the
+ * follow-on DETACH/DELETE cannot happen. prog_id and map_id overlay the same
+ * union offset in bpf_attr, so one CO-RE read serves both id cmds.
+ *
+ * The agent's own runtime bpf() calls (allowlist BPF_MAP_UPDATE_ELEM, ringbuf
+ * consume) act on fds it already holds from load time — they never call
+ * *_GET_FD_BY_ID or BPF_OBJ_GET, so they never reach a deny branch. The cfg
+ * agent_tgid additionally exempts the agent itself (it may re-open its own pins
+ * on resume).
+ *
+ * Armed by self_defense_cfg.enabled, which Go flips to 1 only AFTER populating
+ * the id sets — so there is no window where the hook denies before ids are
+ * known. Until then every call returns 0 (allow), i.e. fully inert.
+ *
+ * The combined .bpf.c provides vmlinux/BPF helpers, LICENSE, EPERM, and the
+ * bpf_self_defense_event struct (bpf_self_defense_event.h) before this file.
+ */
+
+#ifndef ENOENT
+#define ENOENT 2
+#endif
+
+#define COLDSTEP_PIN_PREFIX_MAX 64
+#define COLDSTEP_SELFDEF_DEDUP_NS 1000000000ULL /* 1s ringbuf-emit cooldown */
+
+struct cs_self_defense_cfg {
+	__u32 agent_tgid; /* tgid of the coldstep agent process (exempt) */
+	__u8 enabled;     /* 0 until Go has populated the id sets */
+	__u8 _pad[3];
+};
+
+/* Set membership: coldstep's own prog ids (BPF_OBJ_GET_INFO_BY_FD at load). */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 64);
+	__type(key, __u32);
+	__type(value, __u8);
+} self_prog_ids SEC(".maps");
+
+/* Set membership: coldstep's own map ids. */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 64);
+	__type(key, __u32);
+	__type(value, __u8);
+} self_map_ids SEC(".maps");
+
+/* The agent's bpffs pin directory prefix (NUL-terminated). Empty string (first
+ * byte 0) disables the BPF_OBJ_GET branch entirely. */
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__type(value, char[COLDSTEP_PIN_PREFIX_MAX]);
+} self_pin_prefix SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__type(value, struct cs_self_defense_cfg);
+} self_defense_cfg SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(max_entries, 1 << 12); /* 4 KiB; tamper attempts are low volume */
+} bpf_self_defense_events SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__type(value, __u32);
+} bpf_self_defense_reserve_failures SEC(".maps");
+
+/* Dedup ringbuf emits: key = ((u64)cmd << 32) | target_id, value = last ts. */
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 256);
+	__type(key, __u64);
+	__type(value, __u64);
+} self_defense_seen SEC(".maps");
+
+static __always_inline void selfdef_note_reserve_failed(void)
+{
+	__u32 k = 0;
+	/* AUDIT(5a): null checked — only used inside `if (v)`. */
+	__u32 *v = bpf_map_lookup_elem(&bpf_self_defense_reserve_failures, &k);
+	if (v)
+		__sync_fetch_and_add(v, 1);
+}
+
+/* Returns true if a ringbuf emit for (cmd,id) should be suppressed because one
+ * was emitted within the last COLDSTEP_SELFDEF_DEDUP_NS. Always lets the FIRST
+ * sighting through. Deny still happens regardless — this only rate-limits the
+ * emit so a retry loop is not a ringbuf storm. */
+static __always_inline bool selfdef_dedup(__s32 cmd, __u32 id, __u64 now)
+{
+	__u64 key = ((__u64)(__u32)cmd << 32) | (__u64)id;
+	/* AUDIT(5a): null checked. */
+	__u64 *last = bpf_map_lookup_elem(&self_defense_seen, &key);
+	if (last && (now - *last) < COLDSTEP_SELFDEF_DEDUP_NS)
+		return true;
+	bpf_map_update_elem(&self_defense_seen, &key, &now, BPF_ANY);
+	return false;
+}
+
+static __always_inline void selfdef_emit(__s32 cmd, __u32 id, __u8 kind)
+{
+	__u64 now = bpf_ktime_get_ns();
+	if (selfdef_dedup(cmd, id, now))
+		return;
+
+	/* AUDIT(5b): submit/discard paired — only exit between reserve and submit
+	 * is the `!ev` early return (no slot held). Submit unconditional after. */
+	struct bpf_self_defense_event *ev =
+		bpf_ringbuf_reserve(&bpf_self_defense_events, sizeof(*ev), 0);
+	if (!ev) {
+		selfdef_note_reserve_failed();
+		return;
+	}
+	ev->ts = now;
+	bpf_get_current_comm(&ev->comm, sizeof(ev->comm));
+	ev->tgid = (__u32)(bpf_get_current_pid_tgid() >> 32);
+	ev->target_id = id;
+	ev->cmd = cmd;
+	ev->target_kind = kind;
+	ev->_pad[0] = 0;
+	ev->_pad[1] = 0;
+	ev->_pad[2] = 0;
+	bpf_ringbuf_submit(ev, 0);
+}
+
+/* Reads the cfg; returns NULL when the hook is disabled or cfg is missing. */
+static __always_inline struct cs_self_defense_cfg *selfdef_active_cfg(void)
+{
+	__u32 k = 0;
+	/* AUDIT(5a): null checked by caller. */
+	struct cs_self_defense_cfg *cfg = bpf_map_lookup_elem(&self_defense_cfg, &k);
+	if (!cfg || !cfg->enabled)
+		return NULL;
+	return cfg;
+}
+
+/*
+ * lsm/bpf hook. The trailing `int ret` carries the cumulative LSM result; if a
+ * prior module already denied (ret != 0) we propagate it unchanged rather than
+ * override. Returns 0 to allow, -EPERM to deny.
+ */
+SEC("lsm/bpf")
+int BPF_PROG(coldstep_bpf_self_defense, int cmd, union bpf_attr *attr,
+	     unsigned int size, int ret)
+{
+	if (ret != 0)
+		return ret;
+
+	struct cs_self_defense_cfg *cfg = selfdef_active_cfg();
+	if (!cfg)
+		return 0;
+	if (!attr)
+		return 0;
+
+	__u32 self_tgid = (__u32)(bpf_get_current_pid_tgid() >> 32);
+	if (self_tgid == cfg->agent_tgid)
+		return 0; /* the agent itself may re-open its own objects */
+
+	if (cmd == BPF_PROG_GET_FD_BY_ID) {
+		/* prog_id and map_id overlay the same union offset. */
+		__u32 id = BPF_CORE_READ(attr, prog_id);
+		__u8 *hit = bpf_map_lookup_elem(&self_prog_ids, &id); /* AUDIT(5a) */
+		if (hit) {
+			selfdef_emit(cmd, id, COLDSTEP_SELFDEF_KIND_PROG);
+			return -EPERM;
+		}
+		return 0;
+	}
+
+	if (cmd == BPF_MAP_GET_FD_BY_ID) {
+		__u32 id = BPF_CORE_READ(attr, map_id);
+		__u8 *hit = bpf_map_lookup_elem(&self_map_ids, &id); /* AUDIT(5a) */
+		if (hit) {
+			selfdef_emit(cmd, id, COLDSTEP_SELFDEF_KIND_MAP);
+			return -EPERM;
+		}
+		return 0;
+	}
+
+	if (cmd == BPF_OBJ_GET) {
+		__u32 k = 0;
+		/* AUDIT(5a): null checked. */
+		char *prefix = bpf_map_lookup_elem(&self_pin_prefix, &k);
+		if (!prefix || prefix[0] == '\0')
+			return 0; /* pin protection disabled */
+
+		__u64 uptr = BPF_CORE_READ(attr, pathname);
+		char path[COLDSTEP_PIN_PREFIX_MAX] = {};
+		/* AUDIT(5f): allow-on-error — a failed user read must NOT block a
+		 * legitimate open, so we fall through to allow when the read fails. */
+		long n = bpf_probe_read_user_str(&path, sizeof(path), (const void *)uptr);
+		if (n <= 0)
+			return 0;
+
+		/* Bounded prefix compare against the configured pin dir. */
+		bool match = true;
+#pragma unroll
+		for (int i = 0; i < COLDSTEP_PIN_PREFIX_MAX; i++) {
+			char pc = prefix[i];
+			if (pc == '\0')
+				break; /* end of prefix => full prefix matched so far */
+			if (path[i] != pc) {
+				match = false;
+				break;
+			}
+		}
+		if (match) {
+			selfdef_emit(cmd, 0, COLDSTEP_SELFDEF_KIND_PIN);
+			return -EPERM;
+		}
+		return 0;
+	}
+
+	return 0;
+}

--- a/internal/agent/bpf_self_defense_source_test.go
+++ b/internal/agent/bpf_self_defense_source_test.go
@@ -1,0 +1,83 @@
+//go:build linux
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestBpfSelfDefenseSourceWiring pins sub-project B's BPF wiring: the lsm/bpf
+// self-defense section is included in the combined source before the socket LSM
+// section, it is a lsm/bpf program, it propagates a prior LSM denial unchanged,
+// dispatches the three self-object cmds, exempts the agent's own tgid, and ships
+// inert (the cfg.enabled gate). These are source invariants the verifier work in
+// later slices depends on — assert them without a BPF load so they run on any
+// Linux arch.
+func TestBpfSelfDefenseSourceWiring(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+
+	combined, err := os.ReadFile(filepath.Join(root, "bpf", "trace_defend_all.bpf.c"))
+	if err != nil {
+		t.Fatalf("read combined: %v", err)
+	}
+	ct := string(combined)
+	selfIdx := strings.Index(ct, `#include "trace_lsm_bpf_self_defense.inc"`)
+	lsmIdx := strings.Index(ct, `#include "trace_lsm_defend_lsm.inc"`)
+	if selfIdx < 0 || lsmIdx < 0 || !(selfIdx < lsmIdx) {
+		t.Fatalf("self-defense section must be included before the socket LSM section: self=%d lsm=%d", selfIdx, lsmIdx)
+	}
+	if !strings.Contains(ct, `#include "bpf_self_defense_event.h"`) {
+		t.Error("combined source must include bpf_self_defense_event.h")
+	}
+
+	src, err := os.ReadFile(filepath.Join(root, "bpf", "trace_lsm_bpf_self_defense.inc"))
+	if err != nil {
+		t.Fatalf("read self-defense inc: %v", err)
+	}
+	st := string(src)
+
+	if !strings.Contains(st, `SEC("lsm/bpf")`) {
+		t.Error("self-defense must be a lsm/bpf program")
+	}
+	// Propagate a prior LSM module's denial rather than overriding it.
+	if !strings.Contains(st, "if (ret != 0)") || !strings.Contains(st, "return ret;") {
+		t.Error("self-defense must propagate a prior LSM denial (ret != 0 => return ret)")
+	}
+	// Inert until configured: the cfg.enabled gate must guard the whole hook.
+	if !strings.Contains(st, "enabled") || !strings.Contains(st, "selfdef_active_cfg(") {
+		t.Error("self-defense must be gated by self_defense_cfg.enabled (selfdef_active_cfg)")
+	}
+	// Agent self-exemption.
+	if !strings.Contains(st, "cfg->agent_tgid") {
+		t.Error("self-defense must exempt the agent's own tgid")
+	}
+	// The three self-object cmds dispatched against the id sets / pin prefix.
+	for _, want := range []string{
+		"BPF_PROG_GET_FD_BY_ID",
+		"BPF_MAP_GET_FD_BY_ID",
+		"BPF_OBJ_GET",
+		"self_prog_ids",
+		"self_map_ids",
+		"self_pin_prefix",
+	} {
+		if !strings.Contains(st, want) {
+			t.Errorf("missing expected reference %q", want)
+		}
+	}
+	// Deny is -EPERM; the pin-path user read must be allow-on-error (never block
+	// a legitimate open on a failed read).
+	if !strings.Contains(st, "return -EPERM;") {
+		t.Error("self-defense must deny with -EPERM on a self-object hit")
+	}
+	if !strings.Contains(st, "bpf_probe_read_user_str(") {
+		t.Error("pin-path branch must read attr->pathname via bpf_probe_read_user_str")
+	}
+}

--- a/internal/bpf/defend/loader.go
+++ b/internal/bpf/defend/loader.go
@@ -267,6 +267,22 @@ func LoadDefendObjectsForKernel(obj *DefendObjects, wantLSM, wantIOUringLSM bool
 		// lsm_socket_sendpage section and sendpage_observed map.
 		detachProgramIfPresent(coll, "lsm_socket_sendpage", &obj.LsmSocketSendpage)
 		detachMapIfPresent(coll, "sendpage_observed", &obj.SendpageObserved)
+
+		// Sub-project B: lsm/bpf self-defense (deny tamper of coldstep's own
+		// BPF objects). Optional (tolerate absence on stubs predating the
+		// section). The program ships inert — self_defense_cfg.enabled stays 0
+		// until the agent has populated self_prog_ids / self_map_ids, so a
+		// present-but-unconfigured program is a safe no-op (returns 0/allow on
+		// every bpf() call). Same gate as the other LSM hooks: only reached
+		// when CONFIG_BPF_LSM is present and the LSM section did not fall back.
+		detachProgramIfPresent(coll, "coldstep_bpf_self_defense", &obj.ColdstepBpfSelfDefense)
+		detachMapIfPresent(coll, "self_prog_ids", &obj.SelfProgIds)
+		detachMapIfPresent(coll, "self_map_ids", &obj.SelfMapIds)
+		detachMapIfPresent(coll, "self_pin_prefix", &obj.SelfPinPrefix)
+		detachMapIfPresent(coll, "self_defense_cfg", &obj.SelfDefenseCfg)
+		detachMapIfPresent(coll, "bpf_self_defense_events", &obj.BpfSelfDefenseEvents)
+		detachMapIfPresent(coll, "bpf_self_defense_reserve_failures", &obj.BpfSelfDefenseReserveFailures)
+		detachMapIfPresent(coll, "self_defense_seen", &obj.SelfDefenseSeen)
 	}
 
 	success = true
@@ -293,6 +309,18 @@ func stripAllLSM(spec *ebpf.CollectionSpec) {
 	// sendpage_observed lives in the LSM section; strip it when LSM is
 	// disabled so we don't pin a per-cpu counter nobody reads.
 	delete(spec.Maps, "sendpage_observed")
+	// Sub-project B: lsm/bpf self-defense program + its maps. Strip together
+	// when CONFIG_BPF_LSM is absent so prog_load does not reject the section
+	// and no maps are left dangling. delete() on a missing key is a no-op, so
+	// this is safe against stubs predating the section.
+	delete(spec.Programs, "coldstep_bpf_self_defense")
+	delete(spec.Maps, "self_prog_ids")
+	delete(spec.Maps, "self_map_ids")
+	delete(spec.Maps, "self_pin_prefix")
+	delete(spec.Maps, "self_defense_cfg")
+	delete(spec.Maps, "bpf_self_defense_events")
+	delete(spec.Maps, "bpf_self_defense_reserve_failures")
+	delete(spec.Maps, "self_defense_seen")
 }
 
 // HaveIOUringLSM reports whether the running kernel exposes the

--- a/internal/bpf/defend/loader_test.go
+++ b/internal/bpf/defend/loader_test.go
@@ -98,6 +98,36 @@ func TestDefendSpecStripsIOUringLSMWithoutLSM(t *testing.T) {
 	}
 }
 
+// TestDefendSpecExposesSelfDefenseProgram asserts the compiled BPF object
+// contains sub-project B's lsm/bpf self-defense program with the expected
+// SectionName, plus its six self_* maps. Pure spec parse — no kernel attach.
+func TestDefendSpecExposesSelfDefenseProgram(t *testing.T) {
+	spec, err := LoadDefend()
+	if err != nil {
+		t.Fatalf("LoadDefend: %v", err)
+	}
+	prog, ok := spec.Programs["coldstep_bpf_self_defense"]
+	if !ok {
+		t.Fatalf("coldstep_bpf_self_defense program missing from CollectionSpec")
+	}
+	if got := prog.SectionName; got != "lsm/bpf" {
+		t.Fatalf("coldstep_bpf_self_defense SectionName=%q want %q", got, "lsm/bpf")
+	}
+	for _, name := range []string{
+		"self_prog_ids",
+		"self_map_ids",
+		"self_pin_prefix",
+		"self_defense_cfg",
+		"bpf_self_defense_events",
+		"bpf_self_defense_reserve_failures",
+		"self_defense_seen",
+	} {
+		if _, present := spec.Maps[name]; !present {
+			t.Fatalf("self-defense map %q missing from CollectionSpec", name)
+		}
+	}
+}
+
 // TestStripAllLSM verifies the shared helper used by both the wantLSM=false
 // initial path and the wantLSM=true post-load fallback removes every LSM
 // program + LSM-only map while leaving cgroup and shared sections intact.
@@ -113,6 +143,7 @@ func TestStripAllLSM(t *testing.T) {
 		"lsm_socket_sendmsg",
 		"lsm_socket_sendpage",
 		"lsm_io_uring_cmd",
+		"coldstep_bpf_self_defense",
 	}
 	for _, name := range mustBeGone {
 		if _, present := spec.Programs[name]; present {
@@ -126,6 +157,13 @@ func TestStripAllLSM(t *testing.T) {
 		"lsm_allowed_ipv4",
 		"lsm_ignored_ipv4_lpm",
 		"sendpage_observed",
+		"self_prog_ids",
+		"self_map_ids",
+		"self_pin_prefix",
+		"self_defense_cfg",
+		"bpf_self_defense_events",
+		"bpf_self_defense_reserve_failures",
+		"self_defense_seen",
 	}
 	for _, name := range mustBeGoneMaps {
 		if _, present := spec.Maps[name]; present {


### PR DESCRIPTION
## What

Sub-project B (eBPF self-defense) slice 1: add an `lsm/bpf` hook that stops a malicious build step with CAP_BPF from grabbing a handle to coldstep's **own** BPF programs/maps and detaching the monitor — the Doyensec/Datadog "unload the monitor" gap. Ships **inert** in this slice (no behavior change).

## Mechanism (self-objects only, zero blast radius)

The hook denies exactly three control-plane ops, and only when they target a coldstep object:

| cmd | discriminator | comparison |
| :-- | :-- | :-- |
| `BPF_PROG_GET_FD_BY_ID` | `attr->prog_id` | ∈ `self_prog_ids` |
| `BPF_MAP_GET_FD_BY_ID` | `attr->map_id` | ∈ `self_map_ids` |
| `BPF_OBJ_GET` | `attr->pathname` | prefix == pin dir |

`prog_id`/`map_id` overlay the same `bpf_attr` union offset, so one CO-RE read serves both id cmds. Realistic CAP_BPF attackers hold no pre-existing fd to coldstep objects, so these "get a handle" paths are the chokepoint: deny the handle and the follow-on DETACH/DELETE can't happen. Other BPF users on the runner are untouched.

The agent's own runtime bpf() calls act on fds it already holds from load time → never reach a deny branch. `cfg.agent_tgid` additionally exempts the agent itself.

## Inert in this slice

`self_defense_cfg.enabled` stays `0` until Go populates the id sets (slice **B2**), so every call returns `0` (allow). A prior LSM module's denial (`ret != 0`) is propagated unchanged. Loader strips the program + its 7 maps as a unit when `CONFIG_BPF_LSM` is absent (strip+continue, per design decision).

## Tests

- Source-assertion: section ordering, `lsm/bpf` SEC, `ret` pass-through, `enabled` gate, agent exemption, three cmds, `-EPERM`, allow-on-error pin read.
- Loader: spec-exposes program + maps; `stripAllLSM` removes program + 7 maps.

Built clean on Linux (WSL 6.6): BPF compiles, stubs regenerate, loader links, tests pass, gofmt + vet clean.

## Follow-ups (this PR train)

- **B2** — Go population (own ids + pin prefix + cfg), reader, telemetry, digest, `enabled=1`.
- **B3** — integration `TestRedTeam_BpfSelfDefense_*` (deny / no-false-positive / no-self-block) + kernel-matrix expectation + docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
