### PR TITLE
feat(agent): io_uring TLS destination correlation (ORDER 1 / BG-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **io_uring TLS destination correlation (ORDER 1 / BG-5).** `io_uring_tls` events now carry the connected IPv4 peer (`dst` + `dst_port`), resolved in kernel from the submission's socket (`req->file` → socket → `sk` → `skc_daddr`), instead of the `"unknown"` placeholder. Best-effort: the SNI still emits with `dst:"unknown"` when the peer is not resolvable.
 - **IPv6-literal allowlisting (SP-2).** `allow` / `allow-file` now accept native IPv6 literals (`2001:db8::1`) and IPv6 CIDRs (`2001:db8::/32`). They are classified to the IP path, parsed by `policy.Parse` into the v6 buckets, and programmed into the defend `allowed_ipv6` LPM trie (literals as `/128`, CIDRs as prefix entries) alongside AAAA-resolved domains. Previously IPv6 literals were silently treated as hostnames and failed to resolve. The `!CIDR` ignore mechanism remains IPv4-only.
 
 ### Fixed

--- a/bpf/trace_connect.bpf.c
+++ b/bpf/trace_connect.bpf.c
@@ -993,6 +993,37 @@ int handle_inet_sock_set_state(struct trace_event_raw_inet_sock_set_state *ctx)
  */
 #define COLDSTEP_USER_MSGHDR_MSG_IOV_OFFSET 16u
 
+/*
+ * ORDER 1 (BG-5): resolve the io_uring submission's fd + connected IPv4 peer
+ * from req->file's socket, mirroring the proven walk in
+ * trace_lsm_defend_iouring.inc (file->private_data as struct socket* -> sk ->
+ * skc_family/skc_daddr/skc_dport). Best-effort: any failed read or non-AF_INET
+ * socket leaves the corresponding field at 0; the TLS event still emits with
+ * the SNI, just without (or with partial) dst. Fills tev->fd/daddr/dport.
+ */
+static __always_inline void iouring_tls_resolve_peer(struct io_kiocb *req,
+						     struct io_uring_tls_event *tev)
+{
+	struct file *file = NULL;
+	if (bpf_core_read(&file, sizeof(file), &req->file) || !file)
+		return;
+	void *priv = NULL;
+	if (bpf_probe_read_kernel(&priv, sizeof(priv), &file->private_data) || !priv)
+		return;
+	struct socket *sock = (struct socket *)priv;
+	struct sock *sk = NULL;
+	if (bpf_probe_read_kernel(&sk, sizeof(sk), &sock->sk) || !sk)
+		return;
+	__u16 fam = 0;
+	if (bpf_probe_read_kernel(&fam, sizeof(fam), &sk->__sk_common.skc_family) ||
+	    fam != AF_INET)
+		return;
+	bpf_probe_read_kernel(&tev->daddr, sizeof(tev->daddr),
+			      &sk->__sk_common.skc_daddr);
+	bpf_probe_read_kernel(&tev->dport, sizeof(tev->dport),
+			      &sk->__sk_common.skc_dport);
+}
+
 SEC("raw_tp/io_uring_submit_sqe")
 int trace_io_uring_submit_sqe(struct bpf_raw_tracepoint_args *ctx)
 {
@@ -1092,7 +1123,12 @@ int trace_io_uring_submit_sqe(struct bpf_raw_tracepoint_args *ctx)
 							tev->op = opcode;
 							tev->_pad[0] = tev->_pad[1] = tev->_pad[2] = 0;
 							tev->capture_len = 0;
+							tev->_gap[0] = tev->_gap[1] = 0;
+							tev->daddr = 0;
+							tev->dport = 0;
 							__builtin_memset(tev->_pad2, 0, sizeof(tev->_pad2));
+							/* ORDER 1: resolve connected peer dst (best-effort). */
+							iouring_tls_resolve_peer(req, tev);
 							/*
 							 * AUDIT(5b/5f): submit only when the full payload
 							 * window was captured; a short/failed read discards

--- a/bpf/trace_connect_obs.h
+++ b/bpf/trace_connect_obs.h
@@ -313,7 +313,11 @@ _Static_assert(sizeof(struct io_uring_send_event) == 40,
  * in-BPF extension walk.
  *
  * Layout (alignment-of-8 from the leading __u64): 8 + 4 + 16 + 1 + 3 + 2 +
- * 256 + 6 = 296. The explicit _pad2[6] tail makes sizeof deterministic.
+ * 256 (payload) + 2 (_gap to 4-align daddr) + 4 (daddr) + 2 (dport) + 6 (_pad2)
+ * = 304. ORDER 1 (BG-5) added the connected-peer dst (resolved from req->file's
+ * socket) so the SNI joins its real destination instead of "unknown". The
+ * submission fd is not a member of io_kiocb in the kernels' BTF here, so it is
+ * not captured. The explicit padding makes sizeof deterministic.
  */
 struct io_uring_tls_event {
 	__u64 timestamp_ns;
@@ -323,10 +327,13 @@ struct io_uring_tls_event {
 	__u8 _pad[3];
 	__u16 capture_len; /* <= TLS_PAYLOAD_MAX */
 	__u8 payload[TLS_PAYLOAD_MAX];
+	__u8 _gap[2]; /* align daddr to a 4-byte boundary */
+	__be32 daddr; /* connected peer IPv4 (network byte order); 0 if unresolved */
+	__be16 dport; /* connected peer port (network byte order); 0 if unresolved */
 	__u8 _pad2[6];
 };
-_Static_assert(sizeof(struct io_uring_tls_event) == 296,
-	       "io_uring_tls_event wire size must match ioUringTLSEventWireSize=296 in agent_linux_decode.go");
+_Static_assert(sizeof(struct io_uring_tls_event) == 304,
+	       "io_uring_tls_event wire size must match ioUringTLSEventWireSize=304 in agent_linux_decode.go");
 
 static __always_inline int read_ipv4_sockaddr(unsigned long sockaddr_ptr, __be16 *port,
 					      __be32 *addr)

--- a/internal/agent/agent_linux_decode.go
+++ b/internal/agent/agent_linux_decode.go
@@ -264,14 +264,16 @@ func decodeBpfSelfDefenseEvent(raw []byte) (ts uint64, comm [16]byte, tgid, targ
 	return ts, comm, tgid, targetID, cmd, kind, true
 }
 
-// decodeIOUringTLSEvent parses io_uring_tls_event (296 bytes, see
+// decodeIOUringTLSEvent parses io_uring_tls_event (304 bytes, see
 // bpf/trace_connect_obs.h). Layout: ts(8) pid(4) comm(16) op(1) _pad(3)
-// capture_len(2, LE) payload(256) _pad2(6). capture_len is clamped to the
-// payload window so a corrupt length can never slice out of bounds; payload
-// is a sub-slice of raw (caller must not retain it past the ringbuf record).
-func decodeIOUringTLSEvent(raw []byte) (ts uint64, pid uint32, op uint8, payload []byte, comm [16]byte, ok bool) {
+// capture_len(2, LE) payload(256) _gap(2) daddr(4, BE) dport(2, BE) _pad2(6).
+// capture_len is clamped to the payload window so a corrupt length can never
+// slice out of bounds; payload is a sub-slice of raw (caller must not retain it
+// past the ringbuf record). daddr/dport are the connected IPv4 peer resolved in
+// kernel (network byte order); both 0 when unresolved.
+func decodeIOUringTLSEvent(raw []byte) (ts uint64, pid uint32, op uint8, payload []byte, comm [16]byte, daddr [4]byte, dport uint16, ok bool) {
 	if len(raw) < ioUringTLSEventWireSize {
-		return 0, 0, 0, nil, [16]byte{}, false
+		return 0, 0, 0, nil, [16]byte{}, [4]byte{}, 0, false
 	}
 	ts = binary.LittleEndian.Uint64(raw[0:8])
 	pid = binary.LittleEndian.Uint32(raw[8:12])
@@ -283,7 +285,10 @@ func decodeIOUringTLSEvent(raw []byte) (ts uint64, pid uint32, op uint8, payload
 	}
 	const payloadOff = 34
 	payload = raw[payloadOff : payloadOff+capLen]
-	return ts, pid, op, payload, comm, true
+	// daddr@292 (4, network byte order), dport@296 (2, network byte order).
+	copy(daddr[:], raw[292:296])
+	dport = binary.BigEndian.Uint16(raw[296:298])
+	return ts, pid, op, payload, comm, daddr, dport, true
 }
 
 // ioUringOpName maps the raw IORING_OP_ byte to the JSONL op string. Values

--- a/internal/agent/agent_linux_ring_read.go
+++ b/internal/agent/agent_linux_ring_read.go
@@ -1089,13 +1089,14 @@ func readBpfSelfDefenseRing(ctx context.Context, cfg config.Config, rd *ringbuf.
 // SNI via the same parser the syscall TLS sniffer uses (telemetry.ParseClientHelloSNI).
 // Returns emit=false when the payload does not parse as a ClientHello with a
 // server_name — the lightweight io_uring_send event already recorded the
-// has_tls_hello signal, so a parse miss is not a silent drop. Dst is always
-// "unknown": the io_uring submission path does not expose the destination.
+// has_tls_hello signal, so a parse miss is not a silent drop. ORDER 1 (BG-5):
+// Dst is the connected IPv4 peer resolved in kernel from the submission's socket
+// (req->file), or "unknown" when the socket peer was not resolvable.
 // seq may be 0 when the caller assigns the real sequence number later (the
 // reader allocates it under jsonlMu only after emit is known, so parse misses
 // do not burn JSONL sequence numbers).
 func ioUringTLSEventFromRaw(raw []byte, ts string, seq uint64) (telemetry.IOUringTLSEvent, bool) {
-	_, pid, op, payload, commb, ok := decodeIOUringTLSEvent(raw)
+	_, pid, op, payload, commb, daddr, dport, ok := decodeIOUringTLSEvent(raw)
 	if !ok {
 		return telemetry.IOUringTLSEvent{}, false
 	}
@@ -1103,15 +1104,20 @@ func ioUringTLSEventFromRaw(raw []byte, ts string, seq uint64) (telemetry.IOUrin
 	if !parsed || sni == "" {
 		return telemetry.IOUringTLSEvent{}, false
 	}
+	dst := "unknown"
+	if daddr != [4]byte{} {
+		dst = net.IPv4(daddr[0], daddr[1], daddr[2], daddr[3]).String()
+	}
 	return telemetry.IOUringTLSEvent{
-		Type: telemetry.EventTypeIOUringTLS,
-		TS:   ts,
-		Seq:  seq,
-		PID:  pid,
-		Comm: telemetry.SanitizeField(nullTermStr(commb[:]), 16),
-		Op:   ioUringOpName(op),
-		SNI:  telemetry.SanitizeField(sni, 253),
-		Dst:  "unknown",
+		Type:    telemetry.EventTypeIOUringTLS,
+		TS:      ts,
+		Seq:     seq,
+		PID:     pid,
+		Comm:    telemetry.SanitizeField(nullTermStr(commb[:]), 16),
+		Op:      ioUringOpName(op),
+		SNI:     telemetry.SanitizeField(sni, 253),
+		Dst:     dst,
+		DstPort: dport,
 	}, true
 }
 

--- a/internal/agent/agent_linux_state_sections.go
+++ b/internal/agent/agent_linux_state_sections.go
@@ -37,8 +37,8 @@ const (
 	ioUringSendEventWireSize = 40
 	// egress_backstop_event (sub-project A): 8(ts)+4(pid)+16(comm)+1(af)+1(ipproto)+2(_pad)+16(daddr)+2(dport)+6(_pad2) → 56
 	egressBackstopEventWireSize = 56
-	// io_uring_tls_event (P6 Phase 2.5): 8(ts)+4(pid)+16(comm)+1(op)+3(_pad)+2(capture_len)+256(payload)+6(_pad2) → 296
-	ioUringTLSEventWireSize = 296
+	// io_uring_tls_event (P6 Phase 2.5; ORDER 1 added dst): 8(ts)+4(pid)+16(comm)+1(op)+3(_pad)+2(capture_len)+256(payload)+2(_gap)+4(daddr)+2(dport)+6(_pad2) → 304
+	ioUringTLSEventWireSize = 304
 	ioUringTLSPayloadMax    = 256
 	// bpf_self_defense_event (sub-project B): 8(ts)+16(comm)+4(tgid)+4(target_id)+4(cmd)+1(target_kind)+3(_pad) → 40
 	bpfSelfDefenseEventWireSize = 40

--- a/internal/agent/decode_network_linux_test.go
+++ b/internal/agent/decode_network_linux_test.go
@@ -585,7 +585,7 @@ func TestDecodeIOUringTLSEvent_roundTrip(t *testing.T) {
 	binary.LittleEndian.PutUint16(raw[32:34], 5)
 	copy(raw[34:39], []byte{0x16, 0x03, 0x01, 0x00, 0x2f})
 
-	ts, pid, op, payload, comm, ok := decodeIOUringTLSEvent(raw)
+	ts, pid, op, payload, comm, _, _, ok := decodeIOUringTLSEvent(raw)
 	if !ok {
 		t.Fatal("expected ok=true")
 	}
@@ -604,7 +604,7 @@ func TestDecodeIOUringTLSEvent_capLenClamped(t *testing.T) {
 	// A corrupt capture_len larger than the payload window must clamp, not panic.
 	raw := make([]byte, ioUringTLSEventWireSize)
 	binary.LittleEndian.PutUint16(raw[32:34], 0xFFFF)
-	_, _, _, payload, _, ok := decodeIOUringTLSEvent(raw)
+	_, _, _, payload, _, _, _, ok := decodeIOUringTLSEvent(raw)
 	if !ok {
 		t.Fatal("expected ok=true")
 	}
@@ -614,9 +614,30 @@ func TestDecodeIOUringTLSEvent_capLenClamped(t *testing.T) {
 }
 
 func TestDecodeIOUringTLSEvent_tooShort(t *testing.T) {
-	_, _, _, _, _, ok := decodeIOUringTLSEvent(make([]byte, ioUringTLSEventWireSize-1))
+	_, _, _, _, _, _, _, ok := decodeIOUringTLSEvent(make([]byte, ioUringTLSEventWireSize-1))
 	if ok {
 		t.Fatal("expected ok=false for short input")
+	}
+}
+
+// ORDER 1 (BG-5): when the kernel resolved the connected peer, daddr/dport are
+// set and the event carries the real dst instead of "unknown".
+func TestIoUringTLSEventFromRaw_resolvesDst(t *testing.T) {
+	hello := buildSyntheticClientHello(t, "b.test")
+	raw := packIOUringTLSWire(t, 26, hello)
+	// daddr@292 = 93.184.216.34 (network byte order), dport@296 = 443 (BE).
+	copy(raw[292:296], []byte{93, 184, 216, 34})
+	binary.BigEndian.PutUint16(raw[296:298], 443)
+
+	ev, emit := ioUringTLSEventFromRaw(raw, "2026-06-09T00:00:00Z", 7)
+	if !emit {
+		t.Fatal("expected emit=true")
+	}
+	if ev.Dst != "93.184.216.34" || ev.DstPort != 443 {
+		t.Fatalf("dst=%q port=%d, want 93.184.216.34/443", ev.Dst, ev.DstPort)
+	}
+	if ev.SNI != "b.test" {
+		t.Fatalf("sni=%q", ev.SNI)
 	}
 }
 

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -651,8 +651,12 @@ type IOUringTLSEvent struct {
 	Comm string `json:"comm"`
 	Op   string `json:"op"` // "SEND" | "SENDMSG"
 	SNI  string `json:"sni"`
-	Dst  string `json:"dst"`
-	Sig  string `json:"sig,omitempty"`
+	// Dst is the connected IPv4 peer resolved in kernel from the submission's
+	// socket (ORDER 1 / BG-5), or "unknown" when unresolvable. DstPort is the
+	// peer port (host order), 0 when unresolved.
+	Dst     string `json:"dst"`
+	DstPort uint16 `json:"dst_port,omitempty"`
+	Sig     string `json:"sig,omitempty"`
 }
 
 // BPFAuditEvent is one JSONL record for a bpf(2) syscall audit event.


### PR DESCRIPTION
## ORDER 1: io_uring TLS destination correlation (BG-5)

`io_uring_tls` events hardcoded `Dst:"unknown"` — the SNI couldn't be joined to its peer. Resolve the connected IPv4 peer **in kernel** from the submission's socket (`req->file` -> `file->private_data` as `struct socket*` -> `sk` -> `skc_daddr`/`skc_dport`), reusing the **proven walk** from `trace_lsm_defend_iouring.inc`.

The submission fd is not a member of `io_kiocb` in the available BTF, so only the dst (not fd) is captured.

### Wire ABI
`io_uring_tls_event` grows 296 -> 304B (payload + _gap(2) + daddr(4) + dport(2) + _pad2(6)); the Go decoder + `ioUringTLSEventWireSize` move in lockstep (`_Static_assert` pins it). `IOUringTLSEvent` gains `dst_port`; `dst` is the real IP or `"unknown"` when unresolved — **non-regressing**.

### Validation
- Wire-decode unit tests incl. a real-dst case; gofmt/vet/staticcheck clean; `go build ./...` + agent/telemetry tests green; BPF compiles+verifies (`go generate`).
- End-to-end io_uring traffic is a **pre-existing repo-wide test gap** (`TestRedTeam_IoUringSend_RequiresIoUringHarness` skips for this reason) — the BPF walk is a proven copy and the change is non-regressing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
