### PR TITLE
feat(action): job summary from markdown RenderSimple, not agent digest (4c-1)

### DIFF
--- a/cmd/coldstep-action/main.go
+++ b/cmd/coldstep-action/main.go
@@ -440,9 +440,17 @@ func runStop(cfg stopConfig) error {
 	reportJobSummary, reportPRSummary := parseReportFlags(cfg.Report)
 
 	if reportJobSummary {
-		if summaryPath := strings.TrimSpace(os.Getenv("GITHUB_STEP_SUMMARY")); summaryPath != "" && strings.TrimSpace(body) != "" {
-			safe := sanitizeDigestForMarkdown(body)
-			block := "## Coldstep - digest (exec / network / defend)\n\n" + safe
+		// Job summary now comes from the pure-markdown generator's simple report
+		// (rendered from the JSONL source of truth), not the agent's
+		// .coldstep-detect.md digest. Fall back to the legacy digest body only
+		// when no event stream was parsed (e.g. agent never started).
+		block := ""
+		if reportAgg != nil {
+			block = reportAgg.RenderSimple()
+		} else if strings.TrimSpace(body) != "" {
+			block = "## Coldstep - digest (exec / network / defend)\n\n" + sanitizeDigestForMarkdown(body)
+		}
+		if summaryPath := strings.TrimSpace(os.Getenv("GITHUB_STEP_SUMMARY")); summaryPath != "" && strings.TrimSpace(block) != "" {
 			if !strings.HasSuffix(block, "\n") {
 				block += "\n"
 			}


### PR DESCRIPTION
`coldstep-action stop` now writes the pure-markdown simple report (`reportAgg.RenderSimple()`, from the JSONL source of truth) to `$GITHUB_STEP_SUMMARY` instead of merging the agent's `.coldstep-detect.md`. Falls back to the legacy digest body only when no event stream was parsed.

Decouples the job summary from the agent's digest path so **4c-2** can delete `internal/report/digest*.go` + the agent's digest-building / detect.md writes — the report-elim goal: privileged agent writes data only, userspace renders.

Build/test/vet green on WSL. detect-mode run validates the summary path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)