### PR TITLE
refactor(config): single detect-profile resolution with documented precedence

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -146,7 +146,7 @@ jobs:
 
 ### What these controls do
 
-- `detect-profile: enhanced`: enables `proc_tree` (fork edges + process tree), `tls_sni` (TLS ClientHello / SNI rows, `"type":"tls"`), and `fs_events` (filesystem events, `"type":"fs_event"`).
+- `detect-profile: enhanced`: enables `proc_tree` (fork edges + process tree), `tls_sni` (TLS ClientHello / SNI rows, `"type":"tls"`), and `fs_events` (filesystem events, `"type":"fs_event"`). Precedence is resolved once (`config.ResolveDetectProfile`): an explicit `--detect-profile` flag wins, then the `COLDSTEP_DETECT_PROFILE` env, then the `standard` default — the same resolution applies to the agent, `coldstep start`, `coldstep stop --strict`, and `coldstep assert-integrity`. The feature gates above are derived from this single value (there is no separate `feature-gates` input).
 - `report: job-summary` (default): merge the digest into the Job Summary tab. Use `pr-comment`, `both`, or `none` for other surfaces.
 - `fail-on-error: true`: fail the step if agent **operational** readiness cannot be established (BPF/load), not merely on policy noise.
 

--- a/internal/actioncli/main.go
+++ b/internal/actioncli/main.go
@@ -45,6 +45,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/coldstep-io/coldstep/internal/config"
 	"github.com/coldstep-io/coldstep/internal/safepath"
 )
 
@@ -147,7 +148,9 @@ func parseStartFlags(args []string) (startConfig, error) {
 	fs.StringVar(&cfg.AllowFile, "allow-file", "", "")
 	fs.BoolVar(&cfg.NoDefaultIgnoredNets, "no-default-ignored-nets", false, "")
 	fs.StringVar(&cfg.LogLevel, "log-level", "info", "")
-	fs.StringVar(&cfg.DetectProfile, "detect-profile", "standard", "")
+	// Empty default: precedence (flag > COLDSTEP_DETECT_PROFILE env > "standard")
+	// is applied once via config.ResolveDetectProfile in runStart.
+	fs.StringVar(&cfg.DetectProfile, "detect-profile", "", "")
 	fs.StringVar(&cfg.ReleasePath, "release-path", "", "")
 	fs.BoolVar(&cfg.FailOnError, "fail-on-error", false, "")
 	fs.IntVar(&cfg.ReadyTimeoutSeconds, "ready-timeout-seconds", 1500, "")
@@ -169,7 +172,9 @@ func parseStopFlags(args []string) (stopConfig, error) {
 	fs.StringVar(&cfg.Report, "report", "job-summary", "")
 	fs.StringVar(&cfg.GithubToken, "github-token", "", "")
 	fs.BoolVar(&cfg.Strict, "strict", false, "")
-	fs.StringVar(&cfg.DetectProfile, "detect-profile", getenvDefault("COLDSTEP_DETECT_PROFILE", ""), "")
+	// Empty default: precedence is applied once via config.ResolveDetectProfile
+	// in runStop (flag > COLDSTEP_DETECT_PROFILE env > "standard").
+	fs.StringVar(&cfg.DetectProfile, "detect-profile", "", "")
 	fs.StringVar(&cfg.DigestOutput, "digest-output", getenvDefault("COLDSTEP_DIGEST_OUTPUT", ""), "")
 	if err := fs.Parse(args); err != nil {
 		return cfg, err
@@ -302,7 +307,10 @@ func runStart(cfg startConfig) error {
 		}
 	}
 
-	detectProfile := strings.ToLower(strings.TrimSpace(cfg.DetectProfile))
+	detectProfile, err := config.ResolveDetectProfile(cfg.DetectProfile, os.Getenv("COLDSTEP_DETECT_PROFILE"))
+	if err != nil {
+		return err
+	}
 	featureGates := ""
 	if detectProfile == "enhanced" {
 		featureGates = "proc_tree=1,tls_sni=1,fs_events=1"
@@ -480,7 +488,11 @@ func runStop(cfg stopConfig) error {
 		if reportAgg == nil {
 			return errors.New("strict: no .coldstep-events.jsonl to evaluate required event types")
 		}
-		if missing := reportAgg.MissingRequiredTypes(cfg.DetectProfile); len(missing) > 0 {
+		profile, err := config.ResolveDetectProfile(cfg.DetectProfile, os.Getenv("COLDSTEP_DETECT_PROFILE"))
+		if err != nil {
+			return err
+		}
+		if missing := reportAgg.MissingRequiredTypes(profile); len(missing) > 0 {
 			return fmt.Errorf("strict: missing required event type(s): %s", strings.Join(missing, ", "))
 		}
 	}

--- a/internal/actioncli/main_test.go
+++ b/internal/actioncli/main_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/coldstep-io/coldstep/internal/config"
 )
 
 func TestTruncate_utf8Boundary(t *testing.T) {
@@ -40,8 +42,14 @@ func TestParseStartFlags_Defaults(t *testing.T) {
 	if cfg.FailOnError {
 		t.Error("expected fail-on-error default=false")
 	}
-	if cfg.DetectProfile != "standard" {
-		t.Errorf("expected default detect-profile=standard, got %q", cfg.DetectProfile)
+	// detect-profile parses to "" by design: precedence (flag > env > "standard")
+	// is applied once in runStart via config.ResolveDetectProfile, not at the
+	// flag-default level. The effective default is still "standard".
+	if cfg.DetectProfile != "" {
+		t.Errorf("expected parsed detect-profile default=\"\" (resolution deferred), got %q", cfg.DetectProfile)
+	}
+	if got, err := config.ResolveDetectProfile(cfg.DetectProfile, ""); err != nil || got != "standard" {
+		t.Errorf("ResolveDetectProfile(%q, \"\") = %q, %v; want \"standard\", nil", cfg.DetectProfile, got, err)
 	}
 }
 

--- a/internal/actioncli/report_markdown.go
+++ b/internal/actioncli/report_markdown.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/coldstep-io/coldstep/internal/atomicwrite"
+	"github.com/coldstep-io/coldstep/internal/config"
 	"github.com/coldstep-io/coldstep/internal/report/markdown"
 	"github.com/coldstep-io/coldstep/internal/safepath"
 )
@@ -192,8 +193,14 @@ func runAssertIntegrity(args []string) error {
 	fs.SetOutput(io.Discard)
 	ws := getenvDefault("GITHUB_WORKSPACE", ".")
 	in := fs.String("in", filepath.Join(ws, ".coldstep-events.jsonl"), "")
-	profile := fs.String("detect-profile", getenvDefault("COLDSTEP_DETECT_PROFILE", ""), "")
+	// Empty default: precedence (flag > COLDSTEP_DETECT_PROFILE env > "standard")
+	// is applied once via config.ResolveDetectProfile after parse.
+	profileFlag := fs.String("detect-profile", "", "")
 	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	profile, err := config.ResolveDetectProfile(*profileFlag, getenvDefault("COLDSTEP_DETECT_PROFILE", ""))
+	if err != nil {
 		return err
 	}
 	inPath, err := safepath.Workspace(*in, "in")
@@ -204,7 +211,7 @@ func runAssertIntegrity(args []string) error {
 	if err != nil {
 		return fmt.Errorf("load events: %w", err)
 	}
-	if missing := agg.MissingRequiredTypes(*profile); len(missing) > 0 {
+	if missing := agg.MissingRequiredTypes(profile); len(missing) > 0 {
 		fmt.Fprintf(os.Stderr,
 			"::error title=Coldstep integrity gate::missing required event type(s): %s\n",
 			strings.Join(missing, ", "))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -106,12 +106,9 @@ func LoadFromEnv() (Config, error) {
 		agentStatus = defaultUnderWorkspace(".coldstep-ready.json")
 	}
 
-	profile := strings.ToLower(strings.TrimSpace(os.Getenv("COLDSTEP_DETECT_PROFILE")))
-	if profile == "" {
-		profile = "standard"
-	}
-	if profile != "standard" && profile != "enhanced" {
-		return Config{}, fmt.Errorf("invalid COLDSTEP_DETECT_PROFILE %q (use standard or enhanced)", os.Getenv("COLDSTEP_DETECT_PROFILE"))
+	profile, err := ResolveDetectProfile("", os.Getenv("COLDSTEP_DETECT_PROFILE"))
+	if err != nil {
+		return Config{}, err
 	}
 
 	gates := ParseFeatureGates(os.Getenv("COLDSTEP_FEATURE_GATES"))
@@ -166,6 +163,30 @@ func mergeEnhancedFeatureGates(profile string, gates map[string]string) map[stri
 func envBoolTrue(key string) bool {
 	v := strings.TrimSpace(os.Getenv(key))
 	return strings.EqualFold(v, "true") || v == "1" || strings.EqualFold(v, "yes") || strings.EqualFold(v, "on")
+}
+
+// ResolveDetectProfile is the single source of truth for the detect profile.
+// Precedence: an explicit flag value wins; otherwise the env value (typically
+// COLDSTEP_DETECT_PROFILE); otherwise the "standard" default. The result is
+// trimmed/lowercased and validated to be exactly "standard" or "enhanced".
+//
+// Both the agent (config.LoadFromEnv) and the action CLI (start/stop/
+// assert-integrity) route through this function so the three layers
+// (action input -> COLDSTEP_DETECT_PROFILE env -> --detect-profile flag)
+// resolve identically everywhere.
+func ResolveDetectProfile(flagValue, envValue string) (string, error) {
+	pick := strings.TrimSpace(flagValue)
+	if pick == "" {
+		pick = strings.TrimSpace(envValue)
+	}
+	normalized := strings.ToLower(pick)
+	if normalized == "" {
+		normalized = "standard"
+	}
+	if normalized != "standard" && normalized != "enhanced" {
+		return "", fmt.Errorf("invalid detect-profile %q (use standard or enhanced)", pick)
+	}
+	return normalized, nil
 }
 
 // Policy returns the parsed allow-list policy (never nil; may be disabled).

--- a/internal/config/resolve_detect_profile_test.go
+++ b/internal/config/resolve_detect_profile_test.go
@@ -1,0 +1,42 @@
+package config
+
+import "testing"
+
+func TestResolveDetectProfile(t *testing.T) {
+	tests := []struct {
+		name    string
+		flag    string
+		env     string
+		want    string
+		wantErr bool
+	}{
+		{name: "both empty -> standard default", flag: "", env: "", want: "standard"},
+		{name: "env only", flag: "", env: "enhanced", want: "enhanced"},
+		{name: "flag only", flag: "enhanced", env: "", want: "enhanced"},
+		{name: "flag wins over env", flag: "enhanced", env: "standard", want: "enhanced"},
+		{name: "flag standard wins over env enhanced", flag: "standard", env: "enhanced", want: "standard"},
+		{name: "flag normalized case+space", flag: "  Enhanced  ", env: "", want: "enhanced"},
+		{name: "env normalized case+space", flag: "", env: "  STANDARD ", want: "standard"},
+		{name: "whitespace flag falls through to env", flag: "   ", env: "enhanced", want: "enhanced"},
+		{name: "invalid flag errors", flag: "bogus", env: "", wantErr: true},
+		{name: "invalid env errors", flag: "", env: "bogus", wantErr: true},
+		{name: "invalid flag errors even with valid env", flag: "bogus", env: "enhanced", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveDetectProfile(tc.flag, tc.env)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ResolveDetectProfile(%q, %q) = %q, want error", tc.flag, tc.env, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveDetectProfile(%q, %q) unexpected error: %v", tc.flag, tc.env, err)
+			}
+			if got != tc.want {
+				t.Fatalf("ResolveDetectProfile(%q, %q) = %q, want %q", tc.flag, tc.env, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`detect-profile` was normalized / validated / defaulted in four places, with an inconsistency: `parseStartFlags` hardcoded the `standard` default and **ignored** `COLDSTEP_DETECT_PROFILE`, while `stop` and `assert-integrity` defaulted from the env. This collapses all of it into one resolver.

### New single source of truth
`config.ResolveDetectProfile(flagValue, envValue) (string, error)`:
- Precedence: explicit `--detect-profile` flag > `COLDSTEP_DETECT_PROFILE` env > `standard`.
- Result trimmed/lowercased and validated to `standard` | `enhanced`.

### Wired through
- `config.LoadFromEnv` (agent).
- actioncli `runStart`, `runStop --strict`, `runAssertIntegrity`. The three flag defaults become `""` so the resolver owns precedence uniformly; **`start` now honors the env** like the others.

### feature-gates
Left as-is: it is **derived** from the resolved detect-profile (its standalone input was already removed in the allowlist/input consolidation), so it has no overlapping layers to collapse. Documented in QUICK_START.

## Verification

- New `TestResolveDetectProfile` covers the precedence / normalization / invalid-value matrix.
- `TestParseStartFlags_Defaults` updated for the new contract (parsed default `""`, resolver yields `standard`).
- `gofmt`, `go vet` (native + `GOOS=linux`), `check-encoding.sh`, and the full native `go test ./...` pass.
- No `src/*.ts` / `action.yml` change → no `dist/` rebuild. The TS layer already maps the input to `COLDSTEP_DETECT_PROFILE`, which the agent now resolves via the shared function.

> Note: `TestWaitForReady_Timeout` fails only on a Windows dev host (Linux `/proc` liveness probe) and is unrelated to this change; it passes on Linux CI.

Phase 2.4 of the simplification plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)