### PR TITLE
chore(defend): resolve missing-map TODOs in defend loader

### DIFF
--- a/internal/agent/agent_linux_policy_maps.go
+++ b/internal/agent/agent_linux_policy_maps.go
@@ -193,11 +193,10 @@ func readPartialEgressCounts(m *ebpf.Map) (sendfile, splice, sendmmsg int) {
 
 // readIPv6ConnectObservedCount returns the per-CPU sum of the
 // ipv6_connect_observed counter populated by the cgroup/connect6
-// observe-only hook (P0-1 Phase 1). Returns 0 when the map is absent
-// (stubs predate the regeneration on Linux).
-// TODO: wire to defend objects after regeneration on Linux — this is a
-// no-op until defendObjs.Ipv6ConnectObserved is populated by the
-// generated bindings.
+// observe-only hook (P0-1 Phase 1). ipv6_connect_observed is
+// unconditionally compiled into the cgroup section and required
+// fail-closed by the loader, so objs.Ipv6ConnectObserved is non-nil
+// whenever defend loaded.
 func readIPv6ConnectObservedCount(objs *defend.DefendObjects) uint32 {
 	if objs == nil {
 		return 0
@@ -206,8 +205,10 @@ func readIPv6ConnectObservedCount(objs *defend.DefendObjects) uint32 {
 }
 
 // readIPv6SendmsgObservedCount mirrors readIPv6ConnectObservedCount for
-// the cgroup/sendmsg6 observe-only hook (P0-1 Phase 1).
-// TODO: wire to defend objects after regeneration on Linux.
+// the cgroup/sendmsg6 observe-only hook (P0-1 Phase 1). ipv6_sendmsg_observed
+// is unconditionally compiled into the cgroup section and required
+// fail-closed by the loader, so objs.Ipv6SendmsgObserved is non-nil
+// whenever defend loaded.
 func readIPv6SendmsgObservedCount(objs *defend.DefendObjects) uint32 {
 	if objs == nil {
 		return 0
@@ -220,10 +221,10 @@ func readIPv6SendmsgObservedCount(objs *defend.DefendObjects) uint32 {
 // kernel-5.15 sendfile(2)/splice(2) egress gap (sock_sendpage path skips
 // cgroup/sendmsg4 and lsm/socket_sendmsg); non-zero values mean sendfile or
 // splice fired in defend mode and was gated against the IPv4 allowlist.
-// Returns 0 when the map is absent (stubs predate the regeneration on Linux
-// or LSM was disabled at load time).
-// TODO: remove the missing-map tolerance once defend objects are regenerated
-// on Linux with bpf/trace_lsm_defend_lsm.inc's sendpage_observed map.
+// Returns 0 when the map is absent — a permanent runtime state, not a stale
+// stub: kernel 6.5+ removed the socket_sendpage LSM hook (so
+// LoadDefendObjectsForKernel strips the map) and the map is likewise absent
+// when LSM was disabled at load time.
 func readSendpageObservedCount(objs *defend.DefendObjects) uint32 {
 	if objs == nil {
 		return 0

--- a/internal/bpf/defend/loader.go
+++ b/internal/bpf/defend/loader.go
@@ -183,11 +183,13 @@ func LoadDefendObjectsForKernel(obj *DefendObjects, wantLSM, wantIOUringLSM bool
 		}
 	}
 
-	// P0-1 Phase 1: IPv6 observe counters. Optional in older generated
-	// stubs; tolerate absence so the cgroup IPv4 path keeps loading.
-	// TODO: remove the missing-map tolerance once defend objects are
-	// regenerated on Linux with bpf/trace_defend_cgroup.inc's
-	// ipv6_connect_observed / ipv6_sendmsg_observed maps.
+	// P0-1 Phase 1: IPv6 observe-only counters. Unconditionally compiled into
+	// the cgroup section by bpf/trace_defend_cgroup.inc (no #if guard), so they
+	// are always present whenever the cgroup IPv4 path loads — the cgroup
+	// section is never stripped (only the LSM section is, on kernels without
+	// CONFIG_BPF_LSM). Require them fail-closed: a missing one means the
+	// embedded ELF is stale or corrupted, matching the allowed_ipv4 /
+	// allowed_ipv6 posture below.
 	cgIPv6Maps := []struct {
 		name string
 		dst  **ebpf.Map
@@ -196,7 +198,9 @@ func LoadDefendObjectsForKernel(obj *DefendObjects, wantLSM, wantIOUringLSM bool
 		{"ipv6_sendmsg_observed", &obj.Ipv6SendmsgObserved},
 	}
 	for _, m := range cgIPv6Maps {
-		detachMapIfPresent(coll, m.name, m.dst)
+		if err := detachMap(coll, m.name, m.dst); err != nil {
+			return LoadResult{}, err
+		}
 	}
 
 	// IPv6 enforcement allowlist trie (H14, v0.4.0): allowed_ipv6 is always
@@ -259,12 +263,11 @@ func LoadDefendObjectsForKernel(obj *DefendObjects, wantLSM, wantIOUringLSM bool
 		}
 
 		// Sendfile/splice gap (kernel 5.15): lsm/socket_sendpage and its
-		// observe-only counter. Optional in older generated stubs; tolerate
-		// absence so existing LSM-enabled kernels still load the connect +
-		// sendmsg path.
-		// TODO: remove the missing-program tolerance once defend objects are
-		// regenerated on Linux with bpf/trace_lsm_defend_lsm.inc's
-		// lsm_socket_sendpage section and sendpage_observed map.
+		// observe-only counter. The tolerance here is permanent, not a stale
+		// stub: LoadDefendObjectsForKernel deletes lsm_socket_sendpage and
+		// sendpage_observed from the spec on kernel 6.5+ (which removed the
+		// socket_sendpage LSM hook) and whenever the LSM section is stripped,
+		// so their absence at this point is expected and must not fail the load.
 		detachProgramIfPresent(coll, "lsm_socket_sendpage", &obj.LsmSocketSendpage)
 		detachMapIfPresent(coll, "sendpage_observed", &obj.SendpageObserved)
 

--- a/internal/bpf/defend/loader_failclosed_test.go
+++ b/internal/bpf/defend/loader_failclosed_test.go
@@ -36,10 +36,15 @@ func TestIPv6EnforcementSymbolsInSpec(t *testing.T) {
 		}
 	}
 
-	if _, ok := spec.Maps["allowed_ipv6"]; !ok {
-		t.Errorf("IPv6 enforcement map \"allowed_ipv6\" missing from CollectionSpec; " +
-			"LoadDefendObjectsForKernel will now fail-closed on absence — " +
-			"regenerate BPF objects via go generate ./internal/bpf/defend/")
+	// allowed_ipv6 (H14 enforcement) plus the cgroup IPv6 observe-only counters
+	// are all required fail-closed by LoadDefendObjectsForKernel — they are
+	// unconditionally compiled into the cgroup section, which is never stripped.
+	for _, name := range []string{"allowed_ipv6", "ipv6_connect_observed", "ipv6_sendmsg_observed"} {
+		if _, ok := spec.Maps[name]; !ok {
+			t.Errorf("required cgroup IPv6 map %q missing from CollectionSpec; "+
+				"LoadDefendObjectsForKernel will now fail-closed on absence — "+
+				"regenerate BPF objects via go generate ./internal/bpf/defend/", name)
+		}
 	}
 }
 


### PR DESCRIPTION
## What

Resolves the three `// TODO: remove ... tolerance once defend objects are regenerated on Linux` comments in the defend loader by distinguishing **genuinely stale** tolerance from **permanent kernel-compat** tolerance.

### Fail-closed: cgroup IPv6 observe counters
`ipv6_connect_observed` / `ipv6_sendmsg_observed` are unconditionally compiled into `bpf/trace_defend_cgroup.inc` (no `#if` guard), and the cgroup section is never stripped (only the LSM section is, on kernels without `CONFIG_BPF_LSM`). So they are always present whenever defend loads.

- `internal/bpf/defend/loader.go`: `detachMapIfPresent` → `detachMap` (fail-closed), matching the `allowed_ipv4` / `allowed_ipv6` posture.
- `internal/bpf/defend/loader_failclosed_test.go`: extend the spec-symbol test to require both maps.
- `internal/agent/agent_linux_policy_maps.go`: drop the "wire after regeneration" TODOs on the two ipv6 read helpers (the maps are now guaranteed non-nil).

### Keep tolerant (corrected comments): sendpage
`lsm_socket_sendpage` / `sendpage_observed` tolerance is **permanent**, not a stale stub. `LoadDefendObjectsForKernel` deletes both from the spec on **kernel 6.5+** (which removed the `socket_sendpage` LSM hook — this includes current `ubuntu-latest`) and whenever the LSM section is stripped. Converting these to a hard `detachProgram`/`detachMap` would break defend load on every modern kernel. Behavior is unchanged; only the misleading "regenerate on Linux" comments are rewritten to state the real reason (`loader.go` + `readSendpageObservedCount`).

## Verification

- `gofmt -l`, `GOOS=linux go vet ./internal/bpf/defend/... ./internal/agent/...` clean.
- New fail-closed spec test guards the two now-required maps.
- Integration + defend-mode CI exercise the real loader on a live kernel.

Phase 2.2 of the simplification plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)