### PR TITLE
feat(action): write pure-markdown detailed report in stop (report-elim phase 1)

### DIFF
--- a/cmd/coldstep-action/main.go
+++ b/cmd/coldstep-action/main.go
@@ -413,6 +413,13 @@ func runStop(cfg stopConfig) error {
 		}
 	}
 
+	// Report-binary elimination (Phase 1): render the pure-markdown detailed
+	// report from the JSONL source of truth and write it to .coldstep-report.md
+	// for artifact upload. Best-effort — never fails the job; the agent's
+	// .coldstep-detect.md remains the job-summary source until later phases swap
+	// it for the markdown generator's simple report.
+	writeDetailedMarkdownReport(baseDir)
+
 	body := ""
 	if raw, err := os.ReadFile(detectLog); err == nil {
 		body = string(raw)

--- a/cmd/coldstep-action/report_markdown.go
+++ b/cmd/coldstep-action/report_markdown.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/coldstep-io/coldstep/internal/atomicwrite"
+	"github.com/coldstep-io/coldstep/internal/report/markdown"
+)
+
+// writeDetailedMarkdownReport reads the JSONL event stream (the source of truth)
+// and writes the pure-markdown detailed report to .coldstep-report.md for
+// artifact upload. Part of eliminating the separate coldstep-report binary:
+// report rendering moves into the userspace stop step.
+//
+// Best-effort: any failure logs to stderr and returns without erroring, so a
+// missing or partial event stream never fails the post-job step. The agent's
+// .coldstep-detect.md remains the job-summary source until a later phase swaps
+// it for markdown.Aggregate.RenderSimple.
+func writeDetailedMarkdownReport(baseDir string) {
+	eventsPath := filepath.Join(baseDir, ".coldstep-events.jsonl")
+	f, err := os.Open(eventsPath) // #nosec G304 -- baseDir is GITHUB_WORKSPACE (trusted env), fixed filename //nolint:gosec
+	if err != nil {
+		// No event stream (e.g. agent never started) — nothing to render.
+		return
+	}
+	defer f.Close()
+
+	agg, err := markdown.Parse(f)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "coldstep: parse events for markdown report: %v\n", err)
+		return
+	}
+
+	outPath := filepath.Join(baseDir, ".coldstep-report.md")
+	if werr := atomicwrite.Bytes(outPath, []byte(agg.RenderDetailed()), 0o644); werr != nil {
+		fmt.Fprintf(os.Stderr, "coldstep: write %s: %v\n", outPath, werr)
+	}
+}

--- a/cmd/coldstep-action/report_markdown_test.go
+++ b/cmd/coldstep-action/report_markdown_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteDetailedMarkdownReport(t *testing.T) {
+	dir := t.TempDir()
+	events := filepath.Join(dir, ".coldstep-events.jsonl")
+	jsonl := strings.Join([]string{
+		`{"type":"tcp","dst":"140.82.121.4","fqdn":"github.com","dport":443}`,
+		`{"type":"udp","dst":"8.8.8.8","dport":53}`,
+		`{"type":"deny","comm":"curl","protocol":"tcp","dst":"1.2.3.4","dport":443,"reason":"dst_not_allowlisted","hook_family":"cgroup","mode":"defend"}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(events, []byte(jsonl), 0o644); err != nil {
+		t.Fatalf("write events: %v", err)
+	}
+
+	writeDetailedMarkdownReport(dir)
+
+	raw, err := os.ReadFile(filepath.Join(dir, ".coldstep-report.md"))
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	out := string(raw)
+	for _, want := range []string{"# coldstep detailed report", "github.com", "## Denies", "curl"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report missing %q:\n%s", want, out)
+		}
+	}
+	// Pure markdown — no embedded HTML.
+	if strings.Contains(out, "<") {
+		t.Errorf("report contains '<' (HTML not allowed):\n%s", out)
+	}
+}
+
+func TestWriteDetailedMarkdownReport_NoEventsNoFile(t *testing.T) {
+	dir := t.TempDir()
+	// No .coldstep-events.jsonl present — helper must be a quiet no-op.
+	writeDetailedMarkdownReport(dir)
+	if _, err := os.Stat(filepath.Join(dir, ".coldstep-report.md")); !os.IsNotExist(err) {
+		t.Fatalf("expected no report file when events are absent, stat err=%v", err)
+	}
+}


### PR DESCRIPTION
## What

Phase 1 of eliminating the separate `coldstep-report` binary. `coldstep-action stop` now reads `.coldstep-events.jsonl` (source of truth) and writes the pure-markdown detailed report to `.coldstep-report.md` via the existing `internal/report/markdown` generator.

## Why additive / de-risked

- Best-effort: missing or partial event stream → quiet no-op, never fails the job.
- The agent's `.coldstep-detect.md` remains the job-summary source, untouched.

## Roadmap (per plan)

- **P1 (this PR)** detailed `.coldstep-report.md` in stop.
- P2 swap job summary to `markdown.RenderSimple`; fold `diff` + a `stop --strict` required-types gate into coldstep-action (drop `internal/report/model` dep).
- P3 rewrite workflows to use coldstep-action + upload `.coldstep-report.md`.
- P4 delete `cmd/coldstep-report` + `internal/report/{model,integrity}` + the agent's HTML/digest path.
- P5 docs + stop publishing `coldstep-report-linux-amd64` (shipped assets stay immutable).

Reputation/OTX already removed (#266), so the plan's enrichment steps are moot.

## Tests

Report written with expected sections + zero embedded HTML; no-events case writes no file. Built + vetted clean on Linux (WSL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)