### PR TITLE
feat(allowlist): IPv6-literal allowlisting (SP-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **IPv6-literal allowlisting (SP-2).** `allow` / `allow-file` now accept native IPv6 literals (`2001:db8::1`) and IPv6 CIDRs (`2001:db8::/32`). They are classified to the IP path, parsed by `policy.Parse` into the v6 buckets, and programmed into the defend `allowed_ipv6` LPM trie (literals as `/128`, CIDRs as prefix entries) alongside AAAA-resolved domains. Previously IPv6 literals were silently treated as hostnames and failed to resolve. The `!CIDR` ignore mechanism remains IPv4-only.
+
+### Fixed
+
+- **Stop step no longer drops the report on a transient GitHub API failure.** The post step renders the report from the already-downloaded + SHA-verified cached binary (`cachedColdstepBinaryPath`) instead of re-fetching the release SHA over the network; a transient Releases API rate-limit/5xx no longer silently omits the report.
+
 ## [0.5.0] — 2026-06-08
 
 ### Changed (BREAKING)

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -99,7 +99,7 @@ Every `with:` key the action accepts (defaults are what you get if you omit the 
 | Input | Default | Summary |
 | :---- | :------ | :------ |
 | **`mode`** | `detect` | **`detect`** — observe only. **`defend`** — block non-allowlisted egress (**`enforce`** is rejected). |
-| **`allow`** | *(empty)* | Comma/newline-separated egress allowlist. Accepts plain domains (`example.com`), wildcard domains (`*.example.com` — **detect only**, rejected at parse time when `mode: defend`), IPv4 literals (`1.2.3.4`), and CIDRs (`10.0.0.0/8`). Prefix a CIDR with `!` to ignore that net (e.g. `!192.168.0.0/16`). Entries are auto-classified. |
+| **`allow`** | *(empty)* | Comma/newline-separated egress allowlist. Accepts plain domains (`example.com`), wildcard domains (`*.example.com` — **detect only**, rejected at parse time when `mode: defend`), IPv4/IPv6 literals (`1.2.3.4`, `2001:db8::1`), and CIDRs (`10.0.0.0/8`, `2001:db8::/32`). Prefix a CIDR with `!` to ignore that net (e.g. `!192.168.0.0/16`). Entries are auto-classified. |
 | **`allow-file`** | *(empty)* | Comma-separated workspace paths to UTF-8 files; same format as `allow`. Merged after inline `allow`. |
 | **`no-default-ignored-nets`** | `false` | If **`true`**, do **not** add implicit **`10.0.0.0/8`** and **`172.16.0.0/12`** ignores. Add your own ignores as **`!CIDR`** entries in **`allow`** / **`allow-file`** (the only ignore mechanism; max **128** CIDRs). |
 | **`detect-profile`** | `standard` | **`detect` only**: `standard` (default) or `enhanced`. Enhanced enables `proc_tree`, `tls_sni`, and `fs_events`, and tightens report-model integrity. |
@@ -187,7 +187,7 @@ Denied egress appears as `"type":"deny"` in JSONL and in the digest.
 
 For large allowlists, keep **UTF-8 text files** in the repository and pass **comma-separated paths** to **`allow-file`** relative to **`GITHUB_WORKSPACE`** (no path escape outside the workspace).
 
-**File format:** optional `#` full-line or end-of-line comments; tokens separated by newlines, commas, and/or spaces (same as editing a long inline `allow:` list, but reviewable in PRs as a file). Entries are auto-classified into domains, wildcard hosts, IPv4 literals, and `!`-prefixed ignore CIDRs.
+**File format:** optional `#` full-line or end-of-line comments; tokens separated by newlines, commas, and/or spaces (same as editing a long inline `allow:` list, but reviewable in PRs as a file). Entries are auto-classified into domains, wildcard hosts, IPv4/IPv6 literals, and `!`-prefixed ignore CIDRs.
 
 **Starter packs:** reference domain/IP packs live in **`scripts/coldstep_bootstrap/`** in the repo. Copy the lines you want into your own **`allow-file`** — there is no separate input to merge them (the `bootstrap-allowlist` input was removed).
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Full list and defaults: **[`action.yml`](action.yml)**. Frequently used:
 | Input | Purpose |
 | :---- | :------ |
 | `mode` | **`detect`** or **`defend`** (blocking). **`enforce`** is rejected. |
-| `allow` / `allow-file` | Unified egress allowlist (**required** for **defend** / blocking). Accepts plain domains, `*.example.com` wildcards (**detect only** — rejected at parse time in `defend`), IPv4 literals/CIDRs, and `!CIDR` ignore entries. |
+| `allow` / `allow-file` | Unified egress allowlist (**required** for **defend** / blocking). Accepts plain domains, `*.example.com` wildcards (**detect only** — rejected at parse time in `defend`), IPv4/IPv6 literals/CIDRs, and `!CIDR` ignore entries. |
 | `fail-on-error` | Fail if the agent never reaches **operational** readiness (BPF/load), not for policy "violations" alone. Defaults to **`true`** in defend mode. |
 | `detect-profile` | **`detect` only:** `standard` (default) or **`enhanced`** — enhanced enables `proc_tree` / `tls_sni` / `fs_events` and sets `COLDSTEP_DETECT_PROFILE` for a stricter required-event-type gate (set the same `COLDSTEP_DETECT_PROFILE` on `coldstep assert-integrity`). |
 | `report` | `job-summary` (default), `pr-comment`, `both`, or `none` — where to post the detect digest. |

--- a/action.yml
+++ b/action.yml
@@ -23,14 +23,16 @@ inputs:
     description: >-
       Comma- or newline-separated egress allowlist — the single list source.
       Accepts plain domains (example.com), wildcard domains (*.example.com),
-      IPv4 literals (1.2.3.4), and CIDRs (10.0.0.0/8). Prefix a CIDR with ! to
-      ignore that net (e.g. !192.168.0.0/16) — this is the only ignore mechanism
-      (see no-default-ignored-nets for the implicit RFC1918 ignores). Entries are
-      auto-classified: IP/CIDR → allowed-ips, !CIDR → ignored nets, domain/wildcard
-      → allowed-hosts + allowed-domains. Merged with allow-file. In defend mode each
-      domain is resolved for both A and AAAA records; matching IPv4 and IPv6
-      addresses populate the BPF allowlists. IPv6 literals are not accepted as
-      input today — use AAAA-bearing hostnames instead. Wildcard entries
+      IPv4 and IPv6 literals (1.2.3.4, 2001:db8::1), and CIDRs (10.0.0.0/8,
+      2001:db8::/32). Prefix an IPv4 CIDR with ! to ignore that net
+      (e.g. !192.168.0.0/16) — this is the only ignore mechanism (see
+      no-default-ignored-nets for the implicit RFC1918 ignores; the ignore trie
+      is IPv4-only). Entries are auto-classified: IP/CIDR → allowed-ips,
+      !CIDR → ignored nets, domain/wildcard → allowed-hosts + allowed-domains.
+      Merged with allow-file. In defend mode each domain is resolved for both A
+      and AAAA records; matching IPv4 and IPv6 addresses populate the BPF
+      allowlists, and literal IPv6 entries are programmed into the allowed_ipv6
+      LPM trie alongside them (SP-2). Wildcard entries
       (*.example.com) are detect-only — they are rejected at parse time when
       mode=defend, because the BPF allowed_domains map uses exact-string lookup.
     required: false

--- a/internal/actioncli/allowlist_files.go
+++ b/internal/actioncli/allowlist_files.go
@@ -2,6 +2,7 @@ package actioncli
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -9,6 +10,21 @@ import (
 )
 
 var ipv4LiteralOrCIDR = regexp.MustCompile(`^(\d{1,3}\.){3}\d{1,3}(/\d{1,2})?$`)
+
+// isIPLiteralOrCIDR reports whether t is an IP literal or CIDR — IPv4 or IPv6
+// (SP-2). Used to route IP entries to the `ips` bucket (-> COLDSTEP_ALLOWED_IPS
+// -> policy.Parse, which programs v4 into allowed_ipv4 and v6 into allowed_ipv6)
+// rather than treating an IPv6 literal as a hostname.
+func isIPLiteralOrCIDR(t string) bool {
+	if ipv4LiteralOrCIDR.MatchString(t) {
+		return true
+	}
+	if strings.Contains(t, "/") {
+		_, _, err := net.ParseCIDR(t)
+		return err == nil
+	}
+	return net.ParseIP(t) != nil
+}
 
 type classifiedAllow struct {
 	domains     []string
@@ -43,8 +59,9 @@ func rejectDefendWildcards(c classifiedAllow) error {
 }
 
 // classifyAllowTokens splits unified allow-list tokens into per-type buckets.
-// Plain or wildcard domains go to both hosts and domains; IPv4 literals/CIDRs
-// go to ips; a leading `!` on an IPv4 CIDR routes it to ignoredNets.
+// Plain or wildcard domains go to both hosts and domains; IP literals/CIDRs —
+// IPv4 or IPv6 (SP-2) — go to ips; a leading `!` on an IPv4 CIDR routes it to
+// ignoredNets (the ignore LPM trie is IPv4-only, so `!IPv6` is not classified).
 func classifyAllowTokens(tokens []string) classifiedAllow {
 	var c classifiedAllow
 	for _, t := range tokens {
@@ -59,7 +76,7 @@ func classifyAllowTokens(tokens []string) classifiedAllow {
 			}
 			continue
 		}
-		if ipv4LiteralOrCIDR.MatchString(t) {
+		if isIPLiteralOrCIDR(t) {
 			c.ips = append(c.ips, t)
 		} else {
 			c.hosts = append(c.hosts, t)

--- a/internal/actioncli/allowlist_parse_more_test.go
+++ b/internal/actioncli/allowlist_parse_more_test.go
@@ -76,6 +76,28 @@ func TestClassifyAllowTokens_Buckets(t *testing.T) {
 	}
 }
 
+// TestClassifyAllowTokens_IPv6 (SP-2): IPv6 literals and CIDRs route to the ips
+// bucket (-> COLDSTEP_ALLOWED_IPS -> policy.Parse -> allowed_ipv6 trie), NOT to
+// the hostname bucket. A `!`-prefixed IPv6 is dropped (ignore trie is v4-only).
+func TestClassifyAllowTokens_IPv6(t *testing.T) {
+	got := classifyAllowTokens([]string{
+		"2001:db8::1",    // literal -> ips
+		"2606:4700::/32", // CIDR -> ips
+		"::1",            // loopback literal -> ips
+		"!2001:db8::/48", // bang v6 -> dropped (v4-only ignore)
+		"example.com",    // domain -> hosts/domains
+		"1.2.3.4",        // v4 literal -> ips
+	})
+	want := classifiedAllow{
+		hosts:   []string{"example.com"},
+		domains: []string{"example.com"},
+		ips:     []string{"2001:db8::1", "2606:4700::/32", "::1", "1.2.3.4"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("classifyAllowTokens IPv6:\n got %+v\nwant %+v", got, want)
+	}
+}
+
 // TestClassifyAllowTokens_RegexIsShapeOnly documents that the IPv4 classifier is
 // a shape match, not a validity check: out-of-range octets and prefixes still
 // route to the ips bucket (downstream policy compilation validates them). This

--- a/internal/agent/agent_linux_policy_maps.go
+++ b/internal/agent/agent_linux_policy_maps.go
@@ -509,6 +509,7 @@ func populateAllowedIPv6Map(m *ebpf.Map, compiled policy.CompileResult, pol *pol
 			continue
 		}
 		var key [20]byte
+		// #nosec G115 -- ones is an IPv6 prefix length from net.IPMask.Size() (0..128); always fits uint32 //nolint:gosec
 		binary.LittleEndian.PutUint32(key[0:4], uint32(ones))
 		copy(key[4:20], ip16)
 		if err := m.Update(key, val, ebpf.UpdateAny); err != nil {

--- a/internal/agent/agent_linux_policy_maps.go
+++ b/internal/agent/agent_linux_policy_maps.go
@@ -41,11 +41,15 @@ func compileDefendAllowlist(ctx context.Context, cfg config.Config, resolver pol
 		return policy.CompileResult{}, perr
 	}
 	pol.MergeLiteralAllowedIPv4Into(&compiled.AllowedIPv4)
+	// SP-2: literal IPv6 addresses count toward the effective allowlist too.
+	pol.MergeLiteralAllowedIPv6Into(&compiled.AllowedIPv6)
+	literalV6CIDRs := len(pol.AllowedIPv6Nets())
 	// P2-1 Phase 2: an IPv6-only allowlist (AAAA resolutions, no A) is
 	// valid — both BPF defend hooks attach, IPv4 cgroup denies everything,
 	// IPv6 cgroup denies everything outside allowed_ipv6. Only reject
-	// when BOTH families are empty (every domain failed both A and AAAA).
-	if compiled.AllowedIPv4.Len() == 0 && compiled.AllowedIPv6.Len() == 0 {
+	// when ALL families are empty (every domain failed both A and AAAA and
+	// no IPv4/IPv6 literals or CIDRs were given).
+	if compiled.AllowedIPv4.Len() == 0 && compiled.AllowedIPv6.Len() == 0 && literalV6CIDRs == 0 {
 		msg := "defend allowlist effective allowlist is empty (no A/AAAA resolutions; add literals to allowed-ips if needed)"
 		if len(compiled.UnresolvedDomains) > 0 {
 			msg += fmt.Sprintf(" — check DNS for: %s", strings.Join(compiled.UnresolvedDomains, ", "))
@@ -343,7 +347,7 @@ func loadDefendMaps(objs *defend.DefendObjects, compiled policy.CompileResult, p
 	// when the map is present in the loaded objects. Loader stripped this
 	// to nil if the BPF stubs predate Phase 2 — populate returns (0, nil)
 	// in that case, so older stubs continue to load IPv4-only defend.
-	ipv6Programmed, err := populateAllowedIPv6Map(objs.AllowedIpv6, compiled)
+	ipv6Programmed, err := populateAllowedIPv6Map(objs.AllowedIpv6, compiled, pol)
 	if err != nil {
 		return 0, 0, 0, err
 	}
@@ -461,19 +465,25 @@ func loadAllowedLPMMap(m *ebpf.Map, plan allowedLPMPlan) error {
 // stubs that predate Phase 2) is tolerated: 0 returned, no error — the
 // BPF program also degrades gracefully because cgroup/connect6 +
 // sendmsg6 will be missing, leaving IPv4-only defend.
-func populateAllowedIPv6Map(m *ebpf.Map, compiled policy.CompileResult) (int, error) {
+func populateAllowedIPv6Map(m *ebpf.Map, compiled policy.CompileResult, pol *policy.Policy) (int, error) {
 	if m == nil {
 		return 0, nil
 	}
+	// SP-2: union AAAA-resolved /128s with literal IPv6 addresses from
+	// allowed-ips. Both are exact /128 entries; literal IPv6 CIDRs are
+	// programmed as prefix entries below.
+	pol.MergeLiteralAllowedIPv6Into(&compiled.AllowedIPv6)
+
 	// Deterministic ordering for reproducibility (tests, logs).
 	keys := make([][16]byte, 0, compiled.AllowedIPv6.Len())
 	compiled.AllowedIPv6.ForEach(func(k [16]byte) { keys = append(keys, k) })
 	sort.Slice(keys, func(i, j int) bool {
 		return bytes.Compare(keys[i][:], keys[j][:]) < 0
 	})
-	if len(keys) > policy.MaxAllowedDefendIPv6Keys {
+	cidrs := pol.AllowedIPv6Nets()
+	if len(keys)+len(cidrs) > policy.MaxAllowedDefendIPv6Keys {
 		return 0, fmt.Errorf("allowed_ipv6: %d entries exceeds BPF max %d",
-			len(keys), policy.MaxAllowedDefendIPv6Keys)
+			len(keys)+len(cidrs), policy.MaxAllowedDefendIPv6Keys)
 	}
 	val := uint8(1)
 	programmed := 0
@@ -484,6 +494,25 @@ func populateAllowedIPv6Map(m *ebpf.Map, compiled policy.CompileResult) (int, er
 		if err := m.Update(key, val, ebpf.UpdateAny); err != nil {
 			return programmed, fmt.Errorf("load allowed_ipv6 map (/128 %s): %w",
 				net.IP(addr[:]).String(), err)
+		}
+		programmed++
+	}
+	// SP-2: literal IPv6 CIDRs as LPM prefix entries. net.ParseCIDR already
+	// masked the network address; prefix length comes from the mask.
+	for _, n := range cidrs {
+		ones, bits := n.Mask.Size()
+		if bits != 128 {
+			continue // defensive: non-v6 mask should never reach here
+		}
+		ip16 := n.IP.To16()
+		if ip16 == nil {
+			continue
+		}
+		var key [20]byte
+		binary.LittleEndian.PutUint32(key[0:4], uint32(ones))
+		copy(key[4:20], ip16)
+		if err := m.Update(key, val, ebpf.UpdateAny); err != nil {
+			return programmed, fmt.Errorf("load allowed_ipv6 map (%s): %w", n.String(), err)
 		}
 		programmed++
 	}

--- a/internal/agent/sp2_ipv6_allowlist_integration_test.go
+++ b/internal/agent/sp2_ipv6_allowlist_integration_test.go
@@ -1,0 +1,61 @@
+//go:build integration && linux && !windows
+
+// SP-2 integration: literal IPv6 allowlist entries (a /128 literal and an IPv6
+// CIDR) are programmed into the real defend `allowed_ipv6` LPM trie. Validates
+// the full classifier->policy->agent->BPF path that the unit tests cover only
+// up to the map boundary. Requires root + a kernel where the defend object
+// loads (allowed_ipv6 is part of the cgroup defend object, not the LSM section).
+
+package agent
+
+import (
+	"encoding/binary"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/coldstep-io/coldstep/internal/bpf/defend"
+	"github.com/coldstep-io/coldstep/internal/policy"
+)
+
+func TestSP2_LiteralIPv6ProgrammedIntoAllowedTrie(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root to load BPF defend objects")
+	}
+	objs := &defend.DefendObjects{}
+	if _, err := defend.LoadDefendObjectsForKernel(objs, true, defend.HaveIOUringLSM()); err != nil {
+		t.Fatalf("load defend objects: %v", err)
+	}
+	defer objs.Close()
+	if objs.AllowedIpv6 == nil {
+		t.Fatal("allowed_ipv6 map absent from loaded defend object")
+	}
+
+	// allow a /128 literal and a /32 CIDR via the policy literal path.
+	pol, err := policy.Parse("", "2001:db8::1, 2606:4700::/32")
+	if err != nil {
+		t.Fatalf("policy.Parse: %v", err)
+	}
+	n, err := populateAllowedIPv6Map(objs.AllowedIpv6, policy.CompileResult{AllowedIPv6: policy.IPv6Set{}}, pol)
+	if err != nil {
+		t.Fatalf("populateAllowedIPv6Map: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("programmed %d entries, want 2 (one /128 literal + one /32 CIDR)", n)
+	}
+
+	// Verify both keys are present in the trie with value 1.
+	lookup := func(prefix uint32, ip string) bool {
+		var key [20]byte
+		binary.LittleEndian.PutUint32(key[0:4], prefix)
+		copy(key[4:20], net.ParseIP(ip).To16())
+		var val uint8
+		return objs.AllowedIpv6.Lookup(key, &val) == nil && val == 1
+	}
+	if !lookup(128, "2001:db8::1") {
+		t.Error("/128 literal 2001:db8::1 not found in allowed_ipv6")
+	}
+	if !lookup(32, "2606:4700::") {
+		t.Error("/32 CIDR 2606:4700:: not found in allowed_ipv6")
+	}
+}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -48,6 +48,13 @@ type Policy struct {
 	ips          map[string]struct{} // IPv4 literals from allowed-ips (4-byte key string)
 	nets         []*net.IPNet        // PR-G: literal IPv4 CIDR allowlist entries (e.g. "10.0.0.0/8")
 	ignored      []*net.IPNet        // merged default + user ignored IPv4 CIDRs (BuildPolicy only)
+	// SP-2: native IPv6 literal allowlist entries. ipv6s holds /128 literals
+	// (16-byte key string); ipv6nets holds IPv6 CIDRs (e.g. "2001:db8::/32").
+	// Both are programmed into the defend `allowed_ipv6` LPM trie alongside
+	// AAAA-resolved domains. IPv4-mapped IPv6 inputs are normalized to IPv4 and
+	// kept in ips/nets so the v4 and v6 sets stay disjoint.
+	ipv6s    map[string]struct{}
+	ipv6nets []*net.IPNet
 }
 
 // validHostnameSuffix matches purely lowercase DNS label characters for wildcard suffix validation.
@@ -58,6 +65,7 @@ func Parse(allowedHosts, allowedIPs string) (*Policy, error) {
 	p := &Policy{
 		exactHosts: make(map[string]struct{}),
 		ips:        make(map[string]struct{}),
+		ipv6s:      make(map[string]struct{}),
 	}
 	for _, h := range splitFields(allowedHosts) {
 		h = strings.ToLower(strings.TrimSpace(h))
@@ -88,16 +96,21 @@ func Parse(allowedHosts, allowedIPs string) (*Policy, error) {
 		if raw == "" {
 			continue
 		}
-		// PR-G: accept either bare IPv4 literal (kept as /32 in p.ips for
-		// fast Classify exact-match) or a CIDR like "10.0.0.0/8" (kept in
-		// p.nets and programmed into the BPF allowed_ipv4 LPM trie).
-		// IPv6 literals and CIDRs are rejected (IPv4 only).
+		// Accept a bare IPv4 literal (kept as /32 in p.ips for fast Classify
+		// exact-match) or an IPv4 CIDR like "10.0.0.0/8" (kept in p.nets and
+		// programmed into the BPF allowed_ipv4 LPM trie). SP-2: also accept
+		// native IPv6 literals (-> p.ipv6s) and IPv6 CIDRs (-> p.ipv6nets) for
+		// the allowed_ipv6 trie. IPv4-mapped IPv6 is normalized to IPv4.
 		if strings.Contains(raw, "/") {
-			ipNet, err := parseIPv4CIDR(raw)
+			ip, ipNet, err := net.ParseCIDR(raw)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("allowed-ips: invalid CIDR %q: %w", raw, err)
 			}
-			p.nets = append(p.nets, ipNet)
+			if ip.To4() != nil {
+				p.nets = append(p.nets, ipNet)
+			} else {
+				p.ipv6nets = append(p.ipv6nets, ipNet)
+			}
 			continue
 		}
 		ip := net.ParseIP(raw)
@@ -108,29 +121,17 @@ func Parse(allowedHosts, allowedIPs string) (*Policy, error) {
 			p.ips[string(ip4)] = struct{}{}
 			continue
 		}
-		if ip.To16() != nil {
-			return nil, fmt.Errorf("allowed-ips: IPv6 literals are not supported, use IPv4: %q", raw)
+		if ip16 := ip.To16(); ip16 != nil {
+			p.ipv6s[string(ip16)] = struct{}{}
+			continue
 		}
 		return nil, fmt.Errorf("invalid allowed IP %q", raw)
 	}
-	p.enabled = len(p.exactHosts) > 0 || len(p.wildSuffixes) > 0 || len(p.ips) > 0 || len(p.nets) > 0
+	if len(p.ipv6s) > MaxAllowedDefendIPv6Keys || len(p.ipv6nets) > MaxAllowedDefendIPv6Keys {
+		return nil, fmt.Errorf("allowed-ips: IPv6 entry count exceeds maximum %d", MaxAllowedDefendIPv6Keys)
+	}
+	p.enabled = len(p.exactHosts) > 0 || len(p.wildSuffixes) > 0 || len(p.ips) > 0 || len(p.nets) > 0 || len(p.ipv6s) > 0 || len(p.ipv6nets) > 0
 	return p, nil
-}
-
-// parseIPv4CIDR validates a CIDR string and returns its canonical *net.IPNet.
-// Used by allowed-ips parsing to support whole-range allowlist entries via the
-// BPF LPM trie introduced in PR-G. Rejects IPv6 and malformed strings.
-// Host-bit CIDR inputs are accepted and normalized to canonical network CIDRs
-// by net.ParseCIDR (for example, 203.0.113.42/24 becomes 203.0.113.0/24).
-func parseIPv4CIDR(raw string) (*net.IPNet, error) {
-	ip, ipNet, err := net.ParseCIDR(raw)
-	if err != nil {
-		return nil, fmt.Errorf("allowed-ips: invalid CIDR %q: %w", raw, err)
-	}
-	if ip.To4() == nil {
-		return nil, fmt.Errorf("allowed-ips: IPv6 CIDRs are not supported, use IPv4: %q", raw)
-	}
-	return ipNet, nil
 }
 
 // BuildPolicy parses allowlists like Parse, then attaches merged default + user ignored IPv4 CIDRs.
@@ -233,6 +234,31 @@ func (p *Policy) AllowedIPv4Nets() []*net.IPNet {
 		return nil
 	}
 	return p.nets
+}
+
+// MergeLiteralAllowedIPv6Into adds literal allowed IPv6 addresses (SP-2) into s,
+// unioned with AAAA domain resolutions, for the defend allowed_ipv6 LPM trie.
+func (p *Policy) MergeLiteralAllowedIPv6Into(s *IPv6Set) {
+	if p == nil || s == nil || len(p.ipv6s) == 0 {
+		return
+	}
+	for sKey := range p.ipv6s {
+		if len(sKey) != net.IPv6len {
+			continue
+		}
+		s.Add(net.IP([]byte(sKey)))
+	}
+}
+
+// AllowedIPv6Nets returns literal IPv6 CIDR allowlist entries (SP-2) parsed from
+// allowed-ips. Bare-IPv6 literals from p.ipv6s are NOT included here — they are
+// programmed as /128 LPM keys via the IPv6Set flow (MergeLiteralAllowedIPv6Into).
+// Returns nil when no IPv6 CIDRs were given.
+func (p *Policy) AllowedIPv6Nets() []*net.IPNet {
+	if p == nil {
+		return nil
+	}
+	return p.ipv6nets
 }
 
 func splitFields(s string) []string {

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -24,10 +24,26 @@ func TestParse_Empty(t *testing.T) {
 	}
 }
 
-func TestParse_AllowedIPv6LiteralRejected(t *testing.T) {
-	_, err := Parse("", "2001:db8::1")
-	if err == nil {
-		t.Fatal("expected error for IPv6 literal in allowed-ips")
+// SP-2: IPv6 literals are now accepted and stored as /128 entries for the
+// defend allowed_ipv6 LPM trie.
+func TestParse_AllowedIPv6Literal(t *testing.T) {
+	p, err := Parse("", "2001:db8::1")
+	if err != nil {
+		t.Fatalf("Parse IPv6 literal: %v", err)
+	}
+	if len(p.ipv6s) != 1 {
+		t.Fatalf("ipv6s = %d want 1", len(p.ipv6s))
+	}
+	if _, ok := p.ipv6s[string(net.ParseIP("2001:db8::1").To16())]; !ok {
+		t.Error("2001:db8::1 not stored in ipv6s")
+	}
+	if !p.enabled {
+		t.Error("policy should be enabled with an IPv6 literal")
+	}
+	var s IPv6Set
+	p.MergeLiteralAllowedIPv6Into(&s)
+	if !s.Contains(net.ParseIP("2001:db8::1")) {
+		t.Error("MergeLiteralAllowedIPv6Into missed the literal")
 	}
 }
 
@@ -90,10 +106,36 @@ func TestParse_AllowedIPv4CIDRNormalizesHostBitsSetInput(t *testing.T) {
 	}
 }
 
-func TestParse_AllowedIPv6CIDRRejected(t *testing.T) {
-	_, err := Parse("", "2001:db8::/32")
-	if err == nil {
-		t.Fatal("expected error for IPv6 CIDR in allowed-ips")
+// SP-2: IPv6 CIDRs are now accepted and stored as prefix entries for the defend
+// allowed_ipv6 LPM trie.
+func TestParse_AllowedIPv6CIDR(t *testing.T) {
+	p, err := Parse("", "2001:db8::/32")
+	if err != nil {
+		t.Fatalf("Parse IPv6 CIDR: %v", err)
+	}
+	nets := p.AllowedIPv6Nets()
+	if len(nets) != 1 {
+		t.Fatalf("AllowedIPv6Nets = %d want 1", len(nets))
+	}
+	if nets[0].String() != "2001:db8::/32" {
+		t.Errorf("CIDR = %q want 2001:db8::/32", nets[0].String())
+	}
+	if !p.enabled {
+		t.Error("policy should be enabled with an IPv6 CIDR")
+	}
+}
+
+// SP-2: a mixed v4/v6 allowlist keeps the families disjoint in the right buckets.
+func TestParse_MixedV4V6(t *testing.T) {
+	p, err := Parse("", "1.2.3.4, 10.0.0.0/8, 2001:db8::1, 2606:4700::/32")
+	if err != nil {
+		t.Fatalf("Parse mixed: %v", err)
+	}
+	if len(p.ips) != 1 || len(p.nets) != 1 {
+		t.Errorf("v4: ips=%d nets=%d want 1/1", len(p.ips), len(p.nets))
+	}
+	if len(p.ipv6s) != 1 || len(p.ipv6nets) != 1 {
+		t.Errorf("v6: ipv6s=%d ipv6nets=%d want 1/1", len(p.ipv6s), len(p.ipv6nets))
 	}
 }
 


### PR DESCRIPTION
## SP-2: IPv6-literal allowlisting (no shortcuts)

`allow` / `allow-file` now accept native IPv6 literals (`2001:db8::1`) and IPv6 CIDRs (`2001:db8::/32`), end to end through every layer.

### Layers
- **Classifier** (`internal/actioncli/allowlist_files.go`): `isIPLiteralOrCIDR` routes IPv6 literals/CIDRs to the IP bucket (was: treated as hostnames -> resolve fail).
- **Policy** (`internal/policy/policy.go`): `Parse` accepts IPv6 -> `p.ipv6s` (/128) + `p.ipv6nets` (CIDRs), bounded by `MaxAllowedDefendIPv6Keys`; adds `MergeLiteralAllowedIPv6Into` + `AllowedIPv6Nets`. Removed dead `parseIPv4CIDR`.
- **Agent** (`agent_linux_policy_maps.go`): `populateAllowedIPv6Map` programs literal /128s + CIDR prefix entries into the real `allowed_ipv6` LPM trie alongside AAAA resolutions; empty-effective-allowlist guard counts literal v6.

The `!CIDR` ignore mechanism stays IPv4-only (ignore trie is v4-only).

### Validation
- Unit: policy (literal/CIDR/mixed parse + merge), classifier (v6 routing).
- **Integration (root WSL 6.6):** programs a /128 literal + a /32 CIDR into the live `allowed_ipv6` LPM trie and verifies both via `Lookup` — PASS.
- gofmt / vet / staticcheck clean; `go build ./...` + unit suite green.

Docs: `action.yml` `allow`, README, QUICK_START, CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
