### PR TITLE
fix(report): sanitize markdown report table cells (injection regression)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,10 +45,10 @@ inputs:
 
   detect-profile:
     description: >-
-      Detect mode only: standard (default) or enhanced. Enhanced merges default feature gates
-      (proc_tree=1, tls_sni=1, fs_events=1) when each key is unset in feature-gates,
-      and sets COLDSTEP_DETECT_PROFILE for the agent. Use the same value when running
-      coldstep-report build-model (COLDSTEP_DETECT_PROFILE) so integrity scoring matches the run.
+      Detect mode only: standard (default) or enhanced. Enhanced enables the
+      proc_tree / tls_sni / fs_events streams and sets COLDSTEP_DETECT_PROFILE for
+      the agent. Use the same value when running coldstep-action assert-integrity
+      (or stop --strict) so the required-event-type gate matches the run.
     required: false
     default: standard
 

--- a/cmd/coldstep-action/main.go
+++ b/cmd/coldstep-action/main.go
@@ -467,10 +467,11 @@ func runStop(cfg stopConfig) error {
 			}
 		}
 	}
-	// Intentionally keep .coldstep-detect.md on disk: it is the agent's primary
-	// digest artifact and several workflows (`Verify detect capabilities`,
-	// `List workspace outputs`, `coldstep-report build-model`, etc.) read it
-	// after Stop. The runner is ephemeral, so cleanup is not needed.
+	// Keep .coldstep-detect.md on disk: the agent still writes it and some
+	// workflows list/read it after Stop. It is no longer the report source
+	// (the markdown generator renders from .coldstep-events.jsonl); a follow-up
+	// removes the agent digest path entirely. The runner is ephemeral, so no
+	// cleanup is needed.
 
 	if reportPRSummary && strings.TrimSpace(body) != "" {
 		token := strings.TrimSpace(cfg.GithubToken)

--- a/internal/report/markdown/markdown.go
+++ b/internal/report/markdown/markdown.go
@@ -455,7 +455,7 @@ func (a *Aggregate) RenderSimple() string {
 	if top := a.topDests(3); len(top) > 0 {
 		parts := make([]string, len(top))
 		for i, d := range top {
-			parts[i] = fmt.Sprintf("%s (%d)", d.name, d.count)
+			parts[i] = fmt.Sprintf("%s (%d)", mdCell(d.name), d.count)
 		}
 		fmt.Fprintf(&b, "\nTop destinations: %s\n", strings.Join(parts, " · "))
 	}
@@ -470,7 +470,7 @@ func (a *Aggregate) RenderDetailed() string {
 	fmt.Fprintf(&b, "\n## Verdict\n\n%s · mode %s · %d events\n", a.verdict(), a.modeLabel(), a.TotalEvents)
 	if a.MetaSeen {
 		fmt.Fprintf(&b, "\nagent %s · kernel %s · profile %s · allowlist %d IP(s) / %d entr(ies)\n",
-			dashIfEmpty(a.AgentVersion), dashIfEmpty(a.KernelRelease), dashIfEmpty(a.DetectProfile),
+			mdCell(dashIfEmpty(a.AgentVersion)), mdCell(dashIfEmpty(a.KernelRelease)), mdCell(dashIfEmpty(a.DetectProfile)),
 			a.AllowlistIPs, a.AllowlistEntries)
 	}
 	if a.RunnerEnv == "dind" {
@@ -494,7 +494,7 @@ func (a *Aggregate) RenderDetailed() string {
 		fmt.Fprintln(&b, "\n| destination | egress events |")
 		fmt.Fprintln(&b, "|---|---|")
 		for _, d := range a.topDests(100) {
-			fmt.Fprintf(&b, "| %s | %d |\n", d.name, d.count)
+			fmt.Fprintf(&b, "| %s | %d |\n", mdCell(d.name), d.count)
 		}
 	}
 
@@ -506,7 +506,7 @@ func (a *Aggregate) RenderDetailed() string {
 		fmt.Fprintln(&b, "|---|---|---|---|---|---|")
 		for _, d := range a.Denies {
 			fmt.Fprintf(&b, "| %s | %s | %s | %d | %s | %s |\n",
-				d.Comm, d.Protocol, d.Dst, d.Dport, d.Reason, dashIfEmpty(d.HookFamily))
+				mdCell(d.Comm), mdCell(d.Protocol), mdCell(d.Dst), d.Dport, mdCell(d.Reason), mdCell(dashIfEmpty(d.HookFamily)))
 		}
 	}
 
@@ -589,4 +589,19 @@ func dashIfEmpty(s string) string {
 		return "-"
 	}
 	return s
+}
+
+// mdCell sanitizes a string for safe interpolation into a Markdown table cell.
+// JSONL string fields (process comm, destination FQDN/SNI, deny reason) are
+// influenced by observed traffic and process state, so a raw `|`, backtick,
+// newline, or `<` would break the table or inject content into the Job Summary
+// / report artifact. Mirrors the old digest's sanitizeCell (lost when the
+// report pipeline was rewritten).
+func mdCell(s string) string {
+	s = strings.ReplaceAll(s, "\r", "")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "|", "·")
+	s = strings.ReplaceAll(s, "`", "'")
+	s = strings.ReplaceAll(s, "<", "‹")
+	return strings.TrimSpace(s)
 }

--- a/internal/report/markdown/markdown_test.go
+++ b/internal/report/markdown/markdown_test.go
@@ -231,3 +231,32 @@ func TestMissingRequiredTypes(t *testing.T) {
 		t.Fatalf("enhanced should report missing udp/http/tls/proc_fork/fs_event")
 	}
 }
+
+// TestRenders_SanitizeInjectedCells guards against Markdown table injection from
+// attacker-influenced JSONL fields (process comm, destination FQDN/SNI, deny
+// reason): a `|`, backtick, newline, or `<` must not survive into a table cell.
+func TestRenders_SanitizeInjectedCells(t *testing.T) {
+	jsonl := strings.Join([]string{
+		`{"type":"tcp","fqdn":"evil|x.example.com","dst":"1.2.3.4","dport":443}`,
+		`{"type":"deny","comm":"sh|` + "`" + `id` + "`" + `","protocol":"tcp","dst":"a|b.com","dport":80,"reason":"x|y","hook_family":"cgroup","mode":"defend"}`,
+	}, "\n") + "\n"
+	a, err := Parse(strings.NewReader(jsonl))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	for name, out := range map[string]string{"detailed": a.RenderDetailed(), "simple": a.RenderSimple()} {
+		// No raw pipe from data should appear beyond the table delimiters. The
+		// injected `evil|x` / `sh|`+backtick must be neutralized: no backtick-id,
+		// and the dest/comm pipes replaced by the middot.
+		if strings.Contains(out, "evil|x.example.com") {
+			t.Errorf("%s: raw injected pipe survived in dest:\n%s", name, out)
+		}
+		if strings.Contains(out, "`id`") {
+			t.Errorf("%s: raw backtick survived in comm:\n%s", name, out)
+		}
+	}
+	det := a.RenderDetailed()
+	if !strings.Contains(det, "evil·x.example.com") {
+		t.Errorf("expected sanitized dest (pipe->middot) in detailed:\n%s", det)
+	}
+}


### PR DESCRIPTION
## Bug

The pure-markdown report generator interpolated **attacker-influenced** JSONL string fields — destination FQDN/SNI, process `comm`, deny `reason`/`dst` — **raw** into Markdown table cells. A `|`, backtick, newline, or `<` (a process named `sh|\`, egress to `evil|x.com`, an SNI from observed traffic) breaks the table or injects content into the GitHub Job Summary + `.coldstep-report.md` artifact.

The agent digest this generator replaced sanitized every cell (`sanitizeCell`); the rewrite dropped it, and the no-HTML guard test only checks fixtures, not runtime data. Found in a bug-hunt of the report-elim changes.

## Fix

Add `mdCell` (`|`→·, backtick→', newline→space, `<`→‹, trim) and wrap every data-derived cell: destination tables (simple + detailed), deny rows, top-destinations line, agent/kernel/profile meta line.

## Test

A JSONL stream with injected `|`/backticks in fqdn/comm/dst/reason renders with pipes neutralized to middots and no surviving backtick run. Build/test green on WSL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)