### PR TITLE
chore(website): bump consumer pin to coldstep-io/coldstep@v0.5.2

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: coldstep-io/coldstep@v0.5.1
+      - uses: coldstep-io/coldstep@v0.5.2
 </code></pre>
             </div>
           </div>
@@ -116,7 +116,7 @@ jobs:
           <div class="inner">
             <h2 id="modes-heading">Two modes, one agent</h2>
             <p class="section-intro">
-              Pin a release tag (e.g. <code>coldstep-io/coldstep@v0.5.1</code>) rather than tracking
+              Pin a release tag (e.g. <code>coldstep-io/coldstep@v0.5.2</code>) rather than tracking
               <code>@main</code>. The legacy <code>enforce</code> mode string is rejected — use
               <code>defend</code>.
             </p>


### PR DESCRIPTION
Post-tag website follow-up for **v0.5.2** (the tag + `coldstep-linux-amd64` are live on Releases). Per `RELEASE_PROCESS.md`, `website/` pins are bumped only after the tag exists so the marketing site never shows a `uses:` pin for an unpublished tag.

- `website/index.html`: `coldstep-io/coldstep@v0.5.1` → `@v0.5.2` (both the example block and the inline pin note).

website-only; no `v0.5.1` references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)