### PR TITLE
feat: add reproducible devcontainer + Makefile devshell

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,50 @@
+# Reproducible Linux dev environment for coldstep.
+#
+# Mirrors the toolchain that scripts/build-agent-linux.sh expects on a GitHub
+# ubuntu-latest runner: clang/llvm + libbpf-dev for the BPF compile path,
+# bpftool (via linux-tools-generic) for the vmlinux.h dump, kernel headers, and
+# a Go toolchain matching go.mod.
+#
+# BPF load/integration tests need a kernel with BTF (/sys/kernel/btf/vmlinux)
+# and CAP_BPF inside the container — see .devcontainer/devcontainer.json
+# (runArgs) and the `make devshell` target, both of which add --cap-add BPF.
+
+FROM ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+# Keep in lockstep with the `go` directive in go.mod.
+ARG GO_VERSION=1.25.11
+
+RUN apt-get update -qq \
+ && apt-get install -y -qq --no-install-recommends \
+      ca-certificates \
+      curl \
+      git \
+      make \
+      clang \
+      llvm \
+      libbpf-dev \
+      linux-tools-generic \
+      linux-headers-generic \
+      build-essential \
+      pkg-config \
+      python3 \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install the Go toolchain that matches go.mod (apt's golang-go lags behind).
+RUN arch="$(dpkg --print-architecture)" \
+ && case "$arch" in \
+      amd64) goarch=amd64 ;; \
+      arm64) goarch=arm64 ;; \
+      *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+    esac \
+ && curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${goarch}.tar.gz" -o /tmp/go.tgz \
+ && tar -C /usr/local -xzf /tmp/go.tgz \
+ && rm /tmp/go.tgz
+
+ENV PATH="/usr/local/go/bin:/root/go/bin:${PATH}"
+ENV GOTOOLCHAIN=auto
+
+WORKDIR /work
+
+CMD ["bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+  "name": "coldstep",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "workspaceFolder": "/work",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/work,type=bind",
+  "runArgs": [
+    "--cap-add=BPF",
+    "--cap-add=PERFMON",
+    "--cap-add=SYS_ADMIN",
+    "--security-opt",
+    "seccomp=unconfined"
+  ],
+  "remoteUser": "root",
+  "postCreateCommand": "go version && clang --version | head -1",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go"
+      ],
+      "settings": {
+        "go.toolsManagement.checkForUpdates": "off",
+        "go.useLanguageServer": true
+      }
+    }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+# coldstep developer convenience targets.
+#
+# The authoritative build is scripts/build-agent-linux.sh (Linux only). These
+# targets wrap the common loops. `make devshell` drops you into a reproducible
+# Ubuntu 24.04 container (.devcontainer/Dockerfile) with the full BPF toolchain
+# and a Go matching go.mod — the same bones as scripts/docker-linux-test.sh.
+
+DOCKER ?= docker
+DEVIMAGE ?= coldstep-dev
+ROOT := $(CURDIR)
+
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help: ## Show this help.
+	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
+		| awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: build
+build: ## Build bin/coldstep via scripts/build-agent-linux.sh (Linux host).
+	bash scripts/build-agent-linux.sh "$(ROOT)"
+
+.PHONY: test
+test: ## Run the Go unit tests (Linux host).
+	go test ./... -count=1
+
+.PHONY: devimage
+devimage: ## Build the .devcontainer dev image.
+	$(DOCKER) build -t $(DEVIMAGE) -f .devcontainer/Dockerfile .
+
+.PHONY: devshell
+devshell: devimage ## Open an interactive dev shell in the container (repo mounted at /work, CAP_BPF).
+	$(DOCKER) run --rm -it \
+		--cap-add BPF \
+		--cap-add PERFMON \
+		-v "$(ROOT):/work" \
+		-w /work \
+		-e GOTOOLCHAIN=auto \
+		$(DEVIMAGE) \
+		bash
+
+.PHONY: linux-test
+linux-test: ## Run the full Linux build + tests in a throwaway container.
+	bash scripts/docker-linux-test.sh "$(ROOT)"


### PR DESCRIPTION
## What

Adds a reproducible Linux dev environment that mirrors the toolchain `scripts/build-agent-linux.sh` expects on a GitHub `ubuntu-latest` runner.

### Files
- **`.devcontainer/Dockerfile`** — Ubuntu 24.04 + `clang`/`llvm` + `libbpf-dev` + `bpftool` (via `linux-tools-generic`) + kernel headers + a Go toolchain pinned to `go.mod` (1.25.11).
- **`.devcontainer/devcontainer.json`** — builds that image, bind-mounts the repo at `/work`, and adds `CAP_BPF`/`PERFMON` (+ `seccomp=unconfined`) so BPF load works inside the container.
- **`Makefile`** — `make devshell` builds the dev image and opens an interactive shell (repo at `/work`, `--cap-add BPF`), the same bones as `scripts/docker-linux-test.sh`. Also `build`, `test`, `devimage`, `linux-test`, and `help`.

### Notes
- `GO_VERSION` build arg is kept in lockstep with the `go` directive in `go.mod`.
- BPF integration tests still require a host kernel exposing BTF; the container adds the needed capabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)