### PR TITLE
ci: factor runner-compat detect harness into a composite action

### DIFF
--- a/.github/actions/detect-assertion-harness/action.yml
+++ b/.github/actions/detect-assertion-harness/action.yml
@@ -1,0 +1,64 @@
+name: "Coldstep detect-mode assertion harness"
+description: >-
+  Shared detect-mode harness for the runner-compat matrix: builds the Linux
+  agent, starts coldstep in detect mode, runs a variant-specific load, stops
+  coldstep, asserts event flow + readiness, and uploads the per-variant
+  artifacts. Keeps the four runner-compat jobs from duplicating the same
+  start/stop/assert/upload block. The calling job owns checkout, setup-go,
+  and any services:/env: it needs.
+
+inputs:
+  variant:
+    description: "Variant name (used for the assert step and artifact name)."
+    required: true
+  load-script:
+    description: >-
+      Variant-specific load shell run between start and stop. Should be
+      best-effort (the harness, not the load, is what is under test).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Build Linux agent
+      shell: bash
+      run: bash scripts/build-agent-linux.sh "${GITHUB_WORKSPACE}"
+
+    - name: Start Coldstep (detect)
+      uses: ./
+      with:
+        phase: start
+        mode: detect
+        detect-profile: enhanced
+        fail-on-error: 'true'
+        release-path: bin/coldstep
+        allow: |
+          *.ubuntu.com
+          theclouddj.com
+
+    - name: Variant load — ${{ inputs.variant }}
+      shell: bash
+      run: ${{ inputs.load-script }}
+
+    - name: Stop Coldstep
+      uses: ./
+      with:
+        phase: stop
+        report: none
+        fail-on-error: 'false'
+
+    - name: Assert event stream + readiness
+      shell: bash
+      run: bash .github/workflows/scripts/runner-compat-assert.sh "${{ inputs.variant }}"
+
+    - name: Upload variant artifacts
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      with:
+        name: coldstep-runner-compat-${{ inputs.variant }}
+        path: |
+          ${{ github.workspace }}/.coldstep-events.jsonl
+          ${{ github.workspace }}/.coldstep-telemetry.json
+          ${{ github.workspace }}/.coldstep-ready.json
+          ${{ github.workspace }}/.coldstep-report.md
+        if-no-files-found: warn

--- a/.github/workflows/coldstep-runner-compat.yml
+++ b/.github/workflows/coldstep-runner-compat.yml
@@ -18,6 +18,11 @@
 # image strings), and `continue-on-error: true` on every variant keeps one
 # failure from cancelling the rest. The aggregate job reads `needs.*.result`
 # and converts per-variant results into the final pass/fail signal.
+#
+# The build/start/load/stop/assert/upload block that every variant shares is
+# factored into the local composite action
+# `.github/actions/detect-assertion-harness`; each job here owns only its
+# checkout, setup-go, services:/env:, and the variant-specific load script.
 
 name: coldstep-runner-compat
 
@@ -46,42 +51,13 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
-      - name: Build Linux agent
-        run: bash scripts/build-agent-linux.sh "${GITHUB_WORKSPACE}"
-      - name: Start Coldstep (detect)
-        uses: ./
+      - name: Detect-mode harness — vanilla
+        uses: ./.github/actions/detect-assertion-harness
         with:
-          phase: start
-          mode: detect
-          detect-profile: enhanced
-          fail-on-error: 'true'
-          release-path: bin/coldstep
-          allow: |
-            *.ubuntu.com
-            theclouddj.com
-      - name: Variant load — vanilla
-        run: |
-          set -euo pipefail
-          curl -4 -fsS --max-time 10 https://archive.ubuntu.com/ >/dev/null || true
-      - name: Stop Coldstep
-        uses: ./
-        with:
-          phase: stop
-          report: none
-          fail-on-error: 'false'
-      - name: Assert event stream + readiness
-        run: bash .github/workflows/scripts/runner-compat-assert.sh vanilla
-      - name: Upload variant artifacts
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: coldstep-runner-compat-vanilla
-          path: |
-            ${{ github.workspace }}/.coldstep-events.jsonl
-            ${{ github.workspace }}/.coldstep-telemetry.json
-            ${{ github.workspace }}/.coldstep-ready.json
-            ${{ github.workspace }}/.coldstep-report.md
-          if-no-files-found: warn
+          variant: vanilla
+          load-script: |
+            set -euo pipefail
+            curl -4 -fsS --max-time 10 https://archive.ubuntu.com/ >/dev/null || true
 
   dind:
     name: dind
@@ -99,46 +75,17 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
-      - name: Build Linux agent
-        run: bash scripts/build-agent-linux.sh "${GITHUB_WORKSPACE}"
-      - name: Start Coldstep (detect)
-        uses: ./
+      - name: Detect-mode harness — dind
+        uses: ./.github/actions/detect-assertion-harness
         with:
-          phase: start
-          mode: detect
-          detect-profile: enhanced
-          fail-on-error: 'true'
-          release-path: bin/coldstep
-          allow: |
-            *.ubuntu.com
-            theclouddj.com
-      - name: Variant load — dind probe
-        run: |
-          set -euo pipefail
-          # Reach the dind sidecar from the runner. The probe is best-effort:
-          # the goal here is exercising cgroup egress against a service
-          # container, not validating dind itself.
-          timeout 10 bash -c 'until nc -z -w1 docker 2375; do sleep 1; done' || true
-          curl -4 -fsS --max-time 10 https://archive.ubuntu.com/ >/dev/null || true
-      - name: Stop Coldstep
-        uses: ./
-        with:
-          phase: stop
-          report: none
-          fail-on-error: 'false'
-      - name: Assert event stream + readiness
-        run: bash .github/workflows/scripts/runner-compat-assert.sh dind
-      - name: Upload variant artifacts
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: coldstep-runner-compat-dind
-          path: |
-            ${{ github.workspace }}/.coldstep-events.jsonl
-            ${{ github.workspace }}/.coldstep-telemetry.json
-            ${{ github.workspace }}/.coldstep-ready.json
-            ${{ github.workspace }}/.coldstep-report.md
-          if-no-files-found: warn
+          variant: dind
+          load-script: |
+            set -euo pipefail
+            # Reach the dind sidecar from the runner. The probe is best-effort:
+            # the goal here is exercising cgroup egress against a service
+            # container, not validating dind itself.
+            timeout 10 bash -c 'until nc -z -w1 docker 2375; do sleep 1; done' || true
+            curl -4 -fsS --max-time 10 https://archive.ubuntu.com/ >/dev/null || true
 
   buildkit:
     name: buildkit
@@ -153,47 +100,18 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
-      - name: Build Linux agent
-        run: bash scripts/build-agent-linux.sh "${GITHUB_WORKSPACE}"
-      - name: Start Coldstep (detect)
-        uses: ./
+      - name: Detect-mode harness — buildkit
+        uses: ./.github/actions/detect-assertion-harness
         with:
-          phase: start
-          mode: detect
-          detect-profile: enhanced
-          fail-on-error: 'true'
-          release-path: bin/coldstep
-          allow: |
-            *.ubuntu.com
-            theclouddj.com
-      - name: Variant load — BuildKit build
-        run: |
-          set -euo pipefail
-          mkdir -p /tmp/buildkit-ctx
-          cat >/tmp/buildkit-ctx/Dockerfile <<'EOF'
-          FROM alpine:3.20
-          RUN echo coldstep-buildkit-compat
-          EOF
-          DOCKER_BUILDKIT=1 docker build -t coldstep-buildkit-compat:latest /tmp/buildkit-ctx || true
-      - name: Stop Coldstep
-        uses: ./
-        with:
-          phase: stop
-          report: none
-          fail-on-error: 'false'
-      - name: Assert event stream + readiness
-        run: bash .github/workflows/scripts/runner-compat-assert.sh buildkit
-      - name: Upload variant artifacts
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: coldstep-runner-compat-buildkit
-          path: |
-            ${{ github.workspace }}/.coldstep-events.jsonl
-            ${{ github.workspace }}/.coldstep-telemetry.json
-            ${{ github.workspace }}/.coldstep-ready.json
-            ${{ github.workspace }}/.coldstep-report.md
-          if-no-files-found: warn
+          variant: buildkit
+          load-script: |
+            set -euo pipefail
+            mkdir -p /tmp/buildkit-ctx
+            cat >/tmp/buildkit-ctx/Dockerfile <<'EOF'
+            FROM alpine:3.20
+            RUN echo coldstep-buildkit-compat
+            EOF
+            DOCKER_BUILDKIT=1 docker build -t coldstep-buildkit-compat:latest /tmp/buildkit-ctx || true
 
   service-containers:
     name: service-containers
@@ -217,43 +135,14 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
-      - name: Build Linux agent
-        run: bash scripts/build-agent-linux.sh "${GITHUB_WORKSPACE}"
-      - name: Start Coldstep (detect)
-        uses: ./
+      - name: Detect-mode harness — service-containers
+        uses: ./.github/actions/detect-assertion-harness
         with:
-          phase: start
-          mode: detect
-          detect-profile: enhanced
-          fail-on-error: 'true'
-          release-path: bin/coldstep
-          allow: |
-            *.ubuntu.com
-            theclouddj.com
-      - name: Variant load — postgres query
-        run: |
-          set -euo pipefail
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq postgresql-client
-          PGPASSWORD=coldstep-compat psql -h localhost -U postgres -c 'SELECT 1;' || true
-      - name: Stop Coldstep
-        uses: ./
-        with:
-          phase: stop
-          report: none
-          fail-on-error: 'false'
-      - name: Assert event stream + readiness
-        run: bash .github/workflows/scripts/runner-compat-assert.sh service-containers
-      - name: Upload variant artifacts
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: coldstep-runner-compat-service-containers
-          path: |
-            ${{ github.workspace }}/.coldstep-events.jsonl
-            ${{ github.workspace }}/.coldstep-telemetry.json
-            ${{ github.workspace }}/.coldstep-ready.json
-            ${{ github.workspace }}/.coldstep-report.md
-          if-no-files-found: warn
+          variant: service-containers
+          load-script: |
+            set -euo pipefail
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq postgresql-client
+            PGPASSWORD=coldstep-compat psql -h localhost -U postgres -c 'SELECT 1;' || true
 
   aggregate:
     name: aggregate


### PR DESCRIPTION
## What

The four `coldstep-runner-compat.yml` variant jobs each duplicated the same block:

```
build agent -> start (detect) -> variant load -> stop -> assert -> upload
```

differing only in `services:`/`env:` and the variant load script. This extracts that block into a local composite action `.github/actions/detect-assertion-harness`. Each job now keeps just its checkout, setup-go, `services:`/`env:`, and a `load-script` input.

## No behavior change

Same matrix coverage (vanilla, dind, buildkit, service-containers), same `allow` list, same `detect-profile: enhanced`, same `runner-compat-assert.sh` assertions, same artifact set. The aggregate job is unchanged.

## On the kernel-matrix workflow

The plan framed this as consolidating **kernel-matrix + runner-compat**. On inspection, `coldstep-kernel-matrix.yml` shares **no** detect-mode assertion steps with runner-compat — it builds the agent and runs the unit + integration test suites; it never starts coldstep in detect mode or asserts event flow. There is nothing in it for this harness to replace, so it is intentionally left untouched. The real (and only) duplication was the four runner-compat jobs.

## Verification

- `yaml.safe_load` parses both the workflow and the composite cleanly.
- runner-compat is a scheduled/dispatch workflow (not part of PR CI), so it is verified by a `workflow_dispatch` run on this branch (see PR checks / linked run) before merge.

Phase 4.2 of the simplification plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)