### PR TITLE
feat(action): coldstep-action diff baseline gate (report-elim phase 2c)

### DIFF
--- a/cmd/coldstep-action/main.go
+++ b/cmd/coldstep-action/main.go
@@ -115,6 +115,8 @@ func main() {
 			fatal(err)
 		}
 		fatal(runStop(cfg))
+	case "diff":
+		fatal(runDiff(os.Args[2:]))
 	default:
 		fatal(fmt.Errorf("unknown command %q", os.Args[1]))
 	}

--- a/cmd/coldstep-action/report_markdown.go
+++ b/cmd/coldstep-action/report_markdown.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/coldstep-io/coldstep/internal/atomicwrite"
 	"github.com/coldstep-io/coldstep/internal/report/markdown"
+	"github.com/coldstep-io/coldstep/internal/safepath"
 )
 
 // writeDetailedMarkdownReport reads the JSONL event stream (the source of truth)
@@ -40,4 +44,92 @@ func writeDetailedMarkdownReport(baseDir string) *markdown.Aggregate {
 		fmt.Fprintf(os.Stderr, "coldstep: write %s: %v\n", outPath, werr)
 	}
 	return agg
+}
+
+// parseAggregateFile parses a JSONL event stream into a markdown.Aggregate.
+func parseAggregateFile(path string) (*markdown.Aggregate, error) {
+	f, err := os.Open(path) // #nosec G304 -- workspace-validated path (safepath.Workspace) //nolint:gosec
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return markdown.Parse(f)
+}
+
+// runDiff implements `coldstep-action diff` — the baseline destination-domain
+// diff that replaces `coldstep-report diff`. It reads two JSONL streams
+// directly (no report model), writes a compact marker block to the job
+// summary, and, with --fail-on-new-domain, exits non-zero when current
+// introduces destination domains absent from baseline (P1-2 supply-chain
+// learning-mode-poisoning gate).
+func runDiff(args []string) error {
+	fs := flag.NewFlagSet("diff", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	ws := getenvDefault("GITHUB_WORKSPACE", ".")
+	current := fs.String("current", filepath.Join(ws, ".coldstep-events.jsonl"), "")
+	baseline := fs.String("baseline", "", "")
+	summary := fs.String("summary", os.Getenv("GITHUB_STEP_SUMMARY"), "")
+	marker := fs.String("marker", "coldstep-prev-diff", "")
+	failOnNewDomain := fs.Bool("fail-on-new-domain", false, "")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*summary) == "" {
+		return fmt.Errorf("diff: summary path is required")
+	}
+	if strings.TrimSpace(*baseline) == "" {
+		return fmt.Errorf("diff: baseline path is required")
+	}
+
+	currentPath, err := safepath.Workspace(*current, "current")
+	if err != nil {
+		return err
+	}
+	baselinePath, err := safepath.Workspace(*baseline, "baseline")
+	if err != nil {
+		return err
+	}
+	summaryPath, err := safepath.Workspace(*summary, "GITHUB_STEP_SUMMARY")
+	if err != nil {
+		return err
+	}
+
+	cur, err := parseAggregateFile(currentPath)
+	if err != nil {
+		return fmt.Errorf("load current events: %w", err)
+	}
+	base, err := parseAggregateFile(baselinePath)
+	if err != nil {
+		return fmt.Errorf("load baseline events: %w", err)
+	}
+
+	added, removed := markdown.DiffDomains(cur, base)
+	result := "no-change"
+	if len(added) > 0 || len(removed) > 0 {
+		result = "changed"
+	}
+
+	block := fmt.Sprintf(
+		"\n#### Previous-run traffic diff (compact)\n\n- %s.result=%s\n- %s.new_domains=%d\n- %s.gone_domains=%d\n",
+		*marker, result, *marker, len(added), *marker, len(removed),
+	)
+	f, err := os.OpenFile(summaryPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644) // #nosec G304 -- workspace-validated //nolint:gosec
+	if err != nil {
+		return err
+	}
+	if _, werr := f.WriteString(block); werr != nil {
+		_ = f.Close()
+		return werr
+	}
+	if cerr := f.Close(); cerr != nil {
+		return cerr
+	}
+
+	if *failOnNewDomain && len(added) > 0 {
+		fmt.Fprintf(os.Stderr,
+			"::error title=Coldstep new destination domains::%d domain(s) present in current but absent from baseline (P1-2): %s\n",
+			len(added), strings.Join(added, ", "))
+		return fmt.Errorf("diff: %d new destination domain(s) not present in baseline", len(added))
+	}
+	return nil
 }

--- a/cmd/coldstep-action/report_markdown_test.go
+++ b/cmd/coldstep-action/report_markdown_test.go
@@ -61,3 +61,32 @@ func TestStopStrictRequiredTypes(t *testing.T) {
 		t.Fatalf("missing = %v want [exec]", missing)
 	}
 }
+
+func TestRunDiff_NewDomainGate(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GITHUB_WORKSPACE", dir)
+	cur := filepath.Join(dir, "cur.jsonl")
+	base := filepath.Join(dir, "base.jsonl")
+	summary := filepath.Join(dir, "summary.md")
+	if err := os.WriteFile(cur, []byte(`{"type":"tcp","fqdn":"evil.example.com","dst":"1.2.3.4","dport":443}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write cur: %v", err)
+	}
+	if err := os.WriteFile(base, []byte(`{"type":"tcp","fqdn":"github.com","dst":"140.82.112.3","dport":443}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write base: %v", err)
+	}
+
+	// Without the gate: writes marker, returns nil.
+	if err := runDiff([]string{"--current=" + cur, "--baseline=" + base, "--summary=" + summary, "--marker=test-diff"}); err != nil {
+		t.Fatalf("runDiff: %v", err)
+	}
+	raw, _ := os.ReadFile(summary)
+	if !strings.Contains(string(raw), "test-diff.result=changed") || !strings.Contains(string(raw), "test-diff.new_domains=1") {
+		t.Fatalf("summary missing markers:\n%s", raw)
+	}
+
+	// With the gate: new domain (evil.example.com) → error.
+	err := runDiff([]string{"--current=" + cur, "--baseline=" + base, "--summary=" + summary, "--fail-on-new-domain"})
+	if err == nil {
+		t.Fatal("expected fail-on-new-domain error")
+	}
+}

--- a/internal/report/markdown/markdown.go
+++ b/internal/report/markdown/markdown.go
@@ -74,6 +74,11 @@ type Aggregate struct {
 	// integrity gate (replaces the model-based integrity.CheckRequiredTypes).
 	seen map[string]struct{}
 
+	// domains is the set of destination FQDNs / SNIs observed (bare IPs
+	// excluded), for the baseline diff gate (replaces model.BuildDiff's
+	// domain set). Populated from net fqdn + tls sni.
+	domains map[string]struct{}
+
 	// EventsSHA256, when set, is rendered as a plain line (never an HTML
 	// comment) for tamper-evidence.
 	EventsSHA256 string
@@ -135,7 +140,7 @@ type denyLine struct {
 // lines are counted in ParseErrors and skipped — a single bad line never aborts
 // the report (defence-in-depth against a build step appending garbage).
 func Parse(r io.Reader) (*Aggregate, error) {
-	a := &Aggregate{Dests: make(map[string]int), seen: make(map[string]struct{})}
+	a := &Aggregate{Dests: make(map[string]int), seen: make(map[string]struct{}), domains: make(map[string]struct{})}
 	sc := bufio.NewScanner(r)
 	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
 	for sc.Scan() {
@@ -216,6 +221,9 @@ func (a *Aggregate) countDest(line []byte) {
 		return
 	}
 	a.Dests[key]++
+	if n.FQDN != "" && !isBareIPv4(n.FQDN) {
+		a.domains[strings.ToLower(n.FQDN)] = struct{}{}
+	}
 }
 
 type metaLine struct {
@@ -269,6 +277,9 @@ func (a *Aggregate) countTLS(line []byte) {
 	if json.Unmarshal(line, &tl) != nil {
 		return
 	}
+	if tl.SNI != "" && !isBareIPv4(tl.SNI) {
+		a.domains[strings.ToLower(tl.SNI)] = struct{}{}
+	}
 	switch tl.Confidence {
 	case "full":
 		a.TLSFull++
@@ -297,6 +308,57 @@ func (a *Aggregate) countDeny(line []byte) {
 		Reason:     d.Reason,
 		HookFamily: d.HookFamily,
 	})
+}
+
+// Domains returns the sorted set of destination FQDNs / SNIs observed (bare
+// IPs excluded). Used by the baseline diff gate.
+func (a *Aggregate) Domains() []string {
+	out := make([]string, 0, len(a.domains))
+	for d := range a.domains {
+		out = append(out, d)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// DiffDomains returns the destination domains added in current vs baseline and
+// those gone (in baseline, absent from current), each sorted. Replaces the
+// model-based baseline diff; bare IPs are excluded so dial-time IP rotation
+// does not create churn (the P1-2 supply-chain gate keys on `added`).
+func DiffDomains(current, baseline *Aggregate) (added, removed []string) {
+	for d := range current.domains {
+		if _, ok := baseline.domains[d]; !ok {
+			added = append(added, d)
+		}
+	}
+	for d := range baseline.domains {
+		if _, ok := current.domains[d]; !ok {
+			removed = append(removed, d)
+		}
+	}
+	sort.Strings(added)
+	sort.Strings(removed)
+	return added, removed
+}
+
+// isBareIPv4 reports whether host is an IPv4 dotted-quad (four all-digit
+// labels) — such destinations are excluded from the domain diff.
+func isBareIPv4(host string) bool {
+	labels := strings.Split(host, ".")
+	if len(labels) != 4 {
+		return false
+	}
+	for _, l := range labels {
+		if l == "" {
+			return false
+		}
+		for _, r := range l {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // RequiredTypes returns the JSONL event types an integrity-strict run expects.


### PR DESCRIPTION
## What

Ports the `coldstep-report diff` baseline gate into `coldstep-action`, JSONL-direct (no `internal/report/model`). Completes the subcommand fold so Phase 4 can delete `cmd/coldstep-report` + `internal/report/model`.

- `markdown.Aggregate` tracks the destination-domain set (FQDN/SNI; bare IPs excluded). New `Domains()`, `DiffDomains(current, baseline)`, `isBareIPv4`.
- `coldstep-action diff --baseline [--current --summary --marker --fail-on-new-domain]` writes a compact marker block (`result` / `new_domains` / `gone_domains`) to the job summary; `--fail-on-new-domain` exits non-zero when current introduces destination domains absent from baseline (P1-2 supply-chain gate).

Replaces `model.BuildDiff`'s fingerprint counts with the actionable domain-set diff (the part the CI gate keys on). Bare IPs excluded so dial-time IP rotation isn't churn.

## Tests

domain diff added/removed, marker block, fail-on-new-domain non-zero exit. Build/vet/test green on WSL.

After this, both report subcommands the workflows use (`stop --strict`, `diff`) live in coldstep-action → Phase 3 rewrites workflows, Phase 4 deletes the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)