### PR TITLE
feat(action): standalone assert-integrity subcommand (report-elim phase 3a)

### DIFF
--- a/cmd/coldstep-action/main.go
+++ b/cmd/coldstep-action/main.go
@@ -117,6 +117,8 @@ func main() {
 		fatal(runStop(cfg))
 	case "diff":
 		fatal(runDiff(os.Args[2:]))
+	case "assert-integrity":
+		fatal(runAssertIntegrity(os.Args[2:]))
 	default:
 		fatal(fmt.Errorf("unknown command %q", os.Args[1]))
 	}

--- a/cmd/coldstep-action/report_markdown.go
+++ b/cmd/coldstep-action/report_markdown.go
@@ -133,3 +133,34 @@ func runDiff(args []string) error {
 	}
 	return nil
 }
+
+// runAssertIntegrity implements `coldstep-action assert-integrity` — the
+// anti-blindness required-event-type gate as a standalone subcommand (1:1
+// replacement for `coldstep-report assert-integrity`, JSONL-direct, no report
+// model). Exits non-zero when expected event types are absent. The detect
+// profile selects the required set (standard vs enhanced).
+func runAssertIntegrity(args []string) error {
+	fs := flag.NewFlagSet("assert-integrity", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	ws := getenvDefault("GITHUB_WORKSPACE", ".")
+	in := fs.String("in", filepath.Join(ws, ".coldstep-events.jsonl"), "")
+	profile := fs.String("detect-profile", getenvDefault("COLDSTEP_DETECT_PROFILE", ""), "")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	inPath, err := safepath.Workspace(*in, "in")
+	if err != nil {
+		return err
+	}
+	agg, err := parseAggregateFile(inPath)
+	if err != nil {
+		return fmt.Errorf("load events: %w", err)
+	}
+	if missing := agg.MissingRequiredTypes(*profile); len(missing) > 0 {
+		fmt.Fprintf(os.Stderr,
+			"::error title=Coldstep integrity gate::missing required event type(s): %s\n",
+			strings.Join(missing, ", "))
+		return fmt.Errorf("assert-integrity: missing required event type(s): %s", strings.Join(missing, ", "))
+	}
+	return nil
+}

--- a/cmd/coldstep-action/report_markdown_test.go
+++ b/cmd/coldstep-action/report_markdown_test.go
@@ -90,3 +90,23 @@ func TestRunDiff_NewDomainGate(t *testing.T) {
 		t.Fatal("expected fail-on-new-domain error")
 	}
 }
+
+func TestRunAssertIntegrity(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GITHUB_WORKSPACE", dir)
+	in := filepath.Join(dir, ".coldstep-events.jsonl")
+	// meta+tcp but no exec → standard profile fails.
+	if err := os.WriteFile(in, []byte(`{"type":"meta"}`+"\n"+`{"type":"tcp"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := runAssertIntegrity([]string{"--in=" + in}); err == nil {
+		t.Fatal("expected failure on missing exec")
+	}
+	// add exec → passes.
+	if err := os.WriteFile(in, []byte(`{"type":"meta"}`+"\n"+`{"type":"tcp"}`+"\n"+`{"type":"exec"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := runAssertIntegrity([]string{"--in=" + in}); err != nil {
+		t.Fatalf("expected pass, got %v", err)
+	}
+}


### PR DESCRIPTION
Adds `coldstep-action assert-integrity [--in --detect-profile]` — the anti-blindness required-event-type gate as a standalone subcommand, a 1:1 JSONL-direct replacement for `coldstep-report assert-integrity` (no report model). Non-zero exit + `::error` annotation when expected event types are absent; detect profile selects the required set.

**Go-only, no workflow change** — deliberately isolates this from the gating-CI workflow rewrite (3b) so a bad YAML edit can't ride in. Complements `stop --strict` (action-native) with a step-friendly form for `uses: ./` workflows.

Test: fails on missing exec (standard), passes once present. Build/test green on WSL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)