### PR TITLE
docs: reflect coldstep-report removal — two binaries, markdown report (phase 5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,10 @@ The config enum (`internal/config/config.go`) uses `ModeDefend` with the underly
 
 ## Build and dev commands
 
-**Build the agent + action + reporter (Linux only).** `scripts/build-agent-linux.sh` is the single source of truth — it installs clang/llvm/libbpf-dev, dumps BTF to `bpf/vmlinux.h` if missing, runs `go generate` for every `internal/bpf/<probe>` package, and `go build`s three binaries into `bin/`:
+**Build the agent + action helper (Linux only).** `scripts/build-agent-linux.sh` is the single source of truth — it installs clang/llvm/libbpf-dev, dumps BTF to `bpf/vmlinux.h` if missing, runs `go generate` for every `internal/bpf/<probe>` package, and `go build`s two binaries into `bin/`:
 
 ```bash
-bash scripts/build-agent-linux.sh "$PWD"    # bin/coldstep, bin/coldstep-action, bin/coldstep-report
+bash scripts/build-agent-linux.sh "$PWD"    # bin/coldstep, bin/coldstep-action
 ```
 
 `bpf/vmlinux.h` and `internal/bpf/**/*_bpfel.go` / `*_bpfeb.go` are **gitignored generated artifacts** — never commit them.
@@ -65,11 +65,10 @@ Set `COLDSTEP_VERIFY_MODE=quick|deep|fast` to switch the wrapper (default `deep`
 
 ## Architecture
 
-### Three Go binaries, one composite action
+### Two Go binaries, one composite action
 
 - **`cmd/coldstep`** (`bin/coldstep run`) — privileged BPF agent. `main` is one line: dispatch to `internal/agent.Main`. Linux-only build (`agent_linux.go`); a non-Linux stub returns an error so the binary still compiles cross-platform.
-- **`cmd/coldstep-action`** (`bin/coldstep-action start|stop`) — the action's runtime helper. `start` parses inputs from flags / `INPUT_*` env, sanitizes allowlists, computes effective config, and spawns `bin/coldstep run` as a `sudo` child. `stop` flushes the digest, optionally merges it into `$GITHUB_STEP_SUMMARY`, and optionally posts a PR comment via the GitHub REST API (bounded by `httpNotifyClient`'s 60s timeout — do not remove).
-- **`cmd/coldstep-report`** — post-run report pipeline invoked by demo workflows: `build-model`, `assert-integrity`, `render-summary`, `render-html`, `diff`, `render-ip-summary`. Reads `.coldstep-events.jsonl`, produces a normalized model under `internal/report/model`, then renders.
+- **`cmd/coldstep-action`** (`bin/coldstep-action start|stop|diff|assert-integrity`) — the action's runtime helper. `start` parses inputs from flags / `INPUT_*` env, sanitizes allowlists, computes effective config, and spawns `bin/coldstep run` as a `sudo` child. `stop` renders the pure-markdown report from `.coldstep-events.jsonl` (`internal/report/markdown`): the simple report into `$GITHUB_STEP_SUMMARY` and the detailed report into `.coldstep-report.md`, optionally posts a PR comment via the GitHub REST API (bounded by `httpNotifyClient`'s 60s timeout — do not remove), and with `--strict` enforces the required-event-type anti-blindness gate. `diff` is the JSONL-direct baseline destination-domain gate (`--fail-on-new-domain`); `assert-integrity` is the standalone required-types gate. The separate `coldstep-report` binary + the model/integrity/HTML pipeline were removed — reporting is now one pure-markdown path in userspace.
 
 ### Composite lifecycle (`action.yml`)
 
@@ -90,7 +89,7 @@ Seven BPF probe packages under `internal/bpf/`, each compiled by `go generate`:
 
 Shared C headers live in `bpf/` (notably `coldstep_pure.h`, `deny_event.h`, `defend_policy.inc`, `defend_lpm_key.h`, `trace_connect_obs.h`, `trace_*_obs.inc`, `trace_tls_write.inc`). Defend hooks come from one combined source `trace_defend_all.bpf.c`, which includes `trace_defend_cgroup.inc` (cgroup `connect4`/`sendmsg4` plus `connect6`/`sendmsg6`) and `trace_lsm_defend_lsm.inc` (BPF LSM `socket_connect`/`socket_sendmsg`), plus `trace_lsm_bpf_self_defense.inc` (BPF LSM `bpf` — sub-project B self-defense). The self-defense hook denies `BPF_PROG_GET_FD_BY_ID` / `BPF_MAP_GET_FD_BY_ID` / `BPF_OBJ_GET` that target coldstep's **own** object ids (recorded into `self_prog_ids`/`self_map_ids` by `armBpfSelfDefense` at startup) by a non-agent task, blocking a CAP_BPF attacker from grabbing a handle to detach the monitor; it is armed (`self_defense_cfg.enabled=1`) only after the id sets are populated, the agent's own tgid is exempt, and it emits a `bpf_self_defense` JSONL row + digest KPI on each denial. Like every LSM hook here it only **enforces** where `bpf` is in the kernel boot `lsm=` chain (`/sys/kernel/security/lsm`) — GH hosted runners boot without it, so the hook attaches but stays silent there; the deny integration test gates on that and skips otherwise. The cgroup section enforces **IPv4, IPv4-mapped IPv6, and native IPv6**: the `connect6`/`sendmsg6` hooks (`defend_cgroup_sock_addr_ipv6`, `bpf/trace_defend_cgroup.inc:296-339`, H14, v0.4.0) gate v4-mapped destinations against the IPv4 allowlist and native IPv6 against the `allowed_ipv6` LPM trie, with `::1` (loopback) and `fe80::/10` (link-local) always bypassing. The **LSM section remains IPv4-only** — do not promise IPv6 for the LSM path. The Go-side loader `defend.LoadDefendObjectsForKernel` strips the LSM section from the spec on kernels without CONFIG_BPF_LSM so prog_load doesn't fail.
 
-The agent's Linux entry (`internal/agent/agent_linux.go`) loads each program in a fixed order, captures BPF status into `telemetry.BPFStatus` rows used by the digest, and drains ringbufs through `agent_linux_ring_read.go`. Feature gates `proc_tree`, `tls_sni`, `fs_events` (parsed in `internal/config/featuregates.go`) toggle optional event streams; `COLDSTEP_DETECT_PROFILE=enhanced` flips defaults on if a key is unset. Set the same profile env on the post-run `coldstep-report build-model` step so integrity scoring matches.
+The agent's Linux entry (`internal/agent/agent_linux.go`) loads each program in a fixed order, captures BPF status into `telemetry.BPFStatus` rows used by the digest, and drains ringbufs through `agent_linux_ring_read.go`. Feature gates `proc_tree`, `tls_sni`, `fs_events` (parsed in `internal/config/featuregates.go`) toggle optional event streams; `COLDSTEP_DETECT_PROFILE=enhanced` flips defaults on if a key is unset. Set the same profile env on the post-run `coldstep-action stop --strict` / `assert-integrity` step so the required-event-type gate matches.
 
 **QUIC / HTTP3 visibility note (P2-2).** QUIC payloads are encrypted at the transport layer and cannot be inspected by the BPF probes, so coldstep treats UDP/443 egress to non-loopback IPv4 as a *likely* QUIC/HTTP3 flow and emits a synthetic `quic_candidate` JSONL line alongside the underlying `udp` event (see `IsQUICCandidate` in `internal/agent/quic_candidate.go` and the `QUIC (port-443 UDP)` KPI row in the digest). This is a userspace heuristic — no BPF/clang work involved — and surfaces the visibility gap explicitly rather than letting QUIC traffic look like silent UDP.
 
@@ -104,9 +103,9 @@ The agent's Linux entry (`internal/agent/agent_linux.go`) loads each program in 
 
 `internal/policy/allowlist.go` resolves the effective IPv4 set. DNS lookups are bounded (`coldstepDomainLookupConcurrencyLimit = 32`, 25s per lookup) and warn when a single domain resolves to >10 IPv4s — warn-only, do not change effective allowlist on that path without updating the comments.
 
-### Report model + integrity gates
+### Report generator + integrity gate
 
-`internal/report/model/` defines the on-disk JSON model that `coldstep-report build-model` produces from JSONL. `internal/report/integrity/` scores it: `RequiredTypesForDetectProfile("enhanced")` expands required event types from `{meta, exec, tcp}` to `{meta, exec, tcp, udp, http, tls, proc_fork, fs_event}`. Detect workflows in CI run `assert-integrity` as an anti-blindness gate.
+`internal/report/markdown/` reads `.coldstep-events.jsonl` (and the shutdown `meta` event for BPF health) and renders both reports as pure Markdown — `RenderSimple` (job summary) + `RenderDetailed` (`.coldstep-report.md` artifact); a regex-guard test forbids any embedded HTML. `markdown.RequiredTypes("enhanced")` expands required event types from `{meta, exec, tcp}` to `{meta, exec, tcp, udp, http, tls, proc_fork, fs_event}`; `coldstep-action assert-integrity` / `stop --strict` enforces them as the anti-blindness gate (replaces the removed `internal/report/{model,integrity}` + `coldstep-report assert-integrity`). The agent still writes its own `.coldstep-detect.md` digest (`internal/report/digest*.go`) but it is no longer the report source — a follow-up removes that path so the agent writes data only.
 
 ### Artifacts written to `$GITHUB_WORKSPACE`
 

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -26,32 +26,29 @@ Recommended workflow:
 1. **Collect ≥ 3 builds.** Run detect across at least three different PRs or branches (preferably touching different parts of the codebase). One short run on one branch is the easiest poisoning target.
 2. **Diff against a baseline.** Before promoting domains to `allow:`, compare the new JSONL against a known-good baseline:
    ```bash
-   coldstep-report diff \
+   coldstep-action diff \
      --baseline baseline.jsonl \
      --current  .coldstep-events.jsonl \
      --summary  diff-summary.md \
      --fail-on-new-domain
    ```
-   `--fail-on-new-domain` exits non-zero when any FQDN appears in the current run but not the baseline. Wire it into CI on PRs that touch `.github/coldstep/egress-allow.txt`.
-3. **Reject short windows.** Use `coldstep-report build-model --min-observation-hours 24` (or set `COLDSTEP_MIN_OBS_HOURS=24`) so a run that observed less than 24 hours of wall-clock traffic flags `short_observation_window=true` in the model — `coldstep-report assert-integrity` then hard-fails. Tune the threshold to whatever observation period your team actually trusts.
-4. **Require a second-engineer review.** Newly observed domains in the diff output get a separate human approval before they land in the `allow:` list. Treat the diff as a code review, not as an automated step that closes itself.
+   `--fail-on-new-domain` exits non-zero when any destination FQDN appears in the current run but not the baseline. Wire it into CI on PRs that touch `.github/coldstep/egress-allow.txt`.
+3. **Require a second-engineer review.** Newly observed domains in the diff output get a separate human approval before they land in the `allow:` list. Treat the diff as a code review, not as an automated step that closes itself.
 
-`build-model` additionally flags **suspicious domains** in the report model (`suspicious_domains` field): high-entropy subdomains (Shannon entropy > 3.5 bits/char on labels longer than 8 chars), domains observed only once across the entire run, and HTTP/TLS observations on non-standard ports. `render-summary` surfaces a `[!WARNING]` block when any are present so reviewers see them before approving the diff.
+> **Note (report pipeline change):** the older `coldstep-report build-model` model — including the `suspicious_domains` / `risk_hint` heuristics (high-entropy/DGA labels, single-observation, port anomalies) and the `--min-observation-hours` window gate — was removed when reporting was consolidated into a single pure-markdown path. The surviving programmatic gates are `coldstep-action diff --fail-on-new-domain` (baseline new-domain) and `coldstep-action assert-integrity` (required event types). The manual-review discipline below still applies; the entropy/window heuristics are a candidate to reintroduce in the markdown generator if needed.
 
-### Building a safe allowlist (H17 learning-mode poisoning protections)
+### Building a safe allowlist (manual review discipline)
 
-Even with the workflow above, **two specific shapes of destination warrant manual review** before they land in `allow:` — and `coldstep-report` now tags them on each flagged entry via `suspicious_domains[].risk_hint`:
+The baseline diff catches **new** domains, but a human should still review newly observed destinations before promoting them to `allow:`. Two shapes warrant extra scrutiny:
 
-| `risk_hint` | What it means | Why to review by hand |
-| :----------- | :------------- | :-------------------- |
-| **`suspicious-dga`** | The leftmost DNS label is ≥ 12 chars of high-entropy text (Shannon ≥ 3.5 bits/char) **or** a 16+-char lowercase hex string (DGA / hash-style). | DGA-shaped labels are characteristic of malware C2 and ephemeral exfil endpoints. Even one observation is enough to want a human to confirm whether the host is a legitimate object-store / CDN URL or attacker infrastructure. |
-| **`single-observation`** | The domain was seen exactly once across the entire JSONL stream (`observation_count == 1`). | Attackers who briefly poisoned a learning run leave exactly this fingerprint. Compare against a longer-window baseline before promoting. |
+- **DGA-shaped hosts** — a leftmost label that is long, high-entropy, or hash-like is characteristic of malware C2 / ephemeral exfil. Confirm it is a legitimate object-store / CDN URL.
+- **Single-observation domains** — a host seen exactly once is the fingerprint of a briefly-poisoned learning run. Compare against a longer-window baseline before promoting.
 
-`assert-integrity` does **not** fail on either hint — it emits a `::warning title=Coldstep learning-mode reviewer hints (H17)::…` annotation listing each flagged entry so reviewers see them in the GitHub Actions UI. The hard gates are still `--min-observation-hours` and `diff --fail-on-new-domain`. Recommended bar before promoting any new domain:
+Recommended bar before promoting any new domain:
 
-- **≥ 24h observation window** (`coldstep-report build-model --min-observation-hours 24`). Shorter windows are inherently easier to poison.
-- **Baseline diff with `--fail-on-new-domain`** on the PR that edits `allow:` / `allow-file`. This is the only step that catches a domain a single human reviewer might wave through.
-- **Manual review of every `risk_hint` entry.** `suspicious-dga` and `single-observation` rows are reviewer-driven by design — there is no automated way to tell good ephemeral URLs from bad ones.
+- **Baseline diff with `--fail-on-new-domain`** on the PR that edits `allow:` / `allow-file` — the one step that catches a domain a single reviewer might wave through.
+- **Collect several builds** across different PRs before trusting the observed set; one short run on one branch is the easiest poisoning target.
+- **Manual review of DGA-shaped / single-observation hosts** — reviewer-driven by design.
 
 ---
 
@@ -209,17 +206,14 @@ For large allowlists, keep **UTF-8 text files** in the repository and pass **com
 
 ## Where to look after a run
 
-- **Summary tab:** digest from `.coldstep-detect.md` (when enabled).
-- **Workspace:** `.coldstep-events.jsonl`, `.coldstep-telemetry.json`.
+- **Summary tab:** the pure-markdown simple report (written by the action's stop step from `.coldstep-events.jsonl`).
+- **Workspace:** `.coldstep-events.jsonl`, `.coldstep-telemetry.json`, and `.coldstep-report.md` (detailed markdown report, uploaded as an artifact by the demo/CI workflows).
 
 Start with default **detect**, then set **`detect-profile: enhanced`** when you need `proc_tree` / `tls_sni` / `fs_events` streams.
 
-### Report pipelines (maintainers)
+### Report pipeline (maintainers)
 
-| Workflow | Summary surface | Artifact notes |
-| -------- | ---------------- | -------------- |
-| **`coldstep-demo-detect.yml`** | Tier-1 BLUF (`coldstep-report render-summary`) | Tier-2 **`coldstep-detect-report.html`** artifact |
-| **`coldstep-detect-demo-dev.yml`** | Tier-1 BLUF + IP classification markdown | JSONL baseline + same Tier-2 **`coldstep-detect-report-html-<runner>`** artifact as **`coldstep-demo-detect`** |
+Reporting is one pure-markdown path in `coldstep-action` (no separate `coldstep-report` binary, no HTML): `stop` renders the simple report to the Job Summary and the detailed report to `.coldstep-report.md`; `diff` and `assert-integrity` are the baseline / anti-blindness gates. Demo/CI workflows upload `.coldstep-report.md` as the downloadable artifact.
 
 Consumers copying **`QUICK_START`** alone only need the default digest + JSONL unless they opt into maintainer workflows.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ### Runtime
 
-Using Coldstep in **your** workflow does **not** require **Python** or **`pip install`** — the composite runs **Go** binaries (`bin/coldstep-action`, `bin/coldstep`, `bin/coldstep-report` after build). Your job may still run **`pip install`**, **`npm ci`**, or any other tooling for **other** steps; Coldstep does **not** restrict that.
+Using Coldstep in **your** workflow does **not** require **Python** or **`pip install`** — the composite runs **Go** binaries (`bin/coldstep-action`, `bin/coldstep` after build). Your job may still run **`pip install`**, **`npm ci`**, or any other tooling for **other** steps; Coldstep does **not** restrict that.
 
 ---
 
@@ -63,7 +63,7 @@ The single `uses:` block is enough — node24 pre/post hooks start the agent bef
 | **Runner OS** | **Linux only** for the agent. **v1 supports `ubuntu-latest` only** (GitHub-hosted Ubuntu x64). Not supported on macOS, Windows, self-hosted, or other `runs-on` labels until explicitly documented in a later release. |
 | **Build on runner** | The action runs [`scripts/build-agent-linux.sh`](scripts/build-agent-linux.sh) (clang, libbpf, **bpftool** against `/sys/kernel/btf/vmlinux` → `bpf/vmlinux.h`, `go generate` / bpf2go, then **`go build`** → **`bin/coldstep`**). |
 | **Privileges** | The agent runs under **`sudo`** to load BPF. |
-| **Action runtime** | Composite action is shell + Go binaries (`bin/coldstep-action`, `bin/coldstep-report`) and no longer requires Node.js runtime hooks. |
+| **Action runtime** | Composite action is shell + Go binaries (`bin/coldstep`, `bin/coldstep-action`); the node24 `pre`/`post` hooks start/stop the agent. |
 
 For **GitHub Actions security posture** — threat model for a workflow job, consumer mitigations (pins, permissions), residual risk, and honest telemetry scope — see **[SECURITY.md](SECURITY.md)** (*GitHub Actions: threat model and mitigations*). For **guaranteed vs best-effort behavior** (telemetry gaps, hook coverage), see **[Guarantees vs best-effort](SECURITY.md#guarantees-vs-best-effort-defend-and-detect)**. Maintainers may keep deeper **egress truthfulness** specs under local **`design/`** (gitignored); consumers should rely on **SECURITY.md** and **README**.
 
@@ -100,8 +100,7 @@ Same **`detect`** / **`defend`** meanings as **[At a glance](#at-a-glance)**. Th
 
 The **post** step merges **`.coldstep-detect.md`** into the **Actions Summary** tab by default (`report: job-summary`). Full **detect-report** workflows set **`report: none`** so the Summary is not dominated by the long shutdown digest:
 
-- **`coldstep-demo-detect.yml`** (`uses: ./`): builds the full **`report-model.json`** (`coldstep-report build-model`), writes Tier-1 BLUF and Tier-2 **`coldstep-detect-report.html`** (downloadable artifact).
-- **`coldstep-detect-demo-dev.yml`** (runs on **`push` to `dev`** and **`workflow_dispatch`**): same `coldstep-report build-model` pipeline as **`coldstep-demo-detect.yml`** (baseline diff rebuild when available, Tier-1 BLUF, Tier-2 **`coldstep-detect-report.html`** artifact **`coldstep-detect-report-html-<runner>`**), then appends the IP/FQDN matrix to the Job Summary.
+- **`coldstep-demo.yml`** (`uses: ./`): runs detect, then `coldstep-action diff` (baseline destination-domain delta) and uploads the pure-markdown **`.coldstep-report.md`** artifact. The simple report lands in the Job Summary via the action's stop step.
 
 Paths can be overridden with env vars such as `COLDSTEP_EVENTS_LOG`, `COLDSTEP_DETECT_LOG`, `COLDSTEP_TELEMETRY_JSON`. For cgroup BPF attach, **`COLDSTEP_CGROUP_PATH`** overrides the directory passed to **`link.AttachCgroup`** (default: cgroup v2 path from **`/proc/self/cgroup`**, else **`/sys/fs/cgroup`**).
 
@@ -130,7 +129,7 @@ Full list and defaults: **[`action.yml`](action.yml)**. Frequently used:
 | `mode` | **`detect`** or **`defend`** (blocking). **`enforce`** is rejected. |
 | `allow` / `allow-file` | Unified egress allowlist (**required** for **defend** / blocking). Accepts plain domains, `*.example.com` wildcards (**detect only** — rejected at parse time in `defend`), IPv4 literals/CIDRs, and `!CIDR` ignore entries. |
 | `fail-on-error` | Fail if the agent never reaches **operational** readiness (BPF/load), not for policy "violations" alone. Defaults to **`true`** in defend mode. |
-| `detect-profile` | **`detect` only:** `standard` (default) or **`enhanced`** — enhanced enables `proc_tree` / `tls_sni` / `fs_events` and sets `COLDSTEP_DETECT_PROFILE` for stricter **report-model** integrity (set the same `COLDSTEP_DETECT_PROFILE` on `coldstep-report build-model`). |
+| `detect-profile` | **`detect` only:** `standard` (default) or **`enhanced`** — enhanced enables `proc_tree` / `tls_sni` / `fs_events` and sets `COLDSTEP_DETECT_PROFILE` for a stricter required-event-type gate (set the same `COLDSTEP_DETECT_PROFILE` on `coldstep-action assert-integrity`). |
 | `report` | `job-summary` (default), `pr-comment`, `both`, or `none` — where to post the detect digest. |
 | `no-default-ignored-nets` | Drop the implicit 10.0.0.0/8 + 172.16.0.0/12 ignores. Add your own ignores as `!CIDR` entries in `allow` / `allow-file`. |
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -61,7 +61,7 @@ If **Upload Linux agent** hits **immutable Release** / **HTTP 422**, the workflo
 
 ## 5. Confirm GitHub Release
 
-- **Releases → `vX.Y.Z`** should list **`coldstep-linux-amd64`** (when upload succeeded) and, from **v0.4.1** onward, **`coldstep-report-linux-amd64`** (issue **#219** — consumer report CLI). The agent asset is the hard requirement; the report asset is best-effort under immutable-release rejection (see workflow logs for `::warning title=Missing coldstep-report-linux-amd64`).
+- **Releases → `vX.Y.Z`** should list **`coldstep-linux-amd64`** (when upload succeeded) — the only published binary asset. The **`coldstep-report-linux-amd64`** asset (issue **#219**) was **retired** when the report binary was folded into `coldstep-action`; already-published assets on prior tags remain (immutable) but new tags no longer ship it.
 - Optional notes: paste the **`CHANGELOG.md`** section for that version.
 - For a **pre-release** (soak / validation first): on the Release, check **Set as pre-release**; clear it when promoting to **Latest**.
 
@@ -72,7 +72,6 @@ If **Upload Linux agent** hits **immutable Release** / **HTTP 422**, the workflo
 ## 7. Consumer sanity check
 
 - `gh release download vX.Y.Z --repo coldstep-io/coldstep --pattern 'coldstep-linux-amd64' --dir /tmp`
-- From **v0.4.1** onward also verify the report binary is present: `gh release download vX.Y.Z --repo coldstep-io/coldstep --pattern 'coldstep-report-linux-amd64' --dir /tmp` (issue **#219**).
 - Demo workflows use **`gh release download "${COLDSTEP_AGENT_VERSION}"`** — version **must match** the tag that has the asset.
 
 ---


### PR DESCRIPTION
Brings docs to match shipped reality after the `coldstep-report` binary + model/integrity/HTML pipeline were deleted (report-elim 4b); reporting is one pure-markdown path in `coldstep-action`.

- **CLAUDE.md**: three→two binaries; coldstep-action documents `start|stop|diff|assert-integrity` + markdown report; report-model section → markdown generator + assert-integrity gate.
- **README**: runtime/binary lines drop coldstep-report; demo + detect-profile rows updated.
- **QUICK_START**: advanced drift section uses `coldstep-action diff`; report pipeline = single markdown path; `.coldstep-report.md` in 'where to look'.
- **RELEASE_PROCESS**: `coldstep-report-linux-amd64` retired (prior tags' assets immutable; new tags ship only the agent).

**Honest capability note:** consolidating to markdown dropped the old `build-model` heuristics — `suspicious_domains`/`risk_hint` (DGA/high-entropy/single-observation) and `--min-observation-hours`. Surviving gates: `diff --fail-on-new-domain` + `assert-integrity`. QUICK_START documents the loss + keeps manual-review discipline; reintroducing the heuristics in the markdown generator is a candidate follow-up. Encoding scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)