### PR TITLE
feat: extract red-team probes into runnable redteam/ sandbox

### DIFF
--- a/.github/workflows/coldstep-redteam-ebpf.yml
+++ b/.github/workflows/coldstep-redteam-ebpf.yml
@@ -65,51 +65,9 @@ jobs:
           release-path: bin/coldstep
 
       - name: Red-team probes (Generate Telemetry)
-        run: |
-          set -euo pipefail
-          
-          echo "--- EXEC CANARY ---"
-          # Standard exec activity
-          ls /etc/passwd >/dev/null
-          # Integrity canary: JSONL exec events must match predicate comm=bash.
-          bash -c 'echo "redteam-bash-canary" >/dev/null'
-          
-          echo "--- UDP/DNS CANARY ---"
-          # Trigger the DNS canary (8.8.8.8)
-          dig @8.8.8.8 google.com +short >/dev/null || true
-          
-          echo "--- BPF AUDIT PROBE ---"
-          # Prefer real binary path so comm=bpftool matches integrity canaries (not a shell wrapper).
-          BPFTOOL_BIN="$(command -v bpftool || true)"
-          if [[ -z "${BPFTOOL_BIN}" && -x /usr/sbin/bpftool ]]; then BPFTOOL_BIN=/usr/sbin/bpftool; fi
-          if [[ -n "${BPFTOOL_BIN}" ]]; then
-            sudo "${BPFTOOL_BIN}" map show >/dev/null 2>&1 || echo "bpftool map show failed; best effort audit signal"
-            sudo "${BPFTOOL_BIN}" prog show >/dev/null 2>&1 || echo "bpftool prog show failed; best effort audit signal"
-            sudo "${BPFTOOL_BIN}" map show >/dev/null 2>&1 || true
-          else
-            echo "bpftool not found; skipping bpf audit probe"
-          fi
-          
-          echo "--- NETWORK EGRESS PROBE (TLS) ---"
-          # TLS connect (SNI: theclouddj.com); -4 so agent records IPv4 TLS (JSONL filters non-IPv4).
-          for _ in 1 2 3; do
-            curl -4 --http1.1 -s -I --max-time 8 https://theclouddj.com >/dev/null && break || true
-            sleep 1
-          done
-          # Second probe: OpenSSL often emits ClientHello in one write (helps when curl path misses SNI sniff).
-          if command -v openssl >/dev/null 2>&1; then
-            timeout 8 openssl s_client -4 -connect theclouddj.com:443 -servername theclouddj.com </dev/null >/dev/null 2>&1 || true
-          fi
-          
-          echo "--- FS EVENT PROBE ---"
-          # Filesystem events (glibc chmod uses fchmodat, which trace_fs hooks).
-          TMP_F=$(mktemp)
-          echo "redteam" > "${TMP_F}"
-          /bin/chmod 400 "${TMP_F}"
-          rm "${TMP_F}"
-
-          # Give ring readers time to drain telemetry before stop.
-          sleep 5
+        # Probe cases live in redteam/<case>/probe.sh (each with a README);
+        # run-all.sh runs them in order and drains the ring readers before stop.
+        run: bash redteam/run-all.sh theclouddj.com
       - name: Stop Coldstep (flush digest)
         uses: ./
         with:

--- a/redteam/README.md
+++ b/redteam/README.md
@@ -1,0 +1,56 @@
+# redteam — eBPF red-team probe sandbox
+
+A small, runnable sandbox of "attack" probes used to validate that coldstep
+actually captures the sensitive activity it claims to. Each case intentionally
+triggers a class of suspicious behavior (process exec, DNS/UDP egress, BPF
+introspection, TLS egress, filesystem permission changes) and the
+[`coldstep-redteam-ebpf`](../.github/workflows/coldstep-redteam-ebpf.yml)
+workflow asserts the events show up in `.coldstep-events.jsonl` with high
+integrity (the anti-blindness gate, `coldstep assert-integrity`).
+
+## Cases
+
+| Case | Signal | Probe |
+| :--- | :----- | :---- |
+| [`exec-canary`](./exec-canary) | arbitrary process exec | `ls`, `bash -c` (comm=bash integrity canary) |
+| [`udp-dns-canary`](./udp-dns-canary) | DNS / UDP egress | `dig @8.8.8.8` |
+| [`bpf-audit-probe`](./bpf-audit-probe) | BPF map/prog enumeration | `bpftool map/prog show` |
+| [`network-egress-tls`](./network-egress-tls) | outbound TLS data egress | `curl` + `openssl s_client` to an allowlisted host |
+| [`fs-event-probe`](./fs-event-probe) | filesystem permission change | `chmod` (fchmodat) on a temp file |
+
+Each case directory has a `probe.sh` (self-contained, runnable) and a
+`README.md` describing the attack signal and the expected coldstep behavior.
+
+## Running
+
+Run the whole suite (this is what the workflow calls):
+
+```bash
+bash redteam/run-all.sh                 # uses default TLS host theclouddj.com
+bash redteam/run-all.sh example.com     # forward a different allowlisted SNI
+```
+
+Or run a single case:
+
+```bash
+bash redteam/exec-canary/probe.sh
+```
+
+The probes are best-effort by design — a missing tool or a blocked egress
+attempt degrades gracefully, because the *attempt* is the telemetry signal.
+
+## Context
+
+The probes generate telemetry; the assertions live in two places:
+
+- **Workflow** — the `audit-validation` job in
+  [`coldstep-redteam-ebpf.yml`](../.github/workflows/coldstep-redteam-ebpf.yml)
+  starts coldstep (detect, enhanced profile), runs `redteam/run-all.sh`, stops
+  coldstep, and runs `coldstep assert-integrity` as the anti-blindness gate.
+- **Go integration tests** — the `redteam-integration` job runs the
+  `TestRedTeam_*` suite under `internal/agent`, which asserts coldstep surfaces
+  the security-review attack paths as JSONL events / deny behavior.
+
+> These probes are deliberately benign (they touch only public hosts, the local
+> temp dir, and read-only BPF introspection). They exist to test the monitor,
+> not to cause harm.

--- a/redteam/bpf-audit-probe/README.md
+++ b/redteam/bpf-audit-probe/README.md
@@ -1,0 +1,20 @@
+# BPF audit probe
+
+**Attack signal:** an attacker enumerating or tampering with loaded BPF
+maps/programs (e.g. to find and detach the monitor).
+
+**Probe:** `sudo bpftool map show` / `prog show` to introspect kernel BPF state.
+
+**Expected coldstep behavior:** the privileged BPF introspection syscalls are
+surfaced by the bpf-audit hook (`bpf_syscall_audit` telemetry). The probe
+resolves a concrete `bpftool` binary so the recorded `comm` is `bpftool`, which
+the integrity canaries match on. All calls are best-effort — a missing or
+wrapper `bpftool` degrades gracefully.
+
+**Requires:** `bpftool` (Debian/Ubuntu: `linux-tools-*`) and `sudo`.
+
+Run it standalone:
+
+```bash
+bash redteam/bpf-audit-probe/probe.sh
+```

--- a/redteam/bpf-audit-probe/probe.sh
+++ b/redteam/bpf-audit-probe/probe.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Red-team case: BPF audit probe.
+#
+# Enumerates loaded BPF maps/programs with bpftool. coldstep's bpf-audit hook
+# should surface these privileged BPF introspection syscalls. Prefers the real
+# bpftool binary path so the recorded comm is `bpftool` (not a shell wrapper),
+# which the integrity canaries match on.
+set -euo pipefail
+
+echo "--- BPF AUDIT PROBE ---"
+# Prefer real binary path so comm=bpftool matches integrity canaries (not a shell wrapper).
+BPFTOOL_BIN="$(command -v bpftool || true)"
+if [[ -z "${BPFTOOL_BIN}" && -x /usr/sbin/bpftool ]]; then BPFTOOL_BIN=/usr/sbin/bpftool; fi
+if [[ -n "${BPFTOOL_BIN}" ]]; then
+	sudo "${BPFTOOL_BIN}" map show >/dev/null 2>&1 || echo "bpftool map show failed; best effort audit signal"
+	sudo "${BPFTOOL_BIN}" prog show >/dev/null 2>&1 || echo "bpftool prog show failed; best effort audit signal"
+	sudo "${BPFTOOL_BIN}" map show >/dev/null 2>&1 || true
+else
+	echo "bpftool not found; skipping bpf audit probe"
+fi

--- a/redteam/exec-canary/README.md
+++ b/redteam/exec-canary/README.md
@@ -1,0 +1,17 @@
+# exec canary
+
+**Attack signal:** arbitrary process execution inside the CI job.
+
+**Probe:** runs `ls /etc/passwd` and a `bash -c` one-liner that emits the
+`redteam-bash-canary` marker.
+
+**Expected coldstep behavior (detect mode):** an `exec` event appears in
+`.coldstep-events.jsonl` for the spawned processes. The `bash` invocation is a
+mandatory integrity canary — `coldstep assert-integrity` fails the job if no
+`exec` event with `comm=bash` is present (anti-blindness gate).
+
+Run it standalone:
+
+```bash
+bash redteam/exec-canary/probe.sh
+```

--- a/redteam/exec-canary/probe.sh
+++ b/redteam/exec-canary/probe.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Red-team case: exec canary.
+#
+# Generates process-exec activity that coldstep's exec tracepoint must capture
+# as `exec` JSONL events. The `redteam-bash-canary` line is an integrity canary
+# matched on the predicate comm=bash by `coldstep assert-integrity`.
+set -euo pipefail
+
+echo "--- EXEC CANARY ---"
+# Standard exec activity.
+ls /etc/passwd >/dev/null
+# Integrity canary: JSONL exec events must match predicate comm=bash.
+bash -c 'echo "redteam-bash-canary" >/dev/null'

--- a/redteam/fs-event-probe/README.md
+++ b/redteam/fs-event-probe/README.md
@@ -1,0 +1,19 @@
+# filesystem event probe
+
+**Attack signal:** filesystem permission changes (e.g. making a dropped
+payload executable, or restricting a file to hide it).
+
+**Probe:** creates a temp file, runs `chmod 400` on it, then removes it. glibc's
+`chmod` is implemented via `fchmodat`, which coldstep's `trace_fs` hook
+captures.
+
+**Expected coldstep behavior (enhanced detect profile):** an `fs_event` appears
+in `.coldstep-events.jsonl` for the `chmod`. Note the agent caps `fs_event`
+output (≈5k lines), so heavy apt/dpkg activity should be done *before* coldstep
+starts to avoid exhausting the cap before this canary fires.
+
+Run it standalone:
+
+```bash
+bash redteam/fs-event-probe/probe.sh
+```

--- a/redteam/fs-event-probe/probe.sh
+++ b/redteam/fs-event-probe/probe.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Red-team case: filesystem event probe.
+#
+# Creates a temp file and chmods it. glibc's chmod uses fchmodat, which
+# coldstep's trace_fs hook captures as an fs_event. Exercises the fs_event
+# JSONL stream (enhanced detect profile).
+set -euo pipefail
+
+echo "--- FS EVENT PROBE ---"
+# Filesystem events (glibc chmod uses fchmodat, which trace_fs hooks).
+TMP_F=$(mktemp)
+echo "redteam" > "${TMP_F}"
+/bin/chmod 400 "${TMP_F}"
+rm "${TMP_F}"

--- a/redteam/network-egress-tls/README.md
+++ b/redteam/network-egress-tls/README.md
@@ -1,0 +1,21 @@
+# network egress (TLS)
+
+**Attack signal:** outbound TLS connection to an external host (data egress).
+
+**Probe:** connects to an allowlisted host over TLS via `curl` (HTTP/1.1) and
+then `openssl s_client`. The two clients fragment the ClientHello differently,
+exercising both of coldstep's SNI-sniff paths. Pass a host as the first
+argument; defaults to `theclouddj.com` (the host the red-team workflow
+allowlists in its `start` step).
+
+**Expected coldstep behavior (detect mode):** an IPv4 `tls` event with the
+target SNI appears in `.coldstep-events.jsonl`. In defend mode, the same host
+must be on the allowlist or the connection is dropped.
+
+**Requires:** `curl` (and optionally `openssl`).
+
+Run it standalone:
+
+```bash
+bash redteam/network-egress-tls/probe.sh theclouddj.com
+```

--- a/redteam/network-egress-tls/probe.sh
+++ b/redteam/network-egress-tls/probe.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Red-team case: network egress (TLS).
+#
+# Opens TLS connections to an allowlisted host so coldstep records IPv4 TLS
+# egress and (best-effort) extracts the SNI. Two client paths are used because
+# they fragment the ClientHello differently: curl, then openssl s_client (which
+# tends to emit the ClientHello in a single write, helping the SNI sniff).
+#
+# The target host is passed as $1 (default: theclouddj.com) so the same script
+# works for any allowlisted SNI.
+set -euo pipefail
+
+HOST="${1:-theclouddj.com}"
+
+echo "--- NETWORK EGRESS PROBE (TLS) -> ${HOST} ---"
+# TLS connect; -4 so agent records IPv4 TLS (JSONL filters non-IPv4).
+for _ in 1 2 3; do
+	curl -4 --http1.1 -s -I --max-time 8 "https://${HOST}" >/dev/null && break || true
+	sleep 1
+done
+# Second probe: OpenSSL often emits ClientHello in one write (helps when curl path misses SNI sniff).
+if command -v openssl >/dev/null 2>&1; then
+	timeout 8 openssl s_client -4 -connect "${HOST}:443" -servername "${HOST}" </dev/null >/dev/null 2>&1 || true
+fi

--- a/redteam/run-all.sh
+++ b/redteam/run-all.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Run every red-team probe case in order, then pause so the agent's ring
+# readers can drain telemetry before coldstep is stopped.
+#
+# This is what the coldstep-redteam-ebpf workflow invokes for its
+# "Red-team probes" step. Each case is a self-contained probe.sh; see the
+# per-case README.md for what it exercises and the expected coldstep behavior.
+#
+# Usage:
+#   bash redteam/run-all.sh [tls-host]
+#
+# tls-host (optional) is forwarded to the network-egress-tls case
+# (default: theclouddj.com).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TLS_HOST="${1:-theclouddj.com}"
+
+bash "${HERE}/exec-canary/probe.sh"
+bash "${HERE}/udp-dns-canary/probe.sh"
+bash "${HERE}/bpf-audit-probe/probe.sh"
+bash "${HERE}/network-egress-tls/probe.sh" "${TLS_HOST}"
+bash "${HERE}/fs-event-probe/probe.sh"
+
+# Give ring readers time to drain telemetry before stop.
+sleep 5

--- a/redteam/udp-dns-canary/README.md
+++ b/redteam/udp-dns-canary/README.md
@@ -1,0 +1,18 @@
+# UDP / DNS canary
+
+**Attack signal:** DNS exfiltration / unexpected UDP egress.
+
+**Probe:** `dig @8.8.8.8 google.com` — a DNS query to a public resolver.
+
+**Expected coldstep behavior (detect mode):** a UDP egress event (and DNS
+telemetry under the enhanced profile) is recorded in `.coldstep-events.jsonl`.
+The probe is best-effort (`|| true`) — the outbound attempt is what matters,
+not whether the resolver answers.
+
+**Requires:** `dig` (Debian/Ubuntu package `dnsutils`).
+
+Run it standalone:
+
+```bash
+bash redteam/udp-dns-canary/probe.sh
+```

--- a/redteam/udp-dns-canary/probe.sh
+++ b/redteam/udp-dns-canary/probe.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Red-team case: UDP / DNS canary.
+#
+# Sends a DNS query to a public resolver (8.8.8.8) so coldstep records a UDP
+# egress / DNS event. Best-effort: the query may be blocked or time out in
+# restricted environments, which is fine — the egress attempt is the signal.
+set -euo pipefail
+
+echo "--- UDP/DNS CANARY ---"
+# Trigger the DNS canary (8.8.8.8).
+dig @8.8.8.8 google.com +short >/dev/null || true


### PR DESCRIPTION
## What

Lifts the inline "Red-team probes" bash block out of `.github/workflows/coldstep-redteam-ebpf.yml` into a self-contained, documented, runnable sandbox under `redteam/`.

### Cases (each a `probe.sh` + `README.md`)
| Case | Signal |
| :--- | :----- |
| `redteam/exec-canary` | arbitrary process exec (comm=bash integrity canary) |
| `redteam/udp-dns-canary` | DNS / UDP egress (`dig @8.8.8.8`) |
| `redteam/bpf-audit-probe` | BPF map/prog enumeration (`bpftool`) |
| `redteam/network-egress-tls` | outbound TLS egress (`curl` + `openssl`) |
| `redteam/fs-event-probe` | filesystem permission change (`chmod`/fchmodat) |

- `redteam/run-all.sh` runs all cases in order and drains the ring readers before stop. TLS host is a parameter (default `theclouddj.com`).
- `redteam/README.md` indexes the cases and explains how the workflow + the `TestRedTeam_*` Go suite consume them.

### Workflow change
The `audit-validation` job's "Red-team probes" step now runs `bash redteam/run-all.sh theclouddj.com` instead of ~45 inline lines. **Behavior is identical** — the script is a verbatim extraction.

### Notes
- Probe scripts are committed executable (mode 100755).
- The red-team workflow triggers on push to `dev` / `workflow_dispatch`, so it won't run on this PR; the change is a behavior-preserving extraction validated by YAML parse + the standard CI suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)