### PR TITLE
feat: add consumer example workflows under examples/

### DIFF
--- a/examples/CONSUMER_GUIDE.md
+++ b/examples/CONSUMER_GUIDE.md
@@ -1,0 +1,81 @@
+# Consumer guide
+
+How to adopt **coldstep** in your own repository. This is the practical
+companion to the runnable workflows in this directory; for the authoritative
+input reference see the repo [`README.md`](../README.md) and
+[`QUICK_START.md`](../QUICK_START.md).
+
+## 1. Add the action
+
+One `uses:` block is all you need. The action is a node24 JavaScript action
+whose `pre` hook starts the agent before your build steps and whose `post` hook
+flushes the digest at job end.
+
+```yaml
+- uses: coldstep-io/coldstep@v0.5.3
+  with:
+    mode: detect
+    fail-on-error: true
+    log-level: info
+```
+
+Always pin a published tag (`@v0.5.3` or newer), never `@main`.
+
+## 2. Inputs you will actually use
+
+| Input | Default | Purpose |
+| :---- | :------ | :------ |
+| `mode` | `detect` | `detect` = observe only. `defend` = block non-allowlisted egress (requires a non-empty allowlist). |
+| `allow` | — | Allowlist entries (comma- or newline-separated): domains, wildcards, IPv4/CIDRs, and `!CIDR` ignore entries. |
+| `allow-file` | — | Path to a file with the same allowlist syntax, one entry per line. |
+| `detect-profile` | base | `enhanced` turns on richer event streams (process tree, TLS SNI, fs events). |
+| `report` | on | Controls the rendered job-summary / `.coldstep-report.md` output. |
+| `fail-on-error` | `false` | When `true`, the job fails if the agent cannot become operationally ready (not when policy denies traffic). |
+| `log-level` | `info` | Agent log verbosity. |
+| `no-default-ignored-nets` | `false` | When `true`, disables the implicit RFC1918 (private-range) ignores. |
+
+## 3. Allowlist syntax
+
+The allowlist is one unified model used by both `allow` and `allow-file`:
+
+```text
+registry.npmjs.org      # domain — resolved (A/AAAA) at startup
+*.githubusercontent.com # wildcard domain
+140.82.112.0/20         # IPv4 CIDR
+93.184.216.34           # single IPv4
+!10.0.0.0/8             # ignore entry — never blocked, never logged as denied
+```
+
+- **Domains** are resolved at startup into the effective IP allowlist. If a
+  domain resolves to many IPs, all are allowed.
+- **Loopback** (`127.0.0.0/8`, `::1`) and the runner's configured DNS resolvers
+  always bypass, so DNS itself is never broken by defend mode.
+- `defend` mode **requires** a non-empty effective allowlist; it refuses to
+  start otherwise.
+
+## 4. Roll out: detect → defend
+
+1. **Observe.** Adopt [`detect-basic.yml`](./detect-basic.yml). Run it on
+   several real builds.
+2. **Read the report.** The job summary and `.coldstep-report.md` list the
+   destinations your build reached. These are your allowlist candidates.
+3. **Author the allowlist.** Put the legitimate destinations into `allow` (or a
+   committed `allow-file`).
+4. **Enforce.** Switch `mode` to `defend` (see
+   [`defend-allowlist.yml`](./defend-allowlist.yml)). Watch the next few runs
+   for unexpected denials and adjust the allowlist.
+
+## 5. Reading the output
+
+- **Job summary** — a compact report written to the GitHub step summary.
+- **`.coldstep-report.md`** — the detailed Markdown report (upload it as an
+  artifact if you want to keep it).
+- **`.coldstep-events.jsonl`** — the append-only event stream (source of truth).
+- **`.coldstep-telemetry.json`** — totals + BPF health.
+
+## 6. Coverage and limits
+
+coldstep is honest about what it does and does not see. Detect-mode IPv6 is not
+observed; QUIC/HTTP3 inner framing, Unix sockets, and some io_uring paths are
+not blocked. See [`SECURITY.md → Coverage Boundaries`](../SECURITY.md#coverage-boundaries)
+for the full matrix and the threat model.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,31 @@
+# coldstep examples
+
+Copy-paste-ready consumer workflows for the
+[`coldstep-io/coldstep`](https://github.com/coldstep-io/coldstep) GitHub Action.
+All examples pin the published tag **`coldstep-io/coldstep@v0.5.3`** — pin a
+release tag, never `@main`.
+
+| File | Mode | What it shows |
+| :--- | :--- | :------------ |
+| [`detect-basic.yml`](./detect-basic.yml) | `detect` | Observe-only telemetry around a real `npm install express`. Nothing is blocked. |
+| [`defend-allowlist.yml`](./defend-allowlist.yml) | `defend` | Block all egress except `registry.npmjs.org` + `nodejs.org`, then run `npm install express`. |
+| [`CONSUMER_GUIDE.md`](./CONSUMER_GUIDE.md) | — | How to adopt coldstep in your own repo: inputs, allowlist syntax, rollout from detect → defend, and reading the report. |
+
+## How to use
+
+1. Copy a `.yml` file into `.github/workflows/` in your repository.
+2. Keep the pinned tag (`@v0.5.3`) or bump to a newer published release.
+3. Use **GitHub-hosted `ubuntu-latest`** — that is the only supported runner
+   for v1 (the agent is Linux/eBPF and needs the hosted kernel's BTF).
+
+## Detect first, then defend
+
+Start with `detect-basic.yml`. Let it run on a few builds and read the job
+summary / `.coldstep-report.md` to learn which destinations your build
+legitimately reaches. Promote those destinations into the `allow` list and
+switch to `defend-allowlist.yml` once the allowlist is complete. See
+[`CONSUMER_GUIDE.md`](./CONSUMER_GUIDE.md) for the full rollout.
+
+For coverage scope (what is and isn't blocked — QUIC, Unix sockets, io_uring,
+detect-mode IPv6) see the repo
+[`SECURITY.md → Coverage Boundaries`](../SECURITY.md#coverage-boundaries).

--- a/examples/defend-allowlist.yml
+++ b/examples/defend-allowlist.yml
@@ -1,0 +1,51 @@
+# Example: coldstep in defend mode (block non-allowlisted egress).
+#
+# Defend mode blocks IPv4 (and IPv6) TCP/UDP egress to destinations that are
+# not on the effective allowlist. A non-empty allowlist is REQUIRED — defend
+# mode refuses to start without one.
+#
+# The `allow` input below permits the two domains an `npm install` needs:
+#   - registry.npmjs.org  (package metadata + tarballs)
+#   - nodejs.org          (used by some packages for Node headers / binaries)
+#
+# Loopback (127.0.0.0/8, ::1) always bypasses, and the runner's configured DNS
+# resolvers are auto-allowed so DNS keeps working. Any egress to a domain/IP
+# NOT covered by the allowlist is dropped at the cgroup/LSM layer.
+#
+# Requirements: GitHub-hosted `ubuntu-latest` (see README → Requirements).
+
+name: defend-allowlist
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: coldstep-io/coldstep@v0.5.3
+        with:
+          mode: defend
+          # Allowlist: comma- or newline-separated domains, wildcards,
+          # IPv4/CIDRs, and `!CIDR` ignore entries. Domains are resolved
+          # (A/AAAA) at startup into the effective IP allowlist.
+          allow: |
+            registry.npmjs.org
+            nodejs.org
+          fail-on-error: true
+          log-level: info
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      # This install only touches allowlisted destinations, so it succeeds.
+      # Add a step that reaches some other host and defend mode will drop it.
+      - run: npm install express

--- a/examples/detect-basic.yml
+++ b/examples/detect-basic.yml
@@ -1,0 +1,41 @@
+# Example: coldstep in detect mode (observe-only).
+#
+# Drop this into `.github/workflows/` in a consumer repository. It starts the
+# coldstep agent before your build steps, runs a representative build
+# (`npm install express`), and flushes a telemetry digest at job end. Nothing
+# is blocked — detect mode only records IPv4 TCP/UDP egress and process
+# activity to JSONL + a job-summary report.
+#
+# Requirements: GitHub-hosted `ubuntu-latest` (see README → Requirements).
+
+name: detect-basic
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # One `uses:` block is all you need. The node24 pre-hook starts the
+      # agent before the steps below; the post-hook flushes the digest.
+      - uses: coldstep-io/coldstep@v0.5.3
+        with:
+          mode: detect          # default; shown here for clarity
+          fail-on-error: true   # fail the job if the agent cannot start
+          log-level: info
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      # Representative egress: npm reaches registry.npmjs.org to fetch express.
+      # In detect mode this is observed and logged, never blocked.
+      - run: npm install express


### PR DESCRIPTION
## What

Adds copy-paste-ready consumer usage examples under `examples/`, all pinned to the freshly published **`coldstep-io/coldstep@v0.5.3`**.

| File | Mode | Shows |
| :--- | :--- | :---- |
| `examples/detect-basic.yml` | `detect` | Observe-only telemetry around a real `npm install express`. |
| `examples/defend-allowlist.yml` | `defend` | Allow only `registry.npmjs.org` + `nodejs.org`, then `npm install express`. |
| `examples/README.md` | — | Index + detect-first rollout guidance. |
| `examples/CONSUMER_GUIDE.md` | — | Inputs, allowlist syntax, detect→defend rollout, reading the report. |

## Notes
- Files live under `examples/`, **not** `.github/workflows/`, so they are documentation, not CI jobs.
- Encoding check passes (UTF-8 / LF, 2-space YAML).

🤖 Generated with [Claude Code](https://claude.com/claude-code)