### PR TITLE
fix(report): label clean defend runs as defend (carry mode in meta)

### DIFF
--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -118,7 +118,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 		// so consumers can see silent event loss without parsing the digest.
 		// Map is nil (and omitted) when every counter is zero.
 		if cfg.EventsLogPath != "" {
-			if shutdownMeta, err := telemetry.BuildMeta(agentVersionString(), bpfSt, cfg.DetectProfile); err != nil {
+			if shutdownMeta, err := telemetry.BuildMeta(agentVersionString(), bpfSt, cfg.DetectProfile, string(cfg.Mode)); err != nil {
 				slog.Warn("build shutdown meta", "err", err)
 			} else {
 				shutdownMeta.DroppedEvents = buildDroppedEventsMap(stats, defendState)
@@ -980,7 +980,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 	}
 
 	if cfg.EventsLogPath != "" {
-		meta, err := telemetry.BuildMeta(agentVersionString(), bpfSt, cfg.DetectProfile)
+		meta, err := telemetry.BuildMeta(agentVersionString(), bpfSt, cfg.DetectProfile, string(cfg.Mode))
 		if err != nil {
 			slog.Warn("build meta", "err", err)
 		} else {

--- a/internal/report/markdown/markdown.go
+++ b/internal/report/markdown/markdown.go
@@ -602,14 +602,18 @@ func dashIfEmpty(s string) string {
 // mdCell sanitizes a string for safe interpolation into a Markdown table cell.
 // JSONL string fields (process comm, destination FQDN/SNI, deny reason) are
 // influenced by observed traffic and process state, so a raw `|`, backtick,
-// newline, or `<` would break the table or inject content into the Job Summary
-// / report artifact. Mirrors the old digest's sanitizeCell (lost when the
-// report pipeline was rewritten).
+// newline, `<`, or link brackets would break the table or inject content into
+// the Job Summary / report artifact. The `[`/`]` substitution neutralizes
+// Markdown link/image syntax (e.g. a hostile SNI `[x](http://evil)` would
+// otherwise render as a clickable link). Mirrors the old digest's sanitizeCell
+// (lost when the report pipeline was rewritten).
 func mdCell(s string) string {
 	s = strings.ReplaceAll(s, "\r", "")
 	s = strings.ReplaceAll(s, "\n", " ")
 	s = strings.ReplaceAll(s, "|", "·")
 	s = strings.ReplaceAll(s, "`", "'")
 	s = strings.ReplaceAll(s, "<", "‹")
+	s = strings.ReplaceAll(s, "[", "［")
+	s = strings.ReplaceAll(s, "]", "］")
 	return strings.TrimSpace(s)
 }

--- a/internal/report/markdown/markdown.go
+++ b/internal/report/markdown/markdown.go
@@ -237,6 +237,7 @@ type metaLine struct {
 	DetectProfile    string            `json:"detect_profile"`
 	AgentVersion     string            `json:"agent_version"`
 	KernelRelease    string            `json:"kernel_release"`
+	Mode             string            `json:"mode"`
 }
 
 func (a *Aggregate) countMeta(line []byte) {
@@ -245,6 +246,13 @@ func (a *Aggregate) countMeta(line []byte) {
 		return
 	}
 	a.MetaSeen = true
+	// Meta is the authoritative mode source: it lets a defend run with zero
+	// deny events still label as defend (deny events alone cannot prove a
+	// defend run happened). Legacy artifacts omit it and fall back to the
+	// deny-derived mode set in countDeny.
+	if m.Mode != "" {
+		a.Mode = m.Mode
+	}
 	a.BPF = m.BPF
 	a.AllowlistIPs = m.AllowlistIPs
 	a.AllowlistEntries = m.AllowlistEntries

--- a/internal/report/markdown/markdown_test.go
+++ b/internal/report/markdown/markdown_test.go
@@ -284,3 +284,19 @@ func TestRenders_SanitizeInjectedCells(t *testing.T) {
 		t.Errorf("expected sanitized dest (pipe->middot) in detailed:\n%s", det)
 	}
 }
+
+// TestRenders_NeutralizeLinkBrackets ensures a hostile SNI/FQDN cannot smuggle a
+// Markdown link/image into the Job Summary or report via `[text](url)` syntax.
+func TestRenders_NeutralizeLinkBrackets(t *testing.T) {
+	jsonl := `{"type":"tls","sni":"[click](http://evil.example)","confidence":"full","dst":"1.2.3.4"}` + "\n" +
+		`{"type":"tcp","fqdn":"[click](http://evil.example)","dst":"1.2.3.4","dport":443}` + "\n"
+	a, err := Parse(strings.NewReader(jsonl))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	for name, out := range map[string]string{"detailed": a.RenderDetailed(), "simple": a.RenderSimple()} {
+		if strings.Contains(out, "[click]") || strings.Contains(out, "](http://evil.example)") {
+			t.Errorf("%s: raw link brackets survived — link injection possible:\n%s", name, out)
+		}
+	}
+}

--- a/internal/report/markdown/markdown_test.go
+++ b/internal/report/markdown/markdown_test.go
@@ -65,6 +65,30 @@ func TestParse_Counts(t *testing.T) {
 	}
 }
 
+// A defend run where everything was allowlisted produces zero deny events.
+// Mode must still come from the meta line, not be inferred as detect.
+func TestParse_DefendModeFromMeta_NoDenies(t *testing.T) {
+	jsonl := `{"type":"meta","ts":"t0","mode":"defend"}
+{"type":"tcp","dst":"140.82.112.3","dport":443,"fqdn":"github.com"}
+`
+	a, err := Parse(strings.NewReader(jsonl))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(a.Denies) != 0 {
+		t.Fatalf("Denies=%d want 0", len(a.Denies))
+	}
+	if a.Mode != "defend" {
+		t.Errorf("Mode=%q want defend (from meta, no deny events)", a.Mode)
+	}
+	if got := a.modeLabel(); got != "defend" {
+		t.Errorf("modeLabel=%q want defend", got)
+	}
+	if !strings.Contains(a.RenderSimple(), "defend") {
+		t.Error("RenderSimple should label the run defend")
+	}
+}
+
 func TestTopDests_Stable(t *testing.T) {
 	a := parseSample(t)
 	top := a.topDests(2)

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -46,6 +46,12 @@ type MetaEvent struct {
 	BPF           []BPFStatus     `json:"bpf"`
 	Capabilities  map[string]bool `json:"capabilities,omitempty"`
 	DetectProfile string          `json:"detect_profile,omitempty"` // "standard" | "enhanced" (from COLDSTEP_DETECT_PROFILE)
+	// Mode is the run mode the agent enforced: "detect" or "defend". It lets the
+	// report label a defend run correctly even when nothing was blocked (zero
+	// deny events) — without it the report can only infer mode from deny lines
+	// and silently mislabels a clean defend run as detect. Omitted on legacy
+	// artifacts written before this field existed.
+	Mode string `json:"mode,omitempty"`
 	// AllowlistIPCount snapshots the number of unique IPv4 addresses produced by
 	// compiling the domain allowlist (P1-1 6a). Zero when not in defend mode.
 	AllowlistIPCount int `json:"allowlist_ip_count,omitempty"`

--- a/internal/telemetry/meta_linux.go
+++ b/internal/telemetry/meta_linux.go
@@ -12,7 +12,8 @@ import (
 
 // BuildMeta constructs the opening JSONL record (call once per agent run).
 // detectProfile is COLDSTEP_DETECT_PROFILE: standard or enhanced (empty treated as standard upstream).
-func BuildMeta(agentVer string, bpf []BPFStatus, detectProfile string) (MetaEvent, error) {
+// mode is the run mode ("detect" / "defend"); empty is omitted from the JSON.
+func BuildMeta(agentVer string, bpf []BPFStatus, detectProfile, mode string) (MetaEvent, error) {
 	var uts unix.Utsname
 	if err := unix.Uname(&uts); err != nil {
 		return MetaEvent{}, err
@@ -46,5 +47,6 @@ func BuildMeta(agentVer string, bpf []BPFStatus, detectProfile string) (MetaEven
 		GitHub:        gh,
 		BPF:           bpf,
 		DetectProfile: dp,
+		Mode:          strings.TrimSpace(mode),
 	}, nil
 }


### PR DESCRIPTION
## Bug: a clean defend run is labeled `detect`

`markdown.Aggregate.Mode` was set **only** from `deny` events (`countDeny`). A defend run where every destination is allowlisted — the success case — emits **zero** deny events, so `modeLabel()` fell back to `"detect"` and the report rendered:

> ## coldstep — detect ✅ no anomalies

…for a run where `mode: defend` was active and enforcing. The operator can't tell defend even ran.

`MetaEvent` carried no mode field, so the JSONL stream had no authoritative mode signal outside deny lines.

## Fix

- Add `Mode` to `MetaEvent` (`json:"mode,omitempty"`).
- Populate it from `cfg.Mode` in both shutdown-meta paths (`BuildMeta` gains a `mode` param).
- Read it as the authoritative mode in the report's `countMeta`; deny-derived mode stays the fallback for legacy artifacts that predate the field.

## Verification

- New test `TestParse_DefendModeFromMeta_NoDenies`: defend meta + zero denies → `Mode == "defend"`, `modeLabel() == "defend"`, `RenderSimple()` contains `defend`.
- `go test ./internal/telemetry ./internal/report/markdown` green (WSL + Windows).
- `go build ./internal/agent` green (signature change to `BuildMeta`).
- gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up commit: neutralize markdown link brackets

`mdCell` escaped `|` / backtick / newline / `<` but left `[` `]` intact, so a hostile SNI/FQDN like `[click](http://evil)` rendered as a clickable link in the Job Summary and report artifact. Mapped `[`/`]` to fullwidth lookalikes (`［`/`］`) to break link/image syntax while keeping cells readable. Added `TestRenders_NeutralizeLinkBrackets`.
