### PR TITLE
chore(ci): move coldstep-demo off coldstep-report (report-elim phase 4a)

### DIFF
--- a/.github/workflows/coldstep-demo.yml
+++ b/.github/workflows/coldstep-demo.yml
@@ -81,8 +81,8 @@ jobs:
           mv bin/coldstep-linux-amd64 bin/coldstep
           chmod +x bin/coldstep
 
-      - name: Build coldstep-report (Go only; agent from release)
-        run: bash scripts/build-coldstep-report-linux.sh "${GITHUB_WORKSPACE}"
+      - name: Build coldstep-action (Go only; agent from release)
+        run: go build -trimpath -ldflags="-s -w" -o bin/coldstep-action ./cmd/coldstep-action
 
       - name: Coldstep (detect mode)
         uses: ./
@@ -276,8 +276,8 @@ jobs:
             fail_diff_unavailable "downloaded artifact missing .coldstep-events.jsonl"
           fi
 
-          if ! ./bin/coldstep-report diff --summary "${summary}" --baseline "${baseline_file}" --current "${current_file}" --marker "${marker_prefix}"; then
-            fail_diff_unavailable "coldstep-report diff failed"
+          if ! ./bin/coldstep-action diff --summary "${summary}" --baseline "${baseline_file}" --current "${current_file}" --marker "${marker_prefix}"; then
+            fail_diff_unavailable "coldstep-action diff failed"
           fi
 
       - name: Persist detect JSONL baseline artifact
@@ -290,58 +290,19 @@ jobs:
           include-hidden-files: true
           overwrite: true
 
-      # Issue #219 consumer pattern demo: download coldstep-report-linux-amd64 from the same Release that
-      # publishes the agent, render an HTML report from the JSONL, upload it as a clickable artifact.
-      # Fail-soft on the download because the asset only exists for tags from v0.4.1 onward; once
-      # COLDSTEP_AGENT_VERSION points at a tag with the asset, the subsequent build-model + render-html
-      # steps activate. Until then, the warning is the only signal.
-      - name: Download coldstep-report binary from GitHub Release
+      # Detailed report: the pure-markdown .coldstep-report.md is written by the
+      # action's stop step (coldstep-action). Upload it as the downloadable
+      # detect-report artifact. (Replaces the retired coldstep-report HTML render
+      # / coldstep-report-linux-amd64 release-binary consumer demo, issue #219.)
+      - name: Upload detect markdown report
         if: always()
-        id: download-coldstep-report
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          mkdir -p bin-release
-          for attempt in 1 2 3; do
-            if gh release download "${COLDSTEP_AGENT_VERSION}" \
-              --repo "${GITHUB_REPOSITORY}" \
-              --pattern 'coldstep-report-linux-amd64' \
-              --dir bin-release; then
-              break
-            fi
-            if [[ "${attempt}" -eq 3 ]]; then
-              echo "::warning title=coldstep-report binary missing::coldstep-report-linux-amd64 not present on release ${COLDSTEP_AGENT_VERSION} (issue #219 ships this from v0.4.1 onward)"
-              exit 0
-            fi
-            sleep $((attempt * 5))
-          done
-          if [[ -f bin-release/coldstep-report-linux-amd64 ]]; then
-            chmod +x bin-release/coldstep-report-linux-amd64
-            echo "available=true" >> "${GITHUB_OUTPUT}"
-          fi
-
-      - name: Render HTML report from JSONL
-        if: always() && steps.download-coldstep-report.outputs.available == 'true'
-        env:
-          COLDSTEP_REPORT_CURRENT_JSONL: ${{ github.workspace }}/.coldstep-events.jsonl
-          COLDSTEP_REPORT_MODEL_OUT: ${{ github.workspace }}/.coldstep-report-model.json
-          COLDSTEP_DETECT_PROFILE: enhanced
-        run: |
-          set -euo pipefail
-          ./bin-release/coldstep-report-linux-amd64 build-model
-          COLDSTEP_REPORT_MODEL_IN="${GITHUB_WORKSPACE}/.coldstep-report-model.json" \
-          COLDSTEP_REPORT_HTML_OUT="${GITHUB_WORKSPACE}/coldstep-detect-report.html" \
-            ./bin-release/coldstep-report-linux-amd64 render-html
-
-      - name: Upload detect HTML report
-        if: always() && steps.download-coldstep-report.outputs.available == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: coldstep-detect-html-report
-          path: ${{ github.workspace }}/coldstep-detect-report.html
+          name: coldstep-detect-report-md
+          path: ${{ github.workspace }}/.coldstep-report.md
           retention-days: 14
+          include-hidden-files: true
+          if-no-files-found: warn
           if-no-files-found: warn
 
       - name: List workspace Coldstep artifacts
@@ -385,9 +346,6 @@ jobs:
           done
           mv bin/coldstep-linux-amd64 bin/coldstep
           chmod +x bin/coldstep
-
-      - name: Build coldstep-report (Go only; agent from release)
-        run: bash scripts/build-coldstep-report-linux.sh "${GITHUB_WORKSPACE}"
 
       # apt and stub-resolver DNS must run before defend: cgroup deny breaks 127.0.0.53:53 and unrelated UDP.
       - name: Install runtime probes (before defend so mirrors/DNS still work)


### PR DESCRIPTION
Last workflow consuming `coldstep-report`. Detect job: build `coldstep-action` (pure Go); baseline diff via `coldstep-action diff`; replace the issue-#219 release-binary download + `render-html` + HTML artifact with an upload of the pure-markdown `.coldstep-report.md`. Defend job: drop the now-unused build step.

**No workflow now invokes `coldstep-report`.** Phase 4b deletes the binary, `internal/report/{model,integrity}`, `scripts/build-coldstep-report-linux.sh`, and the build-agent-linux report build. YAML parses clean (demo runs on demo triggers, not PR ci-runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)