### PR TITLE
refactor(config): centralize mode branching behind config.ModeConfig

### DIFF
--- a/internal/agent/agent_linux.go
+++ b/internal/agent/agent_linux.go
@@ -43,6 +43,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 
 	s := &runState{
 		cfg:            cfg,
+		mode:           cfg.ModeConfig(),
 		pol:            pol,
 		stats:          newRunStats(),
 		defendState:    newDefendState(),
@@ -121,7 +122,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 
 	// Detect mode: ready after syscall trace initialized. Defend mode defers
 	// readiness until after the deny reader goroutine is launched (below).
-	if cfg.Mode != config.ModeDefend {
+	if !s.mode.DeferReadiness {
 		if err := writeAgentStatus(cfg.AgentStatusPath, true); err != nil {
 			return fmt.Errorf("agent ready status: %w", err)
 		}
@@ -169,7 +170,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 	// alive, so the GitHub Action's probe steps cannot race the reader being
 	// attached. Detect-mode readiness was written above.
 	var readyErr error
-	if cfg.Mode == config.ModeDefend {
+	if s.mode.DeferReadiness {
 		if err := writeAgentStatus(cfg.AgentStatusPath, true); err != nil {
 			readyErr = fmt.Errorf("agent ready status: %w", err)
 			runCancel()

--- a/internal/agent/agent_linux_digest.go
+++ b/internal/agent/agent_linux_digest.go
@@ -137,7 +137,7 @@ func buildCoverageReport(bpf []telemetry.BPFStatus, tlsSNIGate, ioUringAttached,
 
 // digestDefendLabel maps internal defend snapshot + config to the digest/JSONL-facing mode name.
 func digestDefendLabel(cfg config.Config, snap defendSnapshot) string {
-	if cfg.Mode != config.ModeDefend {
+	if !cfg.ModeConfig().Defend {
 		return snap.mode
 	}
 	if strings.TrimSpace(snap.mode) != "" {

--- a/internal/agent/agent_linux_policy_maps.go
+++ b/internal/agent/agent_linux_policy_maps.go
@@ -26,7 +26,7 @@ import (
 )
 
 func compileDefendAllowlist(ctx context.Context, cfg config.Config, resolver policy.LookupIPFunc, maxAttempts int) (policy.CompileResult, error) {
-	if cfg.Mode != config.ModeDefend {
+	if !cfg.ModeConfig().Defend {
 		return policy.CompileResult{}, nil
 	}
 	if len(cfg.AllowedDomains) == 0 {

--- a/internal/agent/agent_run_load.go
+++ b/internal/agent/agent_run_load.go
@@ -28,7 +28,6 @@ import (
 	"github.com/coldstep-io/coldstep/internal/bpf/traceexec"
 	"github.com/coldstep-io/coldstep/internal/bpf/tracefork"
 	"github.com/coldstep-io/coldstep/internal/bpf/tracefs"
-	"github.com/coldstep-io/coldstep/internal/config"
 	"github.com/coldstep-io/coldstep/internal/policy"
 	"github.com/coldstep-io/coldstep/internal/telemetry"
 )
@@ -37,7 +36,7 @@ import (
 // hooks where the kernel supports them). No-op outside defend mode. Sets
 // s.hasDefend / s.hasLSM / s.defendObjs and the defend ring readers.
 func (s *runState) loadDefend(compileCtx context.Context) error {
-	if s.cfg.Mode != config.ModeDefend {
+	if !s.mode.Defend {
 		return nil
 	}
 	haveLSM := false
@@ -92,7 +91,7 @@ func (s *runState) loadDefend(compileCtx context.Context) error {
 
 	backend := chooseDefendBackend(
 		defendBackendConfig{
-			modeDefend: s.cfg.Mode == config.ModeDefend,
+			modeDefend: s.mode.Defend,
 			haveLSM:    s.hasLSM,
 		},
 		lsmAttachErr,
@@ -416,7 +415,7 @@ func (s *runState) armSyscall() error {
 	if err != nil {
 		slog.Info("syscall egress tracing disabled", "err", err)
 		s.bpfSt[1] = telemetry.BPFStatus{Name: "raw_tp/sys_enter (connect, sendto, http sniff, tls)", OK: false, Detail: bpfDetail(err)}
-		if s.cfg.Mode == config.ModeDefend {
+		if s.mode.Defend {
 			// Keep the status file for the composite post step; record operational
 			// failure explicitly instead of deleting the path.
 			_ = writeAgentStatus(s.cfg.AgentStatusPath, false)
@@ -712,10 +711,10 @@ func (s *runState) loadKTLS() {
 // loadIPv6Obs attaches the detect-mode IPv6 observe-only cgroup hooks. No-op in
 // defend mode (defend attaches its own cgroup6 programs).
 func (s *runState) loadIPv6Obs() {
-	// H7: detect-mode IPv6 observe-only hooks. Loaded only when cfg.Mode is
-	// not defend — defend's own cgroup/connect6+sendmsg6 programs already
-	// attach there (cgroup hook attach is single-program by default).
-	if s.cfg.Mode == config.ModeDefend {
+	// H7: detect-mode IPv6 observe-only hooks. Loaded only in detect mode —
+	// defend's own cgroup/connect6+sendmsg6 programs already attach there
+	// (cgroup hook attach is single-program by default).
+	if s.mode.Defend {
 		return
 	}
 	cgPath := s.cfg.CgroupAttachPath

--- a/internal/agent/agent_run_state.go
+++ b/internal/agent/agent_run_state.go
@@ -51,8 +51,9 @@ func (c *runCleanup) unwind() {
 // runState holds everything the phase helpers read or mutate. Pointer receiver
 // only; do not copy.
 type runState struct {
-	cfg config.Config
-	pol *policy.Policy
+	cfg  config.Config
+	mode config.ModeConfig
+	pol  *policy.Policy
 
 	stats       *runStats
 	defendState *defendState
@@ -110,7 +111,7 @@ type runState struct {
 // finalizeAllowlist performs the defend-mode resolver auto-allow, records the
 // compiled allowlist snapshot for the digest, and warns on unresolved domains.
 func (s *runState) finalizeAllowlist(compileCtx context.Context) {
-	if s.cfg.Mode == config.ModeDefend && !s.cfg.NoResolverAutoAllow {
+	if s.mode.ResolverAutoAllow {
 		resolverV4, resolverV6 := autoAllowSystemResolvers(&s.defendCompiled, policy.DefaultResolvConfPaths()...)
 		for _, ip := range resolverV4 {
 			slog.Info("defend: system DNS resolver auto-allowed", "resolver", ip.String(), "family", "ipv4")
@@ -136,7 +137,7 @@ func (s *runState) finalizeAllowlist(compileCtx context.Context) {
 	for _, d := range s.defendCompiled.UnresolvedDomains {
 		slog.Warn("allowlist domain did not resolve", "domain", d)
 	}
-	if s.cfg.Mode == config.ModeDefend && len(s.defendCompiled.UnresolvedDomains) > 0 {
+	if s.mode.Defend && len(s.defendCompiled.UnresolvedDomains) > 0 {
 		slog.Warn("allowlist domains unresolved — legitimate traffic to these domains may be blocked",
 			"count", len(s.defendCompiled.UnresolvedDomains))
 	}
@@ -182,7 +183,7 @@ func (s *runState) writeStartupMeta() {
 		meta.RunnerEnv = s.runnerEnv
 	}
 	// H14 v0.4.0 — IPv6 cgroup6 hooks enforce only when defend mode is active.
-	ipv6Enforced := s.cfg.Mode == config.ModeDefend && s.hasDefend
+	ipv6Enforced := s.mode.Defend && s.hasDefend
 	meta.Coverage = buildCoverageReport(s.bpfSt, s.tlsSNIGate, s.ioUringRd.R != nil, ipv6Enforced, 0)
 	if err := telemetry.AppendJSONL(s.cfg.EventsLogPath, meta, s.signer); err != nil {
 		slog.Warn("meta jsonl", "err", err)
@@ -216,7 +217,7 @@ func (s *runState) writeShutdownTelemetry() {
 	} else {
 		shutdownMeta.EventsFileSHA256 = sum
 	}
-	ipv6EnforcedShutdown := s.cfg.Mode == config.ModeDefend && s.hasDefend
+	ipv6EnforcedShutdown := s.mode.Defend && s.hasDefend
 	shutdownMeta.Coverage = buildCoverageReport(s.bpfSt, s.tlsSNIGate, s.ioUringRd.R != nil, ipv6EnforcedShutdown, s.stats.quicObservedTotal())
 	if err := telemetry.AppendJSONL(s.cfg.EventsLogPath, shutdownMeta, s.signer); err != nil {
 		slog.Warn("shutdown meta jsonl", "err", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -198,3 +198,39 @@ func (c Config) Policy() (*policy.Policy, error) {
 func (c Config) PublicMode() string {
 	return string(c.Mode)
 }
+
+// ModeConfig carries the behavioral flags derived once from Config.Mode (and the
+// mode-coupled inputs that gate them), so consumers branch on a named capability
+// instead of repeating `Mode == ModeDefend` comparisons. Resolve it once at
+// startup via Config.ModeConfig() and pass it (or its booleans) to consumers.
+type ModeConfig struct {
+	// Defend is true in defend mode (block non-allowlisted IPv4 egress).
+	Defend bool
+	// Detect is true in detect mode (observe-only telemetry); always !Defend.
+	Detect bool
+	// AllowlistEnforced is true when egress is gated against the effective
+	// allowlist in-kernel (defend only).
+	AllowlistEnforced bool
+	// DenyEmitted is true when the agent emits `deny` events (defend only).
+	DenyEmitted bool
+	// DeferReadiness is true when .coldstep-ready.json must be written only
+	// after the deny reader goroutines are alive (defend only); detect writes
+	// readiness as soon as syscall tracing attaches.
+	DeferReadiness bool
+	// ResolverAutoAllow is true when the host's DNS resolver IPs are folded into
+	// the allowlist (defend mode unless explicitly opted out).
+	ResolverAutoAllow bool
+}
+
+// ModeConfig resolves the mode-derived behavioral flags for this config.
+func (c Config) ModeConfig() ModeConfig {
+	defend := c.Mode == ModeDefend
+	return ModeConfig{
+		Defend:            defend,
+		Detect:            !defend,
+		AllowlistEnforced: defend,
+		DenyEmitted:       defend,
+		DeferReadiness:    defend,
+		ResolverAutoAllow: defend && !c.NoResolverAutoAllow,
+	}
+}

--- a/internal/config/mode_config_test.go
+++ b/internal/config/mode_config_test.go
@@ -1,0 +1,63 @@
+//go:build !windows
+
+// Go tests are not built or run on Windows (out of scope; avoids Smart App Control blocking
+// unsigned *.test.exe). Authoritative runs: GitHub Actions ubuntu-latest.
+
+package config
+
+import "testing"
+
+func TestModeConfig_Defend(t *testing.T) {
+	mc := Config{Mode: ModeDefend}.ModeConfig()
+	if !mc.Defend {
+		t.Fatalf("Defend = false, want true")
+	}
+	if mc.Detect {
+		t.Fatalf("Detect = true, want false")
+	}
+	for name, got := range map[string]bool{
+		"AllowlistEnforced": mc.AllowlistEnforced,
+		"DenyEmitted":       mc.DenyEmitted,
+		"DeferReadiness":    mc.DeferReadiness,
+		"ResolverAutoAllow": mc.ResolverAutoAllow,
+	} {
+		if !got {
+			t.Errorf("%s = false, want true in defend mode", name)
+		}
+	}
+}
+
+func TestModeConfig_Detect(t *testing.T) {
+	mc := Config{Mode: ModeDetect}.ModeConfig()
+	if mc.Defend {
+		t.Fatalf("Defend = true, want false")
+	}
+	if !mc.Detect {
+		t.Fatalf("Detect = false, want true")
+	}
+	for name, got := range map[string]bool{
+		"AllowlistEnforced": mc.AllowlistEnforced,
+		"DenyEmitted":       mc.DenyEmitted,
+		"DeferReadiness":    mc.DeferReadiness,
+		"ResolverAutoAllow": mc.ResolverAutoAllow,
+	} {
+		if got {
+			t.Errorf("%s = true, want false in detect mode", name)
+		}
+	}
+}
+
+func TestModeConfig_ResolverAutoAllowOptOut(t *testing.T) {
+	// Defend mode normally auto-allows resolver IPs; NoResolverAutoAllow opts out.
+	mc := Config{Mode: ModeDefend, NoResolverAutoAllow: true}.ModeConfig()
+	if !mc.Defend {
+		t.Fatalf("Defend = false, want true")
+	}
+	if mc.ResolverAutoAllow {
+		t.Errorf("ResolverAutoAllow = true, want false when NoResolverAutoAllow is set")
+	}
+	// Other defend flags are unaffected by the resolver opt-out.
+	if !mc.AllowlistEnforced || !mc.DenyEmitted || !mc.DeferReadiness {
+		t.Errorf("resolver opt-out must not disable enforcement flags: %+v", mc)
+	}
+}


### PR DESCRIPTION
## What

Centralize the mode branching scattered across the agent behind a single
`config.ModeConfig`. Every `Mode == ModeDefend` / `Mode != ModeDefend`
comparison was an inline restatement of a mode-derived behavior; replace them
with named, resolved booleans.

## ModeConfig

`config.ModeConfig` (resolved once via `Config.ModeConfig()`):

| field | meaning |
|-------|---------|
| `Defend` / `Detect` | mode (`Detect == !Defend`) |
| `AllowlistEnforced` | egress gated against the allowlist in-kernel (defend) |
| `DenyEmitted` | agent emits `deny` events (defend) |
| `DeferReadiness` | `.coldstep-ready.json` written only after deny readers are alive (defend) |
| `ResolverAutoAllow` | host resolver IPs folded into the allowlist (`defend && !NoResolverAutoAllow`) |

`runState` gains a `mode config.ModeConfig` field populated once in `Run`; the
load/attach/spawn phases read `s.mode.*`. The two standalone helpers that take a
`config.Config` (`compileDefendAllowlist`, `digestDefendLabel`) use
`cfg.ModeConfig().Defend`.

## Behavior preservation

Each replacement maps to the identical boolean expression:
- readiness timing: `!DeferReadiness` (detect, early) / `DeferReadiness` (defend, late)
- `loadDefend` / `armSyscall` / `loadIPv6Obs` gates → `Defend`
- `finalizeAllowlist` resolver auto-allow → `ResolverAutoAllow`
- `ipv6Enforced` (startup + shutdown meta) → `Defend && hasDefend`

No change to enforcement, error paths, logging, or the shutdown sequence.

## Verification (Linux / WSL)

- build / vet / staticcheck / `gofmt -l` — clean.
- Unit tests: 239 agent tests (identical set) pass; new `config` ModeConfig
  tests (defend / detect / resolver opt-out) pass. `-race` clean.
- Root+BPF integration: detect-summary + defend-deny pass — confirms the
  `DeferReadiness` timing split is preserved. Full CI integration matrix runs on
  real `ubuntu-latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
