### PR TITLE
docs(website): current examples — IPv6 defend enforcement + report artifact

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,6 @@ go.sum text eol=lf
 # Linux (LF), so a Windows CRLF checkin would falsely fail it. Pin LF.
 dist/**/*.js text eol=lf
 dist/**/*.map text eol=lf
+
+# HTML (website) is LF to avoid CRLF churn from Windows edits
+*.html text eol=lf

--- a/website/index.html
+++ b/website/index.html
@@ -133,11 +133,11 @@ jobs:
               <div class="mode">
                 <h3>Defend</h3>
                 <p>
-                  Block IPv4 egress outside your allowlist via cgroup <code>connect4</code> / <code>sendmsg4</code>
-                  and BPF LSM where available. Requires a non-empty allowlist.
-                  <strong>IPv6 egress is observed and surfaced as a warning</strong> — defend
-                  allowlists are IPv4-only, so any IPv6 destination escapes enforcement and is
-                  flagged 🚨 in the digest.
+                  Block egress outside your allowlist — IPv4 <em>and</em> IPv6 — via cgroup
+                  <code>connect4</code> / <code>sendmsg4</code> + <code>connect6</code> / <code>sendmsg6</code>,
+                  with BPF LSM where available. Requires a non-empty allowlist. Native IPv6 is
+                  enforced against the allowlist; loopback (<code>::1</code>) and link-local
+                  (<code>fe80::/10</code>) always pass.
                 </p>
                 <span class="tag">Opt-in</span>
               </div>
@@ -205,11 +205,11 @@ jobs:
                 <span>Append-only event stream — source of truth for investigations.</span>
               </li>
               <li>
-                <code>.coldstep-detect.md</code>
+                <code>.coldstep-report.md</code>
                 <span>
-                  Compact, GFM-compliant shutdown digest — verdict badge, single-row KPI table,
-                  Coverage scope line, and a collapsible Full KPI fold (per-channel counts and
-                  ringbuf drops).
+                  Pure-Markdown report rendered from the JSONL by <code>coldstep stop</code> —
+                  verdict, destinations, denies, TLS-SNI confidence, coverage signals, and BPF
+                  health. The agent writes data only; the report is built in userspace.
                 </span>
               </li>
               <li>


### PR DESCRIPTION
## Website: current examples + IPv6 defend truth + LF

Post-tag website follow-up (v0.5.0 is live).

- **IPv6 defend fix:** removed the stale 'allowlists are IPv4-only, IPv6 escapes enforcement' claim. Defend enforces IPv6 via cgroup `connect6`/`sendmsg6` against the allowlist (H14, v0.4.0); loopback + link-local bypass.
- **Artifact rename:** `.coldstep-detect.md` -> `.coldstep-report.md` (agent writes data only; report rendered by `coldstep stop` from the JSONL).
- **EOL:** `*.html text eol=lf` in `.gitattributes` + normalize `website/index.html` to LF — stops the 586-line CRLF churn Windows edits produced.

Pin already `@v0.5.0`; example `uses:` block uses current inputs. `coldstep-pages` redeploys on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
