### PR TITLE
feat(agent): arm lsm/bpf self-defense + emit denied tamper events (B2)

### DIFF
--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -384,7 +384,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 							bpfSt = append(bpfSt, telemetry.BPFStatus{Name: "lsm/bpf (self-defense)", OK: false, Detail: bpfDetail(sdErr)})
 						} else {
 							defer sdLnk.Close()
-							progN, mapN := armBpfSelfDefense(&defendObjs, uint32(os.Getpid()))
+							progN, mapN := armBpfSelfDefense(&defendObjs, uint32(os.Getpid())) // #nosec G115 -- pid is always a small positive int; uint32 round-trip is intentional //nolint:gosec
 							if sdRd, rerr := ringbuf.NewReader(defendObjs.BpfSelfDefenseEvents); rerr != nil {
 								slog.Info("bpf self-defense ringbuf unavailable; continuing", "err", rerr)
 							} else {
@@ -1086,6 +1086,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 		denyRd.Close()
 		lsmDenyRd.Close()
 		egressBackstopRd.Close()
+		selfDefenseRd.Close()
 		dnsRd.Close()
 		bpfAuditRd.Close()
 		forkRd.Close()

--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -231,6 +231,8 @@ func Run(ctx context.Context, cfg config.Config) error {
 	defer egressBackstopRd.Close()
 	var lsmDenyRd ringReader
 	defer lsmDenyRd.Close()
+	var selfDefenseRd ringReader
+	defer selfDefenseRd.Close()
 	var syscallObjs *traceconnect.TraceconnectObjects
 	var syscallLnk link.Link
 	var defendObjs defend.DefendObjects
@@ -298,6 +300,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 		defer func() {
 			defendState.setDenyReserveFailures(readUint32PerCPUArraySum(defendObjs.DenyReserveFailures, "deny_reserve_failures"))
 			stats.setEgressBackstopReserveFailures(readUint32PerCPUArraySum(defendObjs.SkbBackstopReserveFailures, "skb_backstop_reserve_failures"))
+			stats.setBpfSelfDefenseReserveFailures(readUint32PerCPUArraySum(defendObjs.BpfSelfDefenseReserveFailures, "bpf_self_defense_reserve_failures"))
 			if hasLSM {
 				defendState.setDenyReserveFailures(readUint32PerCPUArraySum(defendObjs.LsmDenyReserveFailures, "lsm_deny_reserve_failures"))
 			}
@@ -368,6 +371,31 @@ func Run(ctx context.Context, cfg config.Config) error {
 						}
 					} else {
 						slog.Info("lsm/socket_sendpage program not present in defend stubs; rebuild defend objects on Linux to close the sendfile/splice gap")
+					}
+
+					// Sub-project B: lsm/bpf self-defense. Attach the hook, arm
+					// it (record coldstep's own object ids + enabled=1), and
+					// open its ringbuf. Best-effort defense-in-depth — never
+					// fatal. Inert until armed; armBpfSelfDefense flips enabled
+					// only after the protected-id sets are populated.
+					if defendObjs.ColdstepBpfSelfDefense != nil {
+						if sdLnk, sdErr := link.AttachLSM(link.LSMOptions{Program: defendObjs.ColdstepBpfSelfDefense}); sdErr != nil {
+							slog.Info("lsm/bpf self-defense attach failed; monitor tamper protection inactive", "err", sdErr)
+							bpfSt = append(bpfSt, telemetry.BPFStatus{Name: "lsm/bpf (self-defense)", OK: false, Detail: bpfDetail(sdErr)})
+						} else {
+							defer sdLnk.Close()
+							progN, mapN := armBpfSelfDefense(&defendObjs, uint32(os.Getpid()))
+							if sdRd, rerr := ringbuf.NewReader(defendObjs.BpfSelfDefenseEvents); rerr != nil {
+								slog.Info("bpf self-defense ringbuf unavailable; continuing", "err", rerr)
+							} else {
+								selfDefenseRd.R = sdRd
+							}
+							bpfSt = append(bpfSt, telemetry.BPFStatus{
+								Name:   "lsm/bpf (self-defense)",
+								OK:     true,
+								Detail: fmt.Sprintf("protecting %d prog(s) + %d map(s)", progN, mapN),
+							})
+						}
 					}
 
 					// H15: lsm/io_uring_cmd is best-effort defense-in-depth on
@@ -1106,6 +1134,9 @@ func Run(ctx context.Context, cfg config.Config) error {
 	if lsmDenyRd.R != nil {
 		readerCount++
 	}
+	if selfDefenseRd.R != nil {
+		readerCount++
+	}
 	if dnsRd.R != nil {
 		readerCount++
 	}
@@ -1360,6 +1391,13 @@ func Run(ctx context.Context, cfg config.Config) error {
 		go func() {
 			defer wg.Done()
 			sendReaderErr(readDenyRing(runCtx, cfg, lsmDenyRd.R, &seq, &jsonlMu, defendState, signer, "lsm", dnsCache))
+		}()
+	}
+	if selfDefenseRd.R != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sendReaderErr(readBpfSelfDefenseRing(runCtx, cfg, selfDefenseRd.R, stats, &seq, &jsonlMu, signer))
 		}()
 	}
 	if dnsRd.R != nil {

--- a/internal/agent/agent_linux_decode.go
+++ b/internal/agent/agent_linux_decode.go
@@ -262,7 +262,7 @@ func decodeBpfSelfDefenseEvent(raw []byte) (ts uint64, comm [16]byte, tgid, targ
 	copy(comm[:], raw[8:24])
 	tgid = binary.LittleEndian.Uint32(raw[24:28])
 	targetID = binary.LittleEndian.Uint32(raw[28:32])
-	cmd = int32(binary.LittleEndian.Uint32(raw[32:36]))
+	cmd = int32(binary.LittleEndian.Uint32(raw[32:36])) // #nosec G115 -- bpf cmd enum reinterpret of the BPF-side __s32; round-trip is intentional //nolint:gosec
 	kind = raw[36]
 	return ts, comm, tgid, targetID, cmd, kind, true
 }

--- a/internal/agent/agent_linux_decode.go
+++ b/internal/agent/agent_linux_decode.go
@@ -251,6 +251,22 @@ func decodeEgressBackstopEvent(raw []byte) (ts uint64, pid uint32, af uint8, ipp
 	return ts, pid, af, ipproto, daddr, dport, comm, true
 }
 
+// decodeBpfSelfDefenseEvent parses bpf_self_defense_event (40 bytes, see
+// bpf/bpf_self_defense_event.h). Layout: ts(8) comm(16) tgid(4) target_id(4)
+// cmd(4, signed) target_kind(1) _pad(3). All multi-byte fields little-endian.
+func decodeBpfSelfDefenseEvent(raw []byte) (ts uint64, comm [16]byte, tgid, targetID uint32, cmd int32, kind uint8, ok bool) {
+	if len(raw) < bpfSelfDefenseEventWireSize {
+		return 0, [16]byte{}, 0, 0, 0, 0, false
+	}
+	ts = binary.LittleEndian.Uint64(raw[0:8])
+	copy(comm[:], raw[8:24])
+	tgid = binary.LittleEndian.Uint32(raw[24:28])
+	targetID = binary.LittleEndian.Uint32(raw[28:32])
+	cmd = int32(binary.LittleEndian.Uint32(raw[32:36]))
+	kind = raw[36]
+	return ts, comm, tgid, targetID, cmd, kind, true
+}
+
 // decodeIOUringTLSEvent parses io_uring_tls_event (296 bytes, see
 // bpf/trace_connect_obs.h). Layout: ts(8) pid(4) comm(16) op(1) _pad(3)
 // capture_len(2, LE) payload(256) _pad2(6). capture_len is clamped to the

--- a/internal/agent/agent_linux_digest.go
+++ b/internal/agent/agent_linux_digest.go
@@ -40,6 +40,7 @@ func buildDroppedEventsMap(stats *runStats, defendState *defendState) map[string
 	add("io_uring", stats.ioUringRingbufReserveFailures())
 	add("io_uring_tls", stats.ioUringTLSRingbufReserveFailures())
 	add("egress_backstop", stats.egressBackstopReserveFailures())
+	add("bpf_self_defense", stats.bpfSelfDefenseReserveFailures())
 	if defendState != nil {
 		add("deny", defendState.snapshot().denyReserveFailures)
 	}
@@ -259,6 +260,7 @@ func buildDigestInput(
 		FSReaderErrors:                   fsSnap.readErrors,
 		EgressBackstopCount:              stats.egressBackstopCount(),
 		EgressBackstopDsts:               stats.egressBackstopDstList(),
+		BpfSelfDefenseCount:              stats.bpfSelfDefenseCount(),
 	}
 	if procTreeGate {
 		in.ProcForkTotal = stats.procForkTotal()

--- a/internal/agent/agent_linux_ring_read.go
+++ b/internal/agent/agent_linux_ring_read.go
@@ -1104,6 +1104,80 @@ func readEgressBackstopRing(ctx context.Context, cfg config.Config, rd *ringbuf.
 	}
 }
 
+// bpfSelfDefenseKindName maps the wire target_kind byte to a JSONL string.
+func bpfSelfDefenseKindName(k uint8) string {
+	switch k {
+	case 1:
+		return "prog"
+	case 2:
+		return "map"
+	case 3:
+		return "pin"
+	default:
+		return "other"
+	}
+}
+
+// bpfSelfDefenseEventFromRaw decodes a denied self-object tamper attempt
+// (sub-project B). seq may be 0; the reader assigns the real sequence under
+// jsonlMu on emit.
+func bpfSelfDefenseEventFromRaw(raw []byte, ts string, seq uint64) (telemetry.BpfSelfDefenseEvent, bool) {
+	_, commb, tgid, targetID, cmd, kind, ok := decodeBpfSelfDefenseEvent(raw)
+	if !ok {
+		return telemetry.BpfSelfDefenseEvent{}, false
+	}
+	return telemetry.BpfSelfDefenseEvent{
+		Type:       telemetry.EventTypeBpfSelfDefense,
+		TS:         ts,
+		Seq:        seq,
+		TGID:       tgid,
+		Comm:       telemetry.SanitizeField(nullTermStr(commb[:]), 16),
+		Cmd:        cmd,
+		TargetKind: bpfSelfDefenseKindName(kind),
+		TargetID:   targetID,
+		Action:     "denied",
+	}, true
+}
+
+// readBpfSelfDefenseRing drains bpf_self_defense_events (sub-project B). seq is
+// allocated under jsonlMu only on emit (matches every other ring reader).
+func readBpfSelfDefenseRing(ctx context.Context, cfg config.Config, rd *ringbuf.Reader, stats *runStats,
+	seq *telemetry.SeqGen, jsonlMu *sync.Mutex, signer *telemetry.Signer) error {
+	backoff := newRingReadRetryBackoff()
+	for {
+		record, err := rd.Read()
+		if err != nil {
+			if errors.Is(err, ringbuf.ErrClosed) {
+				return nil
+			}
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			delay := backoff.sleep()
+			slog.Warn("ringbuf read (bpf_self_defense)", "err", err, "backoff", delay)
+			continue
+		}
+		backoff.reset()
+
+		ts := time.Now().UTC().Format(time.RFC3339Nano)
+		ev, emit := bpfSelfDefenseEventFromRaw(record.RawSample, ts, 0)
+		if !emit {
+			continue
+		}
+		stats.addBpfSelfDefense()
+		if cfg.EventsLogPath != "" {
+			jsonlMu.Lock()
+			ev.Seq = seq.Next()
+			werr := telemetry.AppendJSONL(cfg.EventsLogPath, ev, signer)
+			jsonlMu.Unlock()
+			if werr != nil {
+				stats.addDropped("bpf_self_defense_jsonl")
+				slog.Warn("events jsonl (bpf_self_defense)", "err", werr)
+			}
+		}
+	}
+}
+
 // ioUringTLSEventFromRaw decodes a captured io_uring ClientHello and parses its
 // SNI via the same parser the syscall TLS sniffer uses (telemetry.ParseClientHelloSNI).
 // Returns emit=false when the payload does not parse as a ClientHello with a

--- a/internal/agent/agent_linux_state.go
+++ b/internal/agent/agent_linux_state.go
@@ -76,6 +76,11 @@ type runStats struct {
 	egressBackstopN                   int
 	egressBackstopReserveFailuresN    int
 	egressBackstopDsts                map[string]struct{}
+	// bpfSelfDefenseN counts denied attempts by a non-agent task to grab a
+	// handle to a coldstep BPF object (sub-project B). reserveFailures is the
+	// ringbuf-reserve drop counter snapshotted at shutdown.
+	bpfSelfDefenseN                int
+	bpfSelfDefenseReserveFailuresN int
 	// ioUringTLSSNISet collects distinct SNI hostnames parsed from io_uring
 	// ClientHello captures (P6 Phase 2.5). Rendered as the "io_uring TLS SNI"
 	// digest KPI row. nil until the first SNI is observed.
@@ -672,6 +677,30 @@ func (s *runStats) egressBackstopReserveFailures() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.egressBackstopReserveFailuresN
+}
+
+func (s *runStats) addBpfSelfDefense() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.bpfSelfDefenseN++
+}
+
+func (s *runStats) bpfSelfDefenseCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.bpfSelfDefenseN
+}
+
+func (s *runStats) setBpfSelfDefenseReserveFailures(n int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.bpfSelfDefenseReserveFailuresN = n
+}
+
+func (s *runStats) bpfSelfDefenseReserveFailures() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.bpfSelfDefenseReserveFailuresN
 }
 
 func (s *runStats) setIoUringTLSRingbufReserveFailures(n int) {

--- a/internal/agent/agent_linux_state_sections.go
+++ b/internal/agent/agent_linux_state_sections.go
@@ -168,6 +168,8 @@ const (
 	// io_uring_tls_event (P6 Phase 2.5): 8(ts)+4(pid)+16(comm)+1(op)+3(_pad)+2(capture_len)+256(payload)+6(_pad2) → 296
 	ioUringTLSEventWireSize = 296
 	ioUringTLSPayloadMax    = 256
+	// bpf_self_defense_event (sub-project B): 8(ts)+16(comm)+4(tgid)+4(target_id)+4(cmd)+1(target_kind)+3(_pad) → 40
+	bpfSelfDefenseEventWireSize = 40
 	// trace_dns.bpf.c dns_sniff_event: __u32 len + __u8 is_tcp + __u8 _pad[3] + data[DNS_SNIFF_MAX]
 	dnsSniffMaxPayload          = 4096                   // DNS_SNIFF_MAX in trace_dns.bpf.c
 	dnsSniffEventWireSizeLegacy = 4 + dnsSniffMaxPayload // pre-is_tcp layout (__u32 len + data[])

--- a/internal/agent/agent_linux_test.go
+++ b/internal/agent/agent_linux_test.go
@@ -1526,3 +1526,16 @@ func TestRunStats_EgressBackstop(t *testing.T) {
 		t.Fatalf("reserveFailures=%d want 2", got)
 	}
 }
+
+func TestRunStats_BpfSelfDefense(t *testing.T) {
+	s := newRunStats()
+	s.addBpfSelfDefense()
+	s.addBpfSelfDefense()
+	s.setBpfSelfDefenseReserveFailures(5)
+	if got := s.bpfSelfDefenseCount(); got != 2 {
+		t.Fatalf("count=%d want 2", got)
+	}
+	if got := s.bpfSelfDefenseReserveFailures(); got != 5 {
+		t.Fatalf("reserveFailures=%d want 5", got)
+	}
+}

--- a/internal/agent/bpf_self_defense_linux.go
+++ b/internal/agent/bpf_self_defense_linux.go
@@ -1,0 +1,133 @@
+//go:build linux
+
+package agent
+
+import (
+	"github.com/cilium/ebpf"
+
+	"github.com/coldstep-io/coldstep/internal/bpf/defend"
+)
+
+// selfDefenseCfgValue mirrors struct cs_self_defense_cfg in
+// bpf/trace_lsm_bpf_self_defense.inc: agent_tgid u32 + enabled u8 + _pad[3].
+type selfDefenseCfgValue struct {
+	AgentTGID uint32
+	Enabled   uint8
+	_         [3]uint8
+}
+
+// armBpfSelfDefense (sub-project B) records the kernel ids of coldstep's own
+// loaded defend programs/maps into self_prog_ids / self_map_ids, then flips
+// self_defense_cfg.enabled to 1 LAST — so the lsm/bpf hook stays inert until
+// the protected-id sets are complete (no arm-before-known-ids window).
+//
+// Best-effort: a missing map (stub predating the section, or LSM stripped)
+// makes this a no-op rather than an error — the program ships inert in that
+// case. self_pin_prefix is left empty because coldstep does not pin its
+// objects today; that disables the BPF_OBJ_GET branch, leaving the by-id
+// protection (the realistic CAP_BPF tamper vector) as the active path.
+//
+// Returns the number of program ids and map ids successfully recorded so the
+// caller can surface it in a BPFStatus row.
+func armBpfSelfDefense(objs *defend.DefendObjects, agentTGID uint32) (progN, mapN int) {
+	if objs.SelfDefenseCfg == nil {
+		return 0, 0 // section absent — nothing to arm
+	}
+
+	one := uint8(1)
+	if objs.SelfProgIds != nil {
+		for _, p := range selfDefenseProgramSet(objs) {
+			if p == nil {
+				continue
+			}
+			info, err := p.Info()
+			if err != nil {
+				continue
+			}
+			id, ok := info.ID()
+			if !ok {
+				continue
+			}
+			if err := objs.SelfProgIds.Put(uint32(id), one); err == nil {
+				progN++
+			}
+		}
+	}
+	if objs.SelfMapIds != nil {
+		for _, m := range selfDefenseMapSet(objs) {
+			if m == nil {
+				continue
+			}
+			info, err := m.Info()
+			if err != nil {
+				continue
+			}
+			id, ok := info.ID()
+			if !ok {
+				continue
+			}
+			if err := objs.SelfMapIds.Put(uint32(id), one); err == nil {
+				mapN++
+			}
+		}
+	}
+
+	// Arm last: enabled=1 only after the id sets are populated.
+	cfg := selfDefenseCfgValue{AgentTGID: agentTGID, Enabled: 1}
+	_ = objs.SelfDefenseCfg.Put(uint32(0), cfg)
+	return progN, mapN
+}
+
+// selfDefenseProgramSet lists every defend program whose handle should be
+// protected. Explicit (not reflection) because the generated DefendObjects
+// embeds unexported structs, and reflect cannot read promoted exported fields
+// through an unexported embed without panicking. nil entries (stripped LSM
+// section, older stub) are skipped by the caller.
+func selfDefenseProgramSet(o *defend.DefendObjects) []*ebpf.Program {
+	return []*ebpf.Program{
+		o.DefendConnect4,
+		o.DefendSendmsg4,
+		o.DefendCgroupConnect6,
+		o.DefendCgroupSendmsg6,
+		o.DefendSkbEgress,
+		o.LsmSocketConnect,
+		o.LsmSocketSendmsg,
+		o.LsmSocketSendpage,
+		o.LsmIoUringCmd,
+		o.ColdstepBpfSelfDefense,
+	}
+}
+
+// selfDefenseMapSet lists every defend map whose handle should be protected,
+// including the self-defense maps themselves (so an attacker cannot grab a
+// handle to self_defense_cfg and disarm the hook). nil entries are skipped.
+func selfDefenseMapSet(o *defend.DefendObjects) []*ebpf.Map {
+	return []*ebpf.Map{
+		o.DenyEvents,
+		o.DenyReserveFailures,
+		o.DefendCfg,
+		o.AllowedIpv4,
+		o.IgnoredIpv4Lpm,
+		o.AllowedDomains,
+		o.DnsCache,
+		o.Ipv6ConnectObserved,
+		o.Ipv6SendmsgObserved,
+		o.AllowedIpv6,
+		o.SkbBackstopEvents,
+		o.SkbBackstopReserveFailures,
+		o.SkbBackstopSeen,
+		o.LsmDenyEvents,
+		o.LsmDenyReserveFailures,
+		o.LsmDefendCfg,
+		o.LsmAllowedIpv4,
+		o.LsmIgnoredIpv4Lpm,
+		o.SendpageObserved,
+		o.SelfProgIds,
+		o.SelfMapIds,
+		o.SelfPinPrefix,
+		o.SelfDefenseCfg,
+		o.BpfSelfDefenseEvents,
+		o.BpfSelfDefenseReserveFailures,
+		o.SelfDefenseSeen,
+	}
+}

--- a/internal/agent/decode_network_linux_test.go
+++ b/internal/agent/decode_network_linux_test.go
@@ -741,3 +741,55 @@ func TestEgressBackstopEventFromRaw_shortNoEmit(t *testing.T) {
 		t.Fatal("expected emit=false for short record")
 	}
 }
+
+func TestDecodeBpfSelfDefenseEvent(t *testing.T) {
+	raw := make([]byte, bpfSelfDefenseEventWireSize)
+	binary.LittleEndian.PutUint64(raw[0:8], 1717000000002)
+	copy(raw[8:24], []byte("attacker\x00"))
+	binary.LittleEndian.PutUint32(raw[24:28], 9001)
+	binary.LittleEndian.PutUint32(raw[28:32], 42)
+	binary.LittleEndian.PutUint32(raw[32:36], 14) // BPF_PROG_GET_FD_BY_ID
+	raw[36] = 1                                   // KIND_PROG
+
+	ts, comm, tgid, targetID, cmd, kind, ok := decodeBpfSelfDefenseEvent(raw)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if ts != 1717000000002 || tgid != 9001 || targetID != 42 || cmd != 14 || kind != 1 {
+		t.Fatalf("ts=%d tgid=%d id=%d cmd=%d kind=%d", ts, tgid, targetID, cmd, kind)
+	}
+	if got := string(bytes.TrimRight(comm[:], "\x00")); got != "attacker" {
+		t.Fatalf("comm %q", got)
+	}
+}
+
+func TestDecodeBpfSelfDefenseEvent_tooShort(t *testing.T) {
+	if _, _, _, _, _, _, ok := decodeBpfSelfDefenseEvent(make([]byte, bpfSelfDefenseEventWireSize-1)); ok {
+		t.Fatal("expected ok=false for short input")
+	}
+}
+
+func TestBpfSelfDefenseEventFromRaw_parses(t *testing.T) {
+	raw := make([]byte, bpfSelfDefenseEventWireSize)
+	binary.LittleEndian.PutUint64(raw[0:8], 7)
+	copy(raw[8:24], []byte("evil\x00"))
+	binary.LittleEndian.PutUint32(raw[24:28], 1234)
+	binary.LittleEndian.PutUint32(raw[28:32], 99)
+	binary.LittleEndian.PutUint32(raw[32:36], 13) // BPF_MAP_GET_FD_BY_ID
+	raw[36] = 2                                   // KIND_MAP
+
+	ev, emit := bpfSelfDefenseEventFromRaw(raw, "2026-06-07T00:00:00Z", 8)
+	if !emit {
+		t.Fatal("expected emit=true")
+	}
+	if ev.Type != "bpf_self_defense" || ev.TargetKind != "map" || ev.TargetID != 99 ||
+		ev.Cmd != 13 || ev.TGID != 1234 || ev.Comm != "evil" || ev.Action != "denied" || ev.Seq != 8 {
+		t.Fatalf("ev=%+v", ev)
+	}
+}
+
+func TestBpfSelfDefenseEventFromRaw_shortNoEmit(t *testing.T) {
+	if _, emit := bpfSelfDefenseEventFromRaw(make([]byte, bpfSelfDefenseEventWireSize-1), "t", 1); emit {
+		t.Fatal("expected emit=false for short record")
+	}
+}

--- a/internal/report/digest.go
+++ b/internal/report/digest.go
@@ -628,6 +628,9 @@ func writeFullKPITable(b *strings.Builder, in DigestInput) {
 	if in.IoUringTLSRingbufReserveFailures > 0 {
 		fmt.Fprintf(b, "| **io_uring_tls_events ringbuf reserve failures** | %d (matched ClientHello captures dropped before SNI parse) |\n", in.IoUringTLSRingbufReserveFailures)
 	}
+	if in.BpfSelfDefenseCount > 0 {
+		fmt.Fprintf(b, "| **🛡️ BPF self-defense** | %d tamper attempt(s) on coldstep's own BPF objects denied (prog/map GET_FD_BY_ID or pin open by a non-agent task) |\n", in.BpfSelfDefenseCount)
+	}
 	if in.IPv6ConnectObserved > 0 {
 		label := "**⚠️ ipv6 connect6 observed (detect — no enforcement)**"
 		if ipv6DefendActive(in) {

--- a/internal/report/digest_test.go
+++ b/internal/report/digest_test.go
@@ -2017,3 +2017,30 @@ func TestDigest_EgressBackstopRow(t *testing.T) {
 		}
 	})
 }
+
+func TestBuildDetectMarkdown_BpfSelfDefenseRow(t *testing.T) {
+	t.Run("hidden when zero", func(t *testing.T) {
+		md := BuildDetectMarkdown(DigestInput{
+			BPF:               []telemetry.BPFStatus{{Name: "lsm/bpf (self-defense)", OK: true}},
+			ExecTotal:         1,
+			TCPTotal:          1,
+			MaxRowsPerSection: 50,
+		})
+		if strings.Contains(md, "BPF self-defense") {
+			t.Fatalf("row must be hidden when zero:\n%s", md)
+		}
+	})
+	t.Run("visible when non-zero", func(t *testing.T) {
+		md := BuildDetectMarkdown(DigestInput{
+			BPF:                 []telemetry.BPFStatus{{Name: "lsm/bpf (self-defense)", OK: true}},
+			ExecTotal:           1,
+			TCPTotal:            1,
+			BpfSelfDefenseCount: 2,
+			MaxRowsPerSection:   50,
+		})
+		needle := "| **🛡️ BPF self-defense** | 2 tamper attempt(s) on coldstep's own BPF objects denied (prog/map GET_FD_BY_ID or pin open by a non-agent task) |"
+		if !strings.Contains(md, needle) {
+			t.Fatalf("missing %q in:\n%s", needle, md)
+		}
+	})
+}

--- a/internal/report/digest_types.go
+++ b/internal/report/digest_types.go
@@ -300,6 +300,11 @@ type DigestInput struct {
 	// EgressBackstopDsts lists the distinct non-allowlisted destination IPs
 	// observed at the egress backstop, sorted. Empty when none.
 	EgressBackstopDsts []string
+	// BpfSelfDefenseCount is the number of denied attempts by a non-agent task
+	// to obtain a handle to a coldstep BPF object (sub-project B). Non-zero is
+	// the self-defense hook working — an informational row, not a coverage gap.
+	// Zero hides the digest row.
+	BpfSelfDefenseCount int
 	// IoUringTLSRingbufReserveFailures counts reserve failures on the dedicated
 	// io_uring_tls_events channel — non-zero means matched ClientHello captures
 	// were dropped before SNI parse (P6 Phase 2.5).

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -662,6 +662,30 @@ type BPFAuditEvent struct {
 	Sig      string `json:"sig,omitempty"`
 }
 
+// EventTypeBpfSelfDefense marks a denied attempt by a non-agent task to obtain
+// a handle to one of coldstep's own BPF objects (sub-project B). The lsm/bpf
+// hook returned -EPERM, so the tamper attempt failed — this record is the
+// audit trail, not a breach. Only emitted in defend mode on kernels with
+// CONFIG_BPF_LSM.
+const EventTypeBpfSelfDefense = "bpf_self_defense"
+
+// BpfSelfDefenseEvent is one JSONL record for a denied bpf() control-plane op
+// against a coldstep object. TargetKind is "prog" | "map" | "pin"; TargetID is
+// the prog/map id for the by-id paths (0 for pin-path opens). Cmd is the raw
+// bpf() command number. Action is always "denied".
+type BpfSelfDefenseEvent struct {
+	Type       string `json:"type"` // "bpf_self_defense"
+	TS         string `json:"ts"`
+	Seq        uint64 `json:"seq"`
+	TGID       uint32 `json:"tgid"`
+	Comm       string `json:"comm"`
+	Cmd        int32  `json:"cmd"`
+	TargetKind string `json:"target_kind"`         // "prog" | "map" | "pin"
+	TargetID   uint32 `json:"target_id,omitempty"` // prog/map id; 0 for pin
+	Action     string `json:"action"`              // "denied"
+	Sig        string `json:"sig,omitempty"`
+}
+
 // BPFTamperEvent is one JSONL record for a detected BPF map or program tampering event.
 type BPFTamperEvent struct {
 	Type     string `json:"type"` // "bpf_tamper"

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -479,6 +479,33 @@ func TestFSEvent_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestBpfSelfDefenseEvent_JSONShape(t *testing.T) {
+	ev := BpfSelfDefenseEvent{
+		Type: EventTypeBpfSelfDefense, TS: "2026-06-07T00:00:00Z", Seq: 3,
+		TGID: 9001, Comm: "attacker", Cmd: 14, TargetKind: "prog",
+		TargetID: 42, Action: "denied",
+	}
+	b, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(b)
+	for _, want := range []string{
+		`"type":"bpf_self_defense"`, `"tgid":9001`, `"comm":"attacker"`,
+		`"cmd":14`, `"target_kind":"prog"`, `"target_id":42`, `"action":"denied"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("json %s missing %s", got, want)
+		}
+	}
+	// target_id omitempty: a pin event (id 0) must omit the field.
+	pin := BpfSelfDefenseEvent{Type: EventTypeBpfSelfDefense, TargetKind: "pin", Action: "denied"}
+	pb, _ := json.Marshal(pin)
+	if strings.Contains(string(pb), `"target_id"`) {
+		t.Errorf("pin event must omit target_id: %s", pb)
+	}
+}
+
 func TestEgressBackstopEvent_JSONShape(t *testing.T) {
 	ev := EgressBackstopEvent{
 		Type: EventTypeEgressBackstop, TS: "2026-06-06T00:00:00Z", Seq: 9,


### PR DESCRIPTION
## What

Sub-project B (eBPF self-defense) slice 2: **activate** the `lsm/bpf` hook shipped inert in #263. The agent now records its own BPF object ids, arms the hook, and emits an audit record when a non-agent task's tamper attempt is denied.

## Population (`armBpfSelfDefense`)

After the LSM section attaches, record the kernel ids of every loaded defend program/map (including the self-defense maps themselves, so an attacker can't grab `self_defense_cfg` to disarm) into `self_prog_ids` / `self_map_ids`, then flip `self_defense_cfg.enabled` to `1` **last** — no window where the hook denies before the protected ids are known. `agent_tgid` exempts the agent itself. `self_pin_prefix` is left empty (coldstep doesn't pin its objects today), disabling the `BPF_OBJ_GET` branch; the by-id protection is the active path. Object enumeration is explicit (not reflection) because the generated `DefendObjects` embeds unexported structs.

## Telemetry / digest

- `BpfSelfDefenseEvent` (type `bpf_self_defense`) + 40-byte wire decoder + `readBpfSelfDefenseRing`.
- BG-1 (seq under `jsonlMu` on emit), BG-3 (reserve-failure counter snapshot at shutdown), and the #259 class (`readerCount++` + goroutine) all wired.
- Hidden-when-zero digest row `🛡️ BPF self-defense | N tamper attempt(s) … denied`. Non-zero is the hook **working** (informational), not a coverage gap.
- `lsm/bpf (self-defense)` BPFStatus row records attach + how many prog/map handles are protected.

## Tests

Event JSON shape (+ `target_id` omitempty for pin), wire decode round-trip + too-short + fromRaw, runStats counters, digest row visible/hidden. Built clean on Linux (WSL 6.6): stubs regenerate, agent links, full unit suite + `vet` pass, gofmt clean.

## Follow-up

- **B3** — integration `TestRedTeam_BpfSelfDefense_*` (deny / no-FP on non-coldstep id / no-self-block on agent's own map update) + kernel-matrix expectation + README/CLAUDE.md defend-surface docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
