### PR TITLE
feat(action): stop --strict required-type gate (report-elim phase 2c)

### DIFF
--- a/cmd/coldstep-action/main.go
+++ b/cmd/coldstep-action/main.go
@@ -89,6 +89,11 @@ type stopConfig struct {
 	FailOnError bool
 	Report      string
 	GithubToken string
+	// Strict enables the anti-blindness required-event-type gate (replaces the
+	// coldstep-report assert-integrity step): a non-zero exit when expected
+	// JSONL event types are missing. DetectProfile selects the required set.
+	Strict        bool
+	DetectProfile string
 }
 
 func main() {
@@ -148,6 +153,8 @@ func parseStopFlags(args []string) (stopConfig, error) {
 	fs.BoolVar(&cfg.FailOnError, "fail-on-error", false, "")
 	fs.StringVar(&cfg.Report, "report", "job-summary", "")
 	fs.StringVar(&cfg.GithubToken, "github-token", "", "")
+	fs.BoolVar(&cfg.Strict, "strict", false, "")
+	fs.StringVar(&cfg.DetectProfile, "detect-profile", getenvDefault("COLDSTEP_DETECT_PROFILE", ""), "")
 	if err := fs.Parse(args); err != nil {
 		return cfg, err
 	}
@@ -418,7 +425,7 @@ func runStop(cfg stopConfig) error {
 	// for artifact upload. Best-effort — never fails the job; the agent's
 	// .coldstep-detect.md remains the job-summary source until later phases swap
 	// it for the markdown generator's simple report.
-	writeDetailedMarkdownReport(baseDir)
+	reportAgg := writeDetailedMarkdownReport(baseDir)
 
 	body := ""
 	if raw, err := os.ReadFile(detectLog); err == nil {
@@ -483,6 +490,18 @@ func runStop(cfg stopConfig) error {
 			if err := postPRComment(token, sanitizeDigestForMarkdown(body)); err != nil {
 				fmt.Fprintf(os.Stderr, "coldstep: report pr-comment: %v\n", err)
 			}
+		}
+	}
+
+	// Anti-blindness gate (--strict): replaces coldstep-report assert-integrity.
+	// Run last so the report is still posted/attached before a missing-type
+	// failure aborts the step.
+	if cfg.Strict {
+		if reportAgg == nil {
+			return errors.New("strict: no .coldstep-events.jsonl to evaluate required event types")
+		}
+		if missing := reportAgg.MissingRequiredTypes(cfg.DetectProfile); len(missing) > 0 {
+			return fmt.Errorf("strict: missing required event type(s): %s", strings.Join(missing, ", "))
 		}
 	}
 	return nil

--- a/cmd/coldstep-action/report_markdown.go
+++ b/cmd/coldstep-action/report_markdown.go
@@ -18,23 +18,26 @@ import (
 // missing or partial event stream never fails the post-job step. The agent's
 // .coldstep-detect.md remains the job-summary source until a later phase swaps
 // it for markdown.Aggregate.RenderSimple.
-func writeDetailedMarkdownReport(baseDir string) {
+// Returns the parsed Aggregate (or nil when no event stream is present) so the
+// caller can reuse it for the --strict required-type gate without re-parsing.
+func writeDetailedMarkdownReport(baseDir string) *markdown.Aggregate {
 	eventsPath := filepath.Join(baseDir, ".coldstep-events.jsonl")
 	f, err := os.Open(eventsPath) // #nosec G304 -- baseDir is GITHUB_WORKSPACE (trusted env), fixed filename //nolint:gosec
 	if err != nil {
 		// No event stream (e.g. agent never started) — nothing to render.
-		return
+		return nil
 	}
 	defer f.Close()
 
 	agg, err := markdown.Parse(f)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "coldstep: parse events for markdown report: %v\n", err)
-		return
+		return nil
 	}
 
 	outPath := filepath.Join(baseDir, ".coldstep-report.md")
 	if werr := atomicwrite.Bytes(outPath, []byte(agg.RenderDetailed()), 0o644); werr != nil {
 		fmt.Fprintf(os.Stderr, "coldstep: write %s: %v\n", outPath, werr)
 	}
+	return agg
 }

--- a/cmd/coldstep-action/report_markdown_test.go
+++ b/cmd/coldstep-action/report_markdown_test.go
@@ -45,3 +45,19 @@ func TestWriteDetailedMarkdownReport_NoEventsNoFile(t *testing.T) {
 		t.Fatalf("expected no report file when events are absent, stat err=%v", err)
 	}
 }
+
+func TestStopStrictRequiredTypes(t *testing.T) {
+	dir := t.TempDir()
+	// Only meta+tcp present — exec missing under the standard profile.
+	jsonl := `{"type":"meta"}` + "\n" + `{"type":"tcp","dst":"1.2.3.4","dport":443}` + "\n"
+	if err := os.WriteFile(filepath.Join(dir, ".coldstep-events.jsonl"), []byte(jsonl), 0o644); err != nil {
+		t.Fatalf("write events: %v", err)
+	}
+	agg := writeDetailedMarkdownReport(dir)
+	if agg == nil {
+		t.Fatal("expected aggregate")
+	}
+	if missing := agg.MissingRequiredTypes(""); len(missing) != 1 || missing[0] != "exec" {
+		t.Fatalf("missing = %v want [exec]", missing)
+	}
+}

--- a/internal/report/markdown/markdown.go
+++ b/internal/report/markdown/markdown.go
@@ -70,6 +70,10 @@ type Aggregate struct {
 	// number of egress events seen for it.
 	Dests map[string]int
 
+	// seen is the set of JSONL event types observed, for the required-type
+	// integrity gate (replaces the model-based integrity.CheckRequiredTypes).
+	seen map[string]struct{}
+
 	// EventsSHA256, when set, is rendered as a plain line (never an HTML
 	// comment) for tamper-evidence.
 	EventsSHA256 string
@@ -131,7 +135,7 @@ type denyLine struct {
 // lines are counted in ParseErrors and skipped — a single bad line never aborts
 // the report (defence-in-depth against a build step appending garbage).
 func Parse(r io.Reader) (*Aggregate, error) {
-	a := &Aggregate{Dests: make(map[string]int)}
+	a := &Aggregate{Dests: make(map[string]int), seen: make(map[string]struct{})}
 	sc := bufio.NewScanner(r)
 	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
 	for sc.Scan() {
@@ -145,6 +149,7 @@ func Parse(r io.Reader) (*Aggregate, error) {
 			continue
 		}
 		a.TotalEvents++
+		a.seen[t.Type] = struct{}{}
 		switch t.Type {
 		case "meta":
 			a.countMeta(line)
@@ -292,6 +297,29 @@ func (a *Aggregate) countDeny(line []byte) {
 		Reason:     d.Reason,
 		HookFamily: d.HookFamily,
 	})
+}
+
+// RequiredTypes returns the JSONL event types an integrity-strict run expects.
+// "enhanced" widens the set to the observe-only egress/process/fs signals.
+// Ported from internal/report/integrity (drops the model dependency).
+func RequiredTypes(detectProfile string) []string {
+	if strings.EqualFold(strings.TrimSpace(detectProfile), "enhanced") {
+		return []string{"meta", "exec", "tcp", "udp", "http", "tls", "proc_fork", "fs_event"}
+	}
+	return []string{"meta", "exec", "tcp"}
+}
+
+// MissingRequiredTypes returns the required event types absent from the stream,
+// sorted. Empty result means the anti-blindness required-type gate passes.
+func (a *Aggregate) MissingRequiredTypes(detectProfile string) []string {
+	var missing []string
+	for _, req := range RequiredTypes(detectProfile) {
+		if _, ok := a.seen[req]; !ok {
+			missing = append(missing, req)
+		}
+	}
+	sort.Strings(missing)
+	return missing
 }
 
 type destCount struct {

--- a/internal/report/markdown/markdown_test.go
+++ b/internal/report/markdown/markdown_test.go
@@ -214,3 +214,20 @@ func TestParse_MetaSignals(t *testing.T) {
 		t.Errorf("simple missing degraded/dind:\n%s", sim)
 	}
 }
+
+func TestMissingRequiredTypes(t *testing.T) {
+	// Standard profile: meta+exec+tcp required.
+	a, _ := Parse(strings.NewReader(`{"type":"meta"}` + "\n" + `{"type":"tcp"}` + "\n"))
+	if got := a.MissingRequiredTypes(""); len(got) != 1 || got[0] != "exec" {
+		t.Fatalf("standard missing = %v want [exec]", got)
+	}
+	full := `{"type":"meta"}` + "\n" + `{"type":"exec"}` + "\n" + `{"type":"tcp"}` + "\n"
+	b, _ := Parse(strings.NewReader(full))
+	if got := b.MissingRequiredTypes(""); len(got) != 0 {
+		t.Fatalf("standard complete missing = %v want none", got)
+	}
+	// Enhanced widens the required set.
+	if got := b.MissingRequiredTypes("enhanced"); len(got) == 0 {
+		t.Fatalf("enhanced should report missing udp/http/tls/proc_fork/fs_event")
+	}
+}


### PR DESCRIPTION
## What

Replaces the `coldstep-report assert-integrity` anti-blindness gate with a JSONL-direct check inside `coldstep-action`, so the gate survives the binary's deletion and drops the `internal/report/{model,integrity}` dependency for this path.

- `markdown.Aggregate` records observed event types; `RequiredTypes(profile)` + `Aggregate.MissingRequiredTypes(profile)` port the required-type lists (standard: meta/exec/tcp; enhanced adds udp/http/tls/proc_fork/fs_event).
- `coldstep-action stop --strict` (+ `--detect-profile`, default `$COLDSTEP_DETECT_PROFILE`): after the report is written/posted, a missing required type aborts with a non-zero exit naming the gap. Runs **last** so the report still attaches before the failure.
- `writeDetailedMarkdownReport` returns the parsed Aggregate so the gate reuses it.

## Why

Part of eliminating `coldstep-report`: Phase 3 workflows call `coldstep-action stop --strict` instead of `assert-integrity`; Phase 4 then deletes `internal/report/integrity`.

## Tests

Required-type sets (standard/enhanced), missing-type detection, strict gate over a meta+tcp (exec-missing) fixture. Build/vet/test green on WSL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)